### PR TITLE
build.rs: split tool and ebpf program build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,7 +115,7 @@ functional_task:
     - ssh ${DISTRO} 'sh -exc "uname -a"'
 
   test_script: &functional_test
-    - ssh -tt ${DISTRO} 'bash --login -exc "cd /vagrant/tests && cargo build"'
+    - ssh -tt ${DISTRO} 'bash --login -exc "cd /vagrant && cargo build"'
     - ssh -tt ${DISTRO} "cd /vagrant/tests && sudo python3 -m pytest ${TEST_EXTRA_ARGS}"
 
 # Manual trigger for non-PR branches.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,22 +11,22 @@ cargo_task_tempate: &cargo_task_template
       - cat Cargo.lock
   setup_script:
     - apt-get update
-    - apt-get -y install llvm clang libelf-dev libpcap-dev python3-pip
+    - apt-get -y install llvm clang libelf-dev libpcap-dev python3-pip make jq
     - rustup component add rustfmt
     - rustup component add clippy
   before_cache_script: rm -rf $CARGO_HOME/registry/index
 
 unittest_task:
   << : *cargo_task_template
-  build_script: cargo build --verbose
-  test_script: cargo test --verbose
+  build_script: make V=1 CARGO_OPTS=--verbose
+  test_script: make test V=1 CARGO_OPTS=--verbose
   check_script:
     - cargo fmt --check
     - cargo clippy -- -D warnings
 
 benchmark_task:
   << : *cargo_task_template
-  build_script: cargo build -F benchmark --verbose --release
+  build_script: make bench V=1 CARGO_OPTS=--verbose
   test_script:
     - ./target/release/retis benchmark --ci events_parsing
     - ./target/release/retis benchmark --ci events_output
@@ -115,7 +115,7 @@ functional_task:
     - ssh ${DISTRO} 'sh -exc "uname -a"'
 
   test_script: &functional_test
-    - ssh -tt ${DISTRO} 'bash --login -exc "cd /vagrant && cargo build"'
+    - ssh -tt ${DISTRO} 'bash --login -exc "cd /vagrant && make V=1"'
     - ssh -tt ${DISTRO} "cd /vagrant/tests && sudo python3 -m pytest ${TEST_EXTRA_ARGS}"
 
 # Manual trigger for non-PR branches.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,10 +26,10 @@ unittest_task:
 
 benchmark_task:
   << : *cargo_task_template
-  build_script: cargo build -F benchmark --verbose
+  build_script: cargo build -F benchmark --verbose --release
   test_script:
-    - ./target/debug/retis benchmark --ci events_parsing
-    - ./target/debug/retis benchmark --ci events_output
+    - ./target/release/retis benchmark --ci events_parsing
+    - ./target/release/retis benchmark --ci events_output
   check_script:
     - cargo clippy -F benchmark -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["tracing", "networking", "linux", "bpf", "ebpf"]
 include = ["src/", "build.rs", "retis-derive/", "profiles/", "tools/", "LICENSE"]
 edition = "2021"
 
+[package.metadata.misc]
+release_name = "bredele"
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,27 @@ else
     CARGO_JOBS := 1
 endif
 
-all: ebpf
+all: build
+
+install: build
+	$(CARGO) $(CARGO_OPTS) install $(CARGO_INSTALL_OPTS)
+
+build: ebpf
 	$(call out_console,CARGO,building retis ...)
 	$(Q)CARGO_BUILD_JOBS=$(CARGO_JOBS) \
 	RETIS_PKG_VERSION=$(RELEASE_VERSION) \
 	RETIS_RELEASE_NAME=$(RELEASE_NAME) \
 	$(CARGO) $(CARGO_OPTS) build $(CARGO_CMD_OPTS)
+
+test: ebpf
+	$(call out_console,CARGO,running tests ...)
+	$(Q)CARGO_BUILD_JOBS=$(CARGO_JOBS) \
+	$(CARGO) $(CARGO_OPTS) test $(CARGO_CMD_OPTS)
+
+bench: ebpf
+	$(call out_console,CARGO,building benchmarks ...)
+	$(Q)CARGO_BUILD_JOBS=$(CARGO_JOBS) \
+	$(CARGO) $(CARGO_OPTS) build -F benchmark --release $(CARGO_CMD_OPTS)
 
 ifeq ($(NOVENDOR),)
 $(LIBBPF_INCLUDES): $(LIBBPF_SYS_LIBBPF_INCLUDES)
