### PR TITLE
Allow reporting the version in the cli

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -231,8 +231,16 @@ impl ThinCli {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
+        let version = if cfg!(debug_assertions) {
+            format!("{}-dbg", env!("CARGO_PKG_VERSION"))
+        } else {
+            env!("CARGO_PKG_VERSION").to_string()
+        };
+
         let args: Vec<OsString> = args.into_iter().map(|x| x.into()).collect();
-        let mut command = MainConfig::augment_args(Command::new("retis")).subcommand_required(true);
+        let mut command = MainConfig::augment_args(Command::new("retis"))
+            .version(version)
+            .subcommand_required(true);
         // Add thin subcommands so that the main help shows them.
         for (_, sub) in self.subcommands.iter() {
             command = command.subcommand(sub.thin().expect("thin command failed"));


### PR DESCRIPTION
Based on #75 with an extra commit.

Instead of only reporting the package version, also report the git HEAD information. This is useful as the Rust package version isn't directly linked to git information (tag, commit, etc) and the same version could be reported for different states of the project. This will help in supporting users to ensure the version points to a real state of the project.

The drawback is this information is retrieved in `build.rs` and the logic re-triggers the full `build.rs` for every `.git/HEAD` change. IMHO this is fine as we'll just force a rebuild when switching branches and/or adding new commits, but not for every development iterations.

Thoughts?