### PR TITLE
collect: fix typo in info msg when loading collectors

### DIFF
--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -185,7 +185,7 @@ impl Collectors {
         //  If auto-mode is used, print the list of module that were started.
         if collect.default_collectors_list {
             info!(
-                "Module(s) started: {}",
+                "Collector(s) started: {}",
                 loaded
                     .iter()
                     .map(|id| id.to_str())


### PR DESCRIPTION
Small typo; fixing it improves the ux.