### PR TITLE
build.rs: do not always rebuild on non debian based systems.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::{
     env,
     fs::{create_dir_all, File},
     io::Write,
+    path::Path,
     process::Command,
 };
 
@@ -155,7 +156,12 @@ fn main() {
     build_extract_stub("src/core/filters/packets/bpf/stub.bpf.c");
 
     for inc in INCLUDE_PATHS.iter() {
-        println!("cargo:rerun-if-changed={inc}");
+        // Useful to avoid to always rebuild on systems that don't use
+        // triplet multi-arch paths. This is harmless, but can be
+        // removed once the header dependency gets rearranged.
+        if Path::new(inc).exists() {
+            println!("cargo:rerun-if-changed={inc}");
+        }
     }
 
     println!("cargo:rerun-if-changed={BINDGEN_HEADER}");


### PR DESCRIPTION
on Fedora this could stretch build time:

```
$ touch src/core/events/events.rs && /bin/time -p cargo build
   Compiling packet-tracer v0.1.0
    Finished dev [unoptimized + debuginfo] target(s) in 8.96s
real 9.17
user 5.99
sys 3.02
```

with this applied:

```
$ touch src/core/events/events.rs && /bin/time -p cargo build
   Compiling packet-tracer v0.1.0
    Finished dev [unoptimized + debuginfo] target(s) in 2.28s
real 2.31
user 1.85
sys 0.44
```