### PR TITLE
merge --ebpf-debug into --log-level

### DIFF
--- a/src/collect/cli.rs
+++ b/src/collect/cli.rs
@@ -18,8 +18,6 @@ use crate::{
 
 #[derive(Args, Debug, Default)]
 pub(crate) struct CollectArgs {
-    #[arg(long, default_value = "false")]
-    pub(super) ebpf_debug: bool,
     #[arg(
         long,
         default_value = "false",

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -141,7 +141,6 @@ impl Collectors {
             .downcast_ref::<Collect>()
             .ok_or_else(|| anyhow!("wrong subcommand"))?;
 
-        probe::common::set_ebpf_debug(collect.args()?.ebpf_debug)?;
         if collect.args()?.stack {
             self.probes.set_probe_opt(probe::ProbeOption::StackTrace)?;
         }

--- a/src/core/probe/kernel/kprobe.rs
+++ b/src/core/probe/kernel/kprobe.rs
@@ -36,9 +36,7 @@ impl ProbeBuilder for KprobeBuilder {
             bail!("Kprobe builder already initialized");
         }
 
-        let mut skel = KprobeSkelBuilder::default();
-        skel.obj_builder.debug(get_ebpf_debug());
-        let mut skel = skel.open()?;
+        let mut skel = KprobeSkelBuilder::default().open()?;
         skel.rodata().nhooks = hooks.len() as u32;
 
         let open_obj = skel.obj;

--- a/src/core/probe/kernel/kretprobe.rs
+++ b/src/core/probe/kernel/kretprobe.rs
@@ -40,9 +40,7 @@ impl ProbeBuilder for KretprobeBuilder {
             bail!("Kretprobe builder already initialized");
         }
 
-        let mut skel = KretprobeSkelBuilder::default();
-        skel.obj_builder.debug(get_ebpf_debug());
-        let mut skel = skel.open()?;
+        let mut skel = KretprobeSkelBuilder::default().open()?;
         skel.rodata().nhooks = hooks.len() as u32;
 
         let open_obj = skel.obj;

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -42,9 +42,7 @@ impl ProbeBuilder for RawTracepointBuilder {
     }
 
     fn attach(&mut self, probe: &Probe) -> Result<()> {
-        let mut skel = RawTracepointSkelBuilder::default();
-        skel.obj_builder.debug(get_ebpf_debug());
-        let mut skel = skel.open()?;
+        let mut skel = RawTracepointSkelBuilder::default().open()?;
 
         let probe = match probe.r#type() {
             ProbeType::RawTracepoint(probe) => probe,

--- a/src/core/probe/mod.rs
+++ b/src/core/probe/mod.rs
@@ -5,8 +5,6 @@
 mod builder;
 
 pub(crate) mod common;
-pub(crate) use common::get_ebpf_debug;
-
 pub(crate) mod kernel;
 
 pub(crate) mod manager;

--- a/src/core/probe/user/usdt.rs
+++ b/src/core/probe/user/usdt.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Result};
 
 use crate::core::filters::Filter;
 use crate::core::probe::builder::*;
-use crate::core::probe::{get_ebpf_debug, Hook, Probe, ProbeType};
+use crate::core::probe::{Hook, Probe, ProbeType};
 
 mod usdt_bpf {
     include!("bpf/.out/usdt.skel.rs");
@@ -42,10 +42,7 @@ impl ProbeBuilder for UsdtBuilder {
             _ => bail!("Wrong probe type"),
         };
 
-        let mut skel = UsdtSkelBuilder::default();
-        skel.obj_builder.debug(get_ebpf_debug());
-        let skel = skel.open()?;
-
+        let skel = UsdtSkelBuilder::default().open()?;
         let open_obj = skel.obj;
         reuse_map_fds(&open_obj, &self.map_fds)?;
 


### PR DESCRIPTION
Use `--log-level debug` to enable BPF debug in libbpf instead of a specific option. This makes thing more consistent and helps in removing the not perfect ebpf-debug handling internally. This prevents from only turning the BPF debug logging on or from only getting non-BPF debug messages, but IMHO that isn't really an issue. 