### PR TITLE
usdt: Fix symbol lookups on binaries with load offsets

### DIFF
--- a/src/core/user/proc.rs
+++ b/src/core/user/proc.rs
@@ -418,7 +418,7 @@ impl Process {
     /// Gets the runtime USDT information of a symbol.
     pub(crate) fn get_note_from_symbol(&self, symbol: u64) -> Result<Option<&UsdtNote>> {
         // Find in the executable.
-        if let Some(note) = self.exec.get_note_from_offset(symbol)? {
+        if let Some(note) = self.exec.get_note_from_addr(symbol)? {
             Ok(Some(note))
         } else if let Some((_, lib)) = self.libs.range((Unbounded, Included(&symbol))).next_back() {
             Ok(lib.get_note_from_addr(symbol)?)


### PR DESCRIPTION
This slip of using offset-based lookups on addresses makes resolution fail (obviously) when the symbol lives in the binary.

Fixes: #114 