@@ -112,23 +127,27 @@ clean: clean-ebpf
 
 help:
 	$(PRINT) 'all                 --  Builds the tool (both eBPF programs and retis).'
+	$(PRINT) 'bench               --  Builds benchmarks.'
 	$(PRINT) 'clean               --  Deletes all the files generated during the build process'
 	$(PRINT) '	                  (eBPF and rust directory).'
 	$(PRINT) 'clean-ebpf          --  Deletes all the files generated during the build process'
 	$(PRINT) '	                  (eBPF only).'
 	$(PRINT) 'ebpf                --  Builds only the eBPF programs.'
+	$(PRINT) 'install             --  Installs Retis.'
+	$(PRINT) 'test                --  Builds and runs unit tests.'
 	$(PRINT)
 	$(PRINT) 'Optional variables that can be used to override the default behavior:'
 	$(PRINT) 'V                   --  If set to 1 the verbose output will be printed.'
 	$(PRINT) '                        cargo verbosity is set to default.'
-	$(PRINT) '                        To override `cargo` behavior please refer to $$(CARGO_OPTS)'
-	$(PRINT) '                        and $$(CARGO_CMD_OPTS).'
+	$(PRINT) '                        To override `cargo` behavior please refer to $$(CARGO_OPTS),'
+	$(PRINT) '                        $$(CARGO_CMD_OPTS) and for the install $$(CARGO_INSTALL_OPTS).'
 	$(PRINT) '                        For further `cargo` customization please refer to configuration'
 	$(PRINT) '                        environment variables'
 	$(PRINT) '                        (https://doc.rust-lang.org/cargo/reference/environment-variables.html).'
 	$(PRINT) 'CARGO_CMD_OPTS      --  Changes `cargo` subcommand default behavior (e.g. --release for `build`).'
+	$(PRINT) 'CARGO_INSTALL_OPTS  --  Changes `cargo` install subcommand default behavior.'
 	$(PRINT) 'CARGO_OPTS          --  Changes `cargo` default behavior (e.g. --verbose).'
 	$(PRINT) 'NOVENDOR            --  Avoid to self detect and consume the vendored headers'
 	$(PRINT) '                        shipped with libbpf-sys.'
 
