### PR TITLE
profiles: add generic

### DIFF
--- a/profiles/generic.yaml
+++ b/profiles/generic.yaml
@@ -1,0 +1,29 @@
+version: 1.0
+name: generic
+about: Generic set of probes, meant to be used as a starting point for debugging sessions
+collect:
+  - args:
+      collectors: skb,skb-tracking
+      probe:
+        - tp:skb:kfree_skb
+        - tp:net:netif_receive_skb
+        - tp:net:netif_rx
+        - kprobe:ip_rcv
+        - kprobe:ipv6_rcv
+        - kprobe:tcp_v4_rcv
+        - kprobe:tcp_v6_rcv
+        - kprobe:tcp_gro_receive
+        - kprobe:tcp6_gro_receive
+        - kprobe:tcp_rcv_established
+        - kprobe:tcp_rcv_state_process
+        - kprobe:udp_rcv
+        - kprobe:udpv6_rcv
+        - kprobe:udp_gro_receive
+        - kprobe:udp6_gro_receive
+        - kprobe:icmp_rcv
+        - kprobe:icmpv6_rcv
+        - tp:net:net_dev_queue
+        - tp:net:net_dev_xmit
+        - kprobe:ip_output
+        - kprobe:ip6_output
+        - kprobe:skb_scrub_packet


### PR DESCRIPTION
Provides a starting point for debugging the net stack.

Open question: is "generic" a good name? I'm not 100% sure :)