### PR TITLE
Fix #182

### DIFF
--- a/src/module/skb/event.rs
+++ b/src/module/skb/event.rs
@@ -129,7 +129,7 @@ impl EventFmt for SkbEvent {
             }
             write!(f, "flags [{}]", flags.into_iter().collect::<String>())?;
 
-            let len = len - (tcp.doff as u16 * 4);
+            let len = len.saturating_sub(tcp.doff as u16 * 4);
             if len > 0 {
                 write!(f, " seq {}:{}", tcp.seq, tcp.seq + len as u32)?;
             } else {


### PR DESCRIPTION
while formatting the event, the TCP formatter logic relies on the len value (normally initialized, but set from the l3 logic).
If the SkbIpEvent is not present, this leads to an 'attempt to subtract with overflow' while calculating the length needed for displaying the seq.
Fix it by saturating at the numeric bounds.

this fixes #182