### PR TITLE
fix build with rustc 1.65

### DIFF
--- a/src/core/filters/packets/ebpfinsn.rs
+++ b/src/core/filters/packets/ebpfinsn.rs
@@ -9,7 +9,7 @@ use crate::core::{
 #[repr(u8)]
 pub(crate) enum eBpfJmpOpExt {
     Bpf(BpfJmpOp),
-    Ne = bpf_sys::BPF_JNE,
+    Ne, // identifies bpf_sys::BPF_JNE
 }
 
 #[repr(u8)]


### PR DESCRIPTION
as reported in #138 by @amorenoz, the build fails using rustc 1.65.

This happens because custom discriminant values are not allowed in enums with tuple or struct variants in rust in versions < 1.66 which is of course the one we need :)

Fix it by removing the discriminant as it was fundamentally introduced for consistency.