### PR TITLE
Make skb-drop collector work on older kernels

### DIFF
--- a/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
+++ b/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
@@ -5,20 +5,19 @@
 #include <common.h>
 
 struct skb_drop_event {
-	u32 drop_reason;
+	s32 drop_reason;
 } __attribute__((packed));
 
 DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 	struct skb_drop_event *e;
 
-	if (!retis_arg_valid(ctx, skb_drop_reason))
-		return 0;
-
 	e = get_event_section(event, COLLECTOR_SKB_DROP, 1, sizeof(*e));
 	if (!e)
 		return 0;
 
-	e->drop_reason = retis_get_skb_drop_reason(ctx);
+	e->drop_reason = retis_arg_valid(ctx, skb_drop_reason) ?
+		retis_get_skb_drop_reason(ctx) : -1;
+
 	return 0;
 )
 


### PR DESCRIPTION
Do not fail if a kernel is old enough not to support skb drop reasons, so that the skb-drop reasons still work (installing probes at the right places) and especially for the dropmon profile to work (which still provides useful data).