### PR TITLE
Use a text format for drop reasons in events

### DIFF
--- a/src/core/kernel/inspect.rs
+++ b/src/core/kernel/inspect.rs
@@ -196,14 +196,14 @@ pub(super) fn find_matching_event(name: &str) -> Result<Option<String>> {
 /// Get a parameter offset given a kernel function, if  any. Can be used to
 /// check a function has a given parameter by using:
 /// `parameter_offset()?.is_some()`
-pub(super) fn parameter_offset(symbol: &Symbol, parameter_type: &str) -> Result<Option<u32>> {
+pub(crate) fn parameter_offset(symbol: &Symbol, parameter_type: &str) -> Result<Option<u32>> {
     get_inspector!()?
         .btf
         .parameter_offset(symbol, parameter_type)
 }
 
 /// Get a function's number of arguments.
-pub(super) fn function_nargs(symbol: &Symbol) -> Result<u32> {
+pub(crate) fn function_nargs(symbol: &Symbol) -> Result<u32> {
     get_inspector!()?.btf.function_nargs(symbol)
 }
 

--- a/src/core/kernel/inspect.rs
+++ b/src/core/kernel/inspect.rs
@@ -216,6 +216,11 @@ pub(crate) fn get_name_offt_from_addr_near(addr: u64) -> Result<(String, u64)> {
     ))
 }
 
+/// Gets a reference to the BTF information for further inspection.
+pub(crate) fn btf_info() -> Result<&'static BtfInfo> {
+    Ok(&get_inspector!()?.btf)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/module/module.rs
+++ b/src/module/module.rs
@@ -224,7 +224,7 @@ pub(crate) fn get_modules() -> Result<Modules> {
         .register(
             ModuleId::SkbDrop,
             Box::new(SkbDropCollector::new()?),
-            Box::<SkbDropEventFactory>::default(),
+            Box::new(SkbDropEventFactory::new()?),
         )?
         .register(
             ModuleId::Ovs,

--- a/src/module/skb_drop/event.rs
+++ b/src/module/skb_drop/event.rs
@@ -1,10 +1,17 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
+use btf_rs::Type;
+use log::warn;
 use plain::Plain;
 
 use crate::{
-    core::events::{
-        bpf::{parse_single_raw_section, BpfRawSection},
-        *,
+    core::{
+        events::{
+            bpf::{parse_single_raw_section, BpfRawSection},
+            *,
+        },
+        kernel::inspect,
     },
     event_section, event_section_factory,
     module::ModuleId,
@@ -13,24 +20,58 @@ use crate::{
 // Skb drop event section. Same as the event from BPF, please keep in sync with
 // its BPF counterpart.
 #[event_section]
-#[repr(C, packed)]
 pub(crate) struct SkbDropEvent {
     /// Reason why a packet was freed/dropped. Only reported from specific
     /// functions. See `enum skb_drop_reason` in the kernel.
-    pub(crate) drop_reason: u32,
+    pub(crate) drop_reason: String,
 }
 
-unsafe impl Plain for SkbDropEvent {}
-
-#[derive(Default)]
 #[event_section_factory(SkbDropEvent)]
-pub(crate) struct SkbDropEventFactory {}
+pub(crate) struct SkbDropEventFactory {
+    reasons: HashMap<u32, String>,
+}
+
+impl SkbDropEventFactory {
+    pub(crate) fn new() -> Result<Self> {
+        let mut reasons = HashMap::new();
+
+        if let (btf, Type::Enum(r#enum)) =
+            inspect::btf_info()?.resolve_type_by_name("skb_drop_reason")?
+        {
+            for member in r#enum.members.iter() {
+                reasons.insert(
+                    u32::try_from(member.val())?,
+                    btf.resolve_name(member)?
+                        .trim_start_matches("SKB_")
+                        .trim_start_matches("DROP_REASON_")
+                        .to_string(),
+                );
+            }
+        } else {
+            warn!("Can't retrieve skb drop reason definitions from the kernel. Events will contain raw data (enum int value).");
+        }
+
+        Ok(Self { reasons })
+    }
+}
 
 impl RawEventSectionFactory for SkbDropEventFactory {
     fn from_raw(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        Ok(Box::new(parse_single_raw_section::<SkbDropEvent>(
-            ModuleId::SkbDrop,
-            raw_sections,
-        )?))
+        let raw = parse_single_raw_section::<BpfSkbDropEvent>(ModuleId::SkbDrop, raw_sections)?;
+        let drop_reason = raw.drop_reason;
+        let drop_reason = match self.reasons.get(&drop_reason) {
+            Some(r) => r.clone(),
+            None => format!("{}", drop_reason),
+        };
+
+        Ok(Box::new(SkbDropEvent { drop_reason }))
     }
 }
+
+#[derive(Default)]
+#[repr(C, packed)]
+struct BpfSkbDropEvent {
+    drop_reason: u32,
+}
+
+unsafe impl Plain for BpfSkbDropEvent {}

--- a/src/module/skb_drop/skb_drop.rs
+++ b/src/module/skb_drop/skb_drop.rs
@@ -1,5 +1,5 @@
-use anyhow::Result;
-use log::{error, info};
+use anyhow::{bail, Result};
+use log::warn;
 
 use super::skb_drop_hook;
 use crate::{
@@ -37,14 +37,14 @@ impl Collector for SkbDropCollector {
         // reason, so check this and handle it nicely.
         match inspect::parameter_offset(&symbol, "enum skb_drop_reason") {
             Err(_) | Ok(None) => {
-                info!("Skb drop reasons are not retrievable on this kernel");
+                warn!("Skb drop reasons are not retrievable on this kernel");
                 return Ok(());
             }
             _ => (),
         }
 
         if let Err(e) = probes.add_probe(Probe::raw_tracepoint(symbol)?) {
-            error!("Could not attach to skb:kfree_skb: {}", e);
+            bail!("Could not attach to skb:kfree_skb: {}", e);
         }
 
         probes.register_kernel_hook(Hook::from(skb_drop_hook::DATA))


### PR DESCRIPTION
This has multiple advantages:

- Ease to understand the reason why a packet was dropped.
- Better compatibility with different kernel versions.

Example:
```
# retis collect -c skb-drop
{"common":{"timestamp":3748134824705},"kernel":{"probe_type":"kprobe","symbol":"kfree_skb_reason"},"skb-drop":{"drop_reason":"tcp old data"}}
{"common":{"timestamp":3748134840945},"kernel":{"probe_type":"kprobe","symbol":"kfree_skb_reason"},"skb-drop":{"drop_reason":"not specified"}}
{"common":{"timestamp":3748223136046},"kernel":{"probe_type":"kprobe","symbol":"kfree_skb_reason"},"skb-drop":{"drop_reason":"tcp invalid sequence"}}
{"common":{"timestamp":3903142678490},"kernel":{"probe_type":"kprobe","symbol":"kfree_skb_reason"},"skb-drop":{"drop_reason":"no socket"}}
```

Based on #102.