### PR TITLE
module: skb_drop: lazy-fill the reason map

### DIFF
--- a/src/module/skb_drop/skb_drop.rs
+++ b/src/module/skb_drop/skb_drop.rs
@@ -63,6 +63,6 @@ impl Module for SkbDropModule {
         self
     }
     fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(SkbDropEventFactory::new()?))
+        Ok(Box::<SkbDropEventFactory>::default())
     }
 }


### PR DESCRIPTION
This removes the use of the inspector for post-processing commands using this event factory to import events, which:
- Makes no sense as the inspector inspect the live system.
- Helps removing a warning if the tool is used as a normal user and/or w/o debugfs being mounted.