### PR TITLE
ovs: add skb filtering on execute_action event

### DIFF
--- a/src/module/ovs/bpf/kernel_exec_tp.bpf.c
+++ b/src/module/ovs/bpf/kernel_exec_tp.bpf.c
@@ -55,7 +55,7 @@ static __always_inline s32 handle_tracking(struct retis_context *ctx,
 }
 
 /* Hook for ovs_do_execute_action tracepoint. */
-DEFINE_HOOK_RAW(
+DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 	struct nlattr *attr;
 	struct sw_flow_key *key;
 	struct exec_event *exec;


### PR DESCRIPTION
The execute action is actually the main event in the OVS module since it happens (hopefully) much more often than the upcall. Add skb filtering to it.