### PR TITLE
module: skb_drop: do not generate fake reason for all events

### DIFF
--- a/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
+++ b/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
@@ -15,8 +15,13 @@ DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 	if (!e)
 		return 0;
 
-	e->drop_reason = retis_arg_valid(ctx, skb_drop_reason) ?
-		retis_get_skb_drop_reason(ctx) : -1;
+	if (bpf_core_type_exists(enum skb_drop_reason)) {
+		if (!retis_arg_valid(ctx, skb_drop_reason))
+			return 0;
+		e->drop_reason = retis_get_skb_drop_reason(ctx);
+	} else {
+		e->drop_reason = -1;
+	}
 
 	return 0;
 )


### PR DESCRIPTION
Commit 915947cd1999 ("module: skb_drop: do not fail on old kernels") introduced a "fake" event to support old kernels not have drop reasons support. However this led to including the fake reason in every even on those old kernels, and for every event not including a genuine reason on newer kernels.

Fix this by:
- Only attaching the probe to the skb:free_skb tracepoint in case the kernel doesn't support drop reasons.
- Check the drop reasons enum exists in BPF side to better support both cases.

Fixes: 915947cd1999 ("module: skb_drop: do not fail on old kernels")