### PR TITLE
ci: remove global env for functional tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,9 +36,6 @@ functional_task:
   # Run for PRs with a specific label
   required_pr_labels: run-functional-tests
   only_if: "$CIRRUS_PR != ''"
-  env:
-    DEBIAN_FRONTEND: noninteractive
-    HOME: /root
 
   matrix: &distro_matrix
     - name: Fedora 38
@@ -69,7 +66,7 @@ functional_task:
       # Installing it from Hashicorp directly
     - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-    - apt-get -y update && apt-get -y install vagrant ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make
+    - DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractiven apt-get -y install vagrant ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make
     - vagrant plugin install vagrant-libvirt
     - systemctl enable --now libvirtd
 


### PR DESCRIPTION
This avoids names getting scrumbled when a PR is labeled after some tests are run.