### PR TITLE
Cli: Add version

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -73,6 +73,7 @@ impl Debug for dyn SubCommand {
 ///
 /// packet-tracer is a tool for capturing networking-related events from the system using ebpf and analyzing them.
 #[derive(Args, Default, Debug)]
+#[command(version)]
 pub(crate) struct MainConfig {}
 
 /// ThinCli handles the first (a.k.a "thin") round of Command Line Interface parsing.


### PR DESCRIPTION
this small series includes the new -V option which shows the version in Cargo.tml and also adds the completion script for bash

edit: dropped the bash script. As discussed during the mtg we'll look into Clap's facilities first.