### PR TITLE
Allow hooks to discard the event

### DIFF
--- a/src/module/nft/bpf/nft.bpf.c
+++ b/src/module/nft/bpf/nft.bpf.c
@@ -73,7 +73,7 @@ static __always_inline int nft_trace(struct nft_config *cfg,
 
 	code = (u32)BPF_CORE_READ(verdict, code);
 	if (!ALLOWED_VERDICTS(code, cfg->verdicts))
-		return 0;
+		return -ENOMSG;
 
 	e = get_event_zsection(event, COLLECTOR_NFT, 1, sizeof(*e));
 	if (!e)


### PR DESCRIPTION
This comes from the following issue: when nft module is used, we'll see many events reported from `__nft_trace_packet`. We can filter the nft section out, by using `--nft-verdicts` but since other hooks are attached we will still see all the events, just not all will contain an nft section. We could use `ProbeOption::NoGenericHook` but then we loose valuable information such as tracking-id or skb data when events are reported.

The real solution is to add an nft filter, and let the user select whether an AND or an OR is wanted (to support tracking packets only when after a given verdict was seen, or to track packets including when they trigger a given verdict). It's not as simple as that because there are actually two AND versions (only when the data is available or always?).

In the meantime, as a temporary solution, we could let hooks return a special value meaning "drop the event". That would be similar to one of the AND cases above, and it should be possible to internally convert this to the proper filtering logic once implemented. This would improve the nft ux **a lot**.

WDYT?