-.PHONY: all clean clean-ebpf ebpf $(EBPF_PROBES) $(GENERIC_HOOKS) help $(OVS_HOOKS)
+.PHONY: all clean clean-ebpf ebpf $(EBPF_PROBES) $(GENERIC_HOOKS) help install $(OVS_HOOKS)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,134 @@
+ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export LLC := llc
+export CLANG := clang
+export OBJCOPY := llvm-objcopy
+
+CARGO := cargo
+PRINT = echo
+
+VERBOSITY := $(filter 1,$(V))
+
+ifeq ($(VERBOSITY),)
+    Q=@
+    MAKE += -s
+    CARGO += -q
+define out_console
+    $(PRINT) -e "[$(1)]\t$(2)"
+endef
+
+.SILENT:
+endif
+
+ifeq ($(NOVENDOR),)
+    # This MUST be kept in sync with API_HEADERS under lib.rs in libbpf-sys
+    LIBBPF_API_HEADERS := bpf.h \
+                          libbpf.h \
+                          btf.h \
+                          bpf_helpers.h \
+                          bpf_helper_defs.h \
+                          bpf_tracing.h \
+                          bpf_endian.h \
+                          bpf_core_read.h \
+                          libbpf_common.h \
+                          usdt.bpf.h
+
+    LIBBPF_SYS_LIBBPF_BASE_PATH := $(dir $(shell cargo metadata --format-version=1 | jq -r '.packages | .[] | select(.name == "libbpf-sys") | .manifest_path'))
+    LIBBPF_SYS_LIBBPF_INCLUDES :=  $(wildcard $(addprefix $(LIBBPF_SYS_LIBBPF_BASE_PATH)/libbpf/src/, $(LIBBPF_API_HEADERS)))
+    LIBBPF_INCLUDES := $(ROOT_DIR)/src/.out
+endif
+
+FILTER_INCLUDES := src/core/filters/packets/bpf/include \
+                   src/core/filters/meta/bpf/include
+# Taking errno.h from libc instead of linux headers.
+# TODO: Remove when we fix proper header dependencies.
+INCLUDES_ALL := $(abspath $(wildcard src/core/probe/bpf/include \
+                                     src/core/probe/kernel/bpf/include \
+                                     src/core/probe/user/bpf/include \
+                                     src/core/events/bpf/include \
+                                     src/core/tracking/bpf/include \
+                                     /usr/include/x86_64-linux-gnu \
+                                     $(FILTER_INCLUDES)))
+INCLUDES_ALL += $(LIBBPF_INCLUDES)
+
+OVS_INCLUDES := $(abspath src/module/ovs/bpf/include)
+INCLUDES := $(addprefix -I, $(INCLUDES_ALL))
+
+EBPF_PROBES := $(abspath src/core/probe/kernel/bpf \
+                        src/core/probe/user/bpf)
+
+GENERIC_HOOKS := $(abspath src/module/skb/bpf \
+                           src/module/skb_drop/bpf \
+                           src/module/skb_tracking/bpf \
+                           src/module/nft/bpf \
+                           src/module/ct/bpf)
+
+OVS_HOOKS := $(abspath src/module/ovs/bpf)
+OUT_NAME := HOOK
+
+JOBS := $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS)))
+
+ifneq ($(JOBS),)
+    CARGO_JOBS := $(JOBS)
+else
+    CARGO_JOBS := 1
+endif
+
+all: ebpf
+	$(call out_console,CARGO,building retis ...)
+	$(Q)CARGO_BUILD_JOBS=$(CARGO_JOBS) \
+	RETIS_PKG_VERSION=$(RELEASE_VERSION) \
+	RETIS_RELEASE_NAME=$(RELEASE_NAME) \
+	$(CARGO) $(CARGO_OPTS) build $(CARGO_CMD_OPTS)
+
+ifeq ($(NOVENDOR),)
+$(LIBBPF_INCLUDES): $(LIBBPF_SYS_LIBBPF_INCLUDES)
+	-mkdir -p $(LIBBPF_INCLUDES)/bpf
+	cp $^ $(LIBBPF_INCLUDES)/bpf/
+endif
+
+$(OVS_HOOKS): INCLUDES_EXTRA := -I$(OVS_INCLUDES)
+
+$(EBPF_PROBES): OUT_NAME := PROBE
+
+ebpf: $(EBPF_PROBES) $(GENERIC_HOOKS) $(OVS_HOOKS)
+
+$(EBPF_PROBES) $(GENERIC_HOOKS) $(OVS_HOOKS): $(LIBBPF_INCLUDES)
+	$(call out_console,$(OUT_NAME),building $@ ...)
+	CFLAGS="$(INCLUDES) $(INCLUDES_EXTRA)" \
+	$(MAKE) -r -f $(ROOT_DIR)/ebpf.mk -C $@ $(TGT)
+
+clean-ebpf:
+	$(call out_console,CLEAN,cleaning ebpf progs...)
+	for i in $(EBPF_PROBES) $(GENERIC_HOOKS) $(OVS_HOOKS); do \
+	    $(MAKE) -r -f $(ROOT_DIR)/ebpf.mk -C $$i clean; \
+	done
+	-if [ -n "$(LIBBPF_INCLUDES)" ]; then \
+	    rm -rf $(LIBBPF_INCLUDES); \
+	fi
+
+clean: clean-ebpf
+	$(call out_console,CLEAN,cleaning retis ...)
+	$(Q)$(CARGO) clean
+
+help:
+	$(PRINT) 'all                 --  Builds the tool (both eBPF programs and retis).'
+	$(PRINT) 'clean               --  Deletes all the files generated during the build process'
+	$(PRINT) '	                  (eBPF and rust directory).'
+	$(PRINT) 'clean-ebpf          --  Deletes all the files generated during the build process'
+	$(PRINT) '	                  (eBPF only).'
+	$(PRINT) 'ebpf                --  Builds only the eBPF programs.'
+	$(PRINT)
+	$(PRINT) 'Optional variables that can be used to override the default behavior:'
+	$(PRINT) 'V                   --  If set to 1 the verbose output will be printed.'
+	$(PRINT) '                        cargo verbosity is set to default.'
+	$(PRINT) '                        To override `cargo` behavior please refer to $$(CARGO_OPTS)'
+	$(PRINT) '                        and $$(CARGO_CMD_OPTS).'
+	$(PRINT) '                        For further `cargo` customization please refer to configuration'
+	$(PRINT) '                        environment variables'
+	$(PRINT) '                        (https://doc.rust-lang.org/cargo/reference/environment-variables.html).'
+	$(PRINT) 'CARGO_CMD_OPTS      --  Changes `cargo` subcommand default behavior (e.g. --release for `build`).'
+	$(PRINT) 'CARGO_OPTS          --  Changes `cargo` default behavior (e.g. --verbose).'
+	$(PRINT) 'NOVENDOR            --  Avoid to self detect and consume the vendored headers'
+	$(PRINT) '                        shipped with libbpf-sys.'
+
+.PHONY: all clean clean-ebpf ebpf $(EBPF_PROBES) $(GENERIC_HOOKS) help $(OVS_HOOKS)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,7 +16,9 @@ dnf install -y \
     git \
     python3-pip \
     socat \
-    nftables
+    nftables \
+    make \
+    jq
 
     python3 -m pip install pytest pyroute2
 SCRIPT
@@ -101,7 +103,9 @@ Vagrant.configure("2") do |config|
           python3-pip \
           openvswitch-switch \
           socat \
-          nftables
+          nftables \
+          make \
+          jq
 
       su vagrant -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -qy"
       python3 -m pip install pytest pyroute2

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -93,8 +93,8 @@ flavor coding style for the BPF parts.
 1. Check the following commands do not return an error:
    1. `cargo fmt --check`
    1. `cargo clippy -- -D warnings`
-   1. `cargo test`, or to include runtime tests,
-      `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo' cargo test --features=test_cap_bpf`
+   1. `make test V=1`, or to include runtime tests,
+      `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=sudo CARGO_CMD_OPTS="--features=test_cap_bpf" make test V=1`
 1. Make sure commits are
    [signed off](https://www.kernel.org/doc/html/latest/process/submitting-patches.html?highlight=signed%20off#developer-s-certificate-of-origin-1-1).
 1. Use a clear, concise and descriptive title.

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,6 +60,7 @@ future use (e.g. logged events using the `-o` cli option).
 Retis depends on the following (in addition to Git and Cargo):
 - rust >= 2021
 - clang
+- jq
 - libelf
 - libpcap
 - llvm
@@ -70,21 +71,21 @@ On Fedora, one can run:
 
 ```none
 $ dnf -y install git cargo clang elfutils-libelf-devel \
-        libpcap-devel llvm make pkgconf-pkg-config
+        jq libpcap-devel llvm make pkgconf-pkg-config
 ```
 
 On Ubuntu:
 
 ```none
 $ apt update
-$ apt -y install git cargo clang libelf-dev libpcap-dev llvm make pkg-config
+$ apt -y install git cargo clang jq libelf-dev libpcap-dev llvm make pkg-config
 ```
 
 Then, to download and build Retis:
 
 ```none
 $ git clone --depth 1 https://github.com/retis-org/retis; cd retis
-$ cargo build --release
+$ make release
 $ ./target/release/retis --help
 ```
 

--- a/ebpf.mk
+++ b/ebpf.mk
@@ -1,0 +1,35 @@
+# Needs to be set because of PT_REGS_PARMx() and any other target
+# specific facility.
+ARCH := x86
+OUT_DIR := .out
+OBJS := $(patsubst %.c,$(OUT_DIR)/%.o,$(wildcard *.c))
+DEP := $(OBJS:%.o=%.d)
+BPF_CFLAGS := -target bpf \
+              -Wall \
+              -Wno-unused-value \
+              -Wno-pointer-sign \
+              -Wno-compare-distinct-pointer-types \
+              -fno-stack-protector \
+              -Werror \
+              -D __TARGET_ARCH_$(ARCH) \
+	      -O2
+
+ALL_REQ := $(OBJS)
+
+all: $(ALL_REQ)
+
+$(OUT_DIR):
+	mkdir -p $(OUT_DIR)/
+
+$(OBJS): | $(OUT_DIR)
+
+$(OUT_DIR)/%.o: %.c
+	$(CLANG) $(CFLAGS) $(BPF_CFLAGS) $(INCLUDES_EXTRA) -MMD -c -g -o $@ $<
+	$(OBJCOPY) --strip-debug $@
+
+-include $(DEP)
+
+clean:
+	-rm -rf $(OUT_DIR)
+
+.PHONY: clean

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -23,7 +23,6 @@ use crate::{
     module::{ModuleId, Modules},
     process::cli::*,
     profiles::{cli::ProfileCmd, Profile},
-    VERSION_NAME,
 };
 
 /// SubCommandRunner defines the common interface to run SubCommands.
@@ -252,10 +251,13 @@ impl ThinCli {
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
+        let pkg_version = option_env!("RETIS_RELEASE_VERSION").unwrap_or("unspec");
+        let pkg_name = option_env!("RETIS_RELEASE_NAME").unwrap_or("unreleased");
+
         let version = if cfg!(debug_assertions) {
-            format!("{}-dbg (\"{VERSION_NAME}\")", env!("CARGO_PKG_VERSION"))
+            format!("{}-dbg (\"{}\")", pkg_version, pkg_name)
         } else {
-            format!("{} (\"{VERSION_NAME}\")", env!("CARGO_PKG_VERSION"))
+            format!("{} (\"{}\")", pkg_version, pkg_name)
         };
 
         let args: Vec<OsString> = args.into_iter().map(|x| x.into()).collect();

--- a/src/core/events/bpf.rs
+++ b/src/core/events/bpf.rs
@@ -314,7 +314,7 @@ pub(crate) fn parse_raw_section<'a, T>(raw_section: &'a BpfRawSection) -> Result
 /// section validity and parsing it into a structured type.
 pub(crate) fn parse_single_raw_section<'a, T>(
     id: ModuleId,
-    raw_sections: &'a Vec<BpfRawSection>,
+    raw_sections: &'a [BpfRawSection],
 ) -> Result<&'a T> {
     if raw_sections.len() != 1 {
         bail!("{id} event from BPF must be a single section");

--- a/src/core/filters/meta/bpf/include/meta_filter.h
+++ b/src/core/filters/meta/bpf/include/meta_filter.h
@@ -213,7 +213,6 @@ static __always_inline
 unsigned int meta_filter(struct sk_buff *skb)
 {
 	struct retis_meta_ctx ctx = {};
-	u8 __nmemb, __type;
 
 	/* reduce actions to load/cmp info. If no entries, return
 	 * match.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,6 @@ use crate::{
 // Re-export derive macros.
 use retis_derive::*;
 
-const VERSION_NAME: &str = "bredele";
-
 fn main() -> Result<()> {
     let mut cli = get_cli()?.build();
 

--- a/src/module/ct/bpf/ct.bpf.c
+++ b/src/module/ct/bpf/ct.bpf.c
@@ -77,11 +77,7 @@ static __always_inline int process_nf_conn(struct ct_event *e,
 					   struct nf_conn *ct, u16 l3num,
 					   u8 protonum)
 {
-	struct nf_conntrack_tuple *orig, *reply;
-	struct nf_conntrack_zone *zone;
-	struct nf_conn *nf_conn;
 	u8 zone_dir;
-
 
 	if (bpf_core_field_exists(ct->zone)) {
 		zone_dir = (u8) BPF_CORE_READ(ct, zone.dir);

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -387,8 +387,8 @@ static __always_inline int process_packet(struct retis_raw_event *event,
 	 * signed arithmetic operations.
 	 */
 	int mac, headroom, linear_len;
-	unsigned char *head, *data;
 	struct skb_packet_event *e;
+	unsigned char *head;
 	u16 network;
 	u32 len;
 

--- a/tools/benchmark_event_output.sh
+++ b/tools/benchmark_event_output.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build --release -F benchmark
+make bench V=1
 
 time_single_single=0
 time_single_multi=0

--- a/tools/benchmark_event_parsing.sh
+++ b/tools/benchmark_event_parsing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cargo build --release -F benchmark
+make bench V=1
 
 time_first=0
 time_1m=0


### PR DESCRIPTION
- build time halved
- finer-grained and better rebuild prereq checks
- clean target actually cleans the tree
- can be easier to use the available tooling (maybe linking progs, if we'll ever use that)
- could be easily extended to build ebpf programs in a container
- ebpf progs can be built independently
- simplifies build.rs (maybe :)
- can make it fairly easy to switch to GCC instead of clang