### PR TITLE
[RFC] dinamically inline packet filter

### DIFF
--- a/src/core/bpf_sys/bpf_sys.rs
+++ b/src/core/bpf_sys/bpf_sys.rs
@@ -4,8 +4,6 @@ use std::io::{Error, Result};
 use std::mem;
 use std::os::raw::c_long;
 
-use anyhow::bail;
-
 // Embed in a mod to skip the linter
 mod bpf_gen {
     #![allow(non_upper_case_globals)]
@@ -39,101 +37,6 @@ pub(crate) fn bpf_unload(fd: u32) -> Result<()> {
     }
 
     Ok(())
-}
-
-fn btf_get_fd(id: u32) -> anyhow::Result<u32> {
-    let mut attrs: bpf_gen::bpf_attr = unsafe { std::mem::zeroed() };
-    let btf_get_fd_attrs = unsafe { &mut attrs.__bindgen_anon_6.__bindgen_anon_1 };
-
-    btf_get_fd_attrs.btf_id = id;
-
-    let res = bpf(bpf_gen::bpf_cmd::BPF_BTF_GET_FD_BY_ID, &attrs)?;
-    Ok(res)
-}
-
-fn obj_get_info(fd: u32, info: &[u8]) -> anyhow::Result<u32> {
-    let mut attrs: bpf_gen::bpf_attr = unsafe { std::mem::zeroed() };
-    let info_attrs = unsafe { &mut attrs.info };
-
-    info_attrs.bpf_fd = fd;
-    info_attrs.info = info.as_ptr() as u64;
-    info_attrs.info_len = info.len() as u32;
-
-    let res = bpf(bpf_gen::bpf_cmd::BPF_OBJ_GET_INFO_BY_FD, &attrs)?;
-    Ok(res)
-}
-
-pub(crate) fn gen_dummy_func_info_rec(btf_tid: u32) -> (bpf_gen::bpf_func_info, usize, u32) {
-    (
-        bpf_gen::bpf_func_info {
-            type_id: btf_tid,
-            insn_off: 0,
-        },
-        std::mem::size_of::<bpf_gen::bpf_func_info>(),
-        1,
-    )
-}
-
-pub(crate) fn load_btf(btf: &[u8]) -> anyhow::Result<u32> {
-    let mut attrs: bpf_gen::bpf_attr = unsafe { std::mem::zeroed() };
-    let btf_load_attrs = unsafe { &mut attrs.__bindgen_anon_7 };
-
-    btf_load_attrs.btf = btf.as_ptr() as u64;
-    btf_load_attrs.btf_size = btf.len() as u32;
-
-    let ret = bpf(bpf_gen::bpf_cmd::BPF_BTF_LOAD, &attrs)?;
-    Ok(ret)
-}
-
-pub(crate) fn get_btf_from_fd(prog_fd: u32) -> anyhow::Result<Vec<u8>> {
-    let prog_info: bpf_gen::bpf_prog_info = unsafe { std::mem::zeroed() };
-
-    if prog_fd == 0 {
-        bail!("Invalid program file descriptor")
-    }
-
-    obj_get_info(prog_fd, unsafe {
-        std::slice::from_raw_parts(
-            &prog_info as *const _ as *const u8,
-            std::mem::size_of::<bpf_gen::bpf_prog_info>(),
-        )
-    })?;
-
-    let prog_btf_id = match prog_info.btf_id {
-        id if id > 0 => id,
-        id => bail!("Invalid bpf prog btf fd ({id})"),
-    };
-
-    let btf_fd = btf_get_fd(prog_btf_id)?;
-
-    let mut btf_info: bpf_gen::bpf_btf_info = unsafe { std::mem::zeroed() };
-    let mut btf_buff = vec![0u8; 2048];
-
-    let mut resized = false;
-
-    loop {
-        btf_info.btf = btf_buff.as_ptr() as u64;
-
-        obj_get_info(btf_fd, unsafe {
-            std::slice::from_raw_parts(
-                &btf_info as *const _ as *const u8,
-                std::mem::size_of::<bpf_gen::bpf_btf_info>(),
-            )
-        })?;
-
-        if btf_info.btf_size <= btf_buff.len() as u32 {
-            break;
-        }
-
-        if !resized {
-            btf_buff.resize(btf_info.btf_size as usize, 0);
-            resized = true;
-        } else {
-            bail!("Unable to retrieve btf data (buff too small)")
-        }
-    }
-
-    Ok(btf_buff)
 }
 
 #[cfg(test)]

--- a/src/core/filters/filters.rs
+++ b/src/core/filters/filters.rs
@@ -1,8 +1,27 @@
 /// eBPF filter wrapper containing the sequence of bytes composing the eBPF program
+
+use std::{collections::HashMap, sync::Mutex};
+
+use anyhow::Result;
+use once_cell::sync::Lazy;
+
 #[derive(Clone)]
 pub(crate) struct BpfFilter(pub(crate) Vec<u8>);
 
 #[derive(Clone)]
 pub(crate) enum Filter {
     Packet(BpfFilter),
+}
+
+static FM: Lazy<Mutex<HashMap<u32, Filter>>> = Lazy::new(|| {
+    Mutex::new(HashMap::new())
+});
+
+pub(crate) fn register_filter(r#type: u32, filter: &Filter) -> Result<()> {
+    FM.lock().unwrap().insert(r#type, filter.clone());
+    Ok(())
+}
+
+pub(crate) fn get_filter(r#type: u32) -> Option<Filter> {
+    FM.lock().unwrap().get(&r#type).cloned()
 }

--- a/src/core/filters/filters.rs
+++ b/src/core/filters/filters.rs
@@ -1,9 +1,10 @@
 /// eBPF filter wrapper containing the sequence of bytes composing the eBPF program
-
 use std::{collections::HashMap, sync::Mutex};
 
 use anyhow::Result;
 use once_cell::sync::Lazy;
+
+use crate::core::workaround;
 
 #[derive(Clone)]
 pub(crate) struct BpfFilter(pub(crate) Vec<u8>);
@@ -13,9 +14,7 @@ pub(crate) enum Filter {
     Packet(BpfFilter),
 }
 
-static FM: Lazy<Mutex<HashMap<u32, Filter>>> = Lazy::new(|| {
-    Mutex::new(HashMap::new())
-});
+static FM: Lazy<Mutex<HashMap<u32, Filter>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 pub(crate) fn register_filter(r#type: u32, filter: &Filter) -> Result<()> {
     FM.lock().unwrap().insert(r#type, filter.clone());
@@ -24,4 +23,24 @@ pub(crate) fn register_filter(r#type: u32, filter: &Filter) -> Result<()> {
 
 pub(crate) fn get_filter(r#type: u32) -> Option<Filter> {
     FM.lock().unwrap().get(&r#type).cloned()
+}
+
+pub(crate) fn register_filter_handler(
+    sec: &str,
+    prog_type: libbpf_rs::ProgramType,
+    func: libbpf_sys::libbpf_prog_prepare_load_fn_t,
+) -> Result<()> {
+    let opts = workaround::ProgHandlerOpts {
+        prepare_load_fn: func,
+        cookie: 0xdeadbeef,
+        ..Default::default()
+    };
+    workaround::register_prog_handler(
+        Some(sec.to_string()),
+        prog_type,
+        libbpf_rs::ProgramAttachType::CgroupInetIngress,
+        opts,
+    )?;
+
+    Ok(())
 }

--- a/src/core/filters/packets/ebpf.rs
+++ b/src/core/filters/packets/ebpf.rs
@@ -232,15 +232,9 @@ impl eBpfProg {
         Ok(())
     }
 
-    /// Prepare to return. If reg selector is set, the value of R0 (A
-    /// reg) will be stored ctx->ret, otherwise an immediate value
-    /// will be set.
+    /// Prepare to return. If reg selector is set, no operation is needed,
+    /// otherwise, k will be set to R0.
     fn prepare_ret(&mut self, insn: &BpfInsn, reg: bool) -> Result<()> {
-        // FIXME: This should handle options and return in A for the
-        // common case. Tracepoint are the exception, and in such case
-        // we return in ctx->ret as, for what it seems to be an issue,
-        // the retval of the freplacing function cannot be a value
-        // other than 0
         if !reg {
             self.add(eBpfInsn::mov(MovInfo::Imm {
                 dst: BpfReg::A,
@@ -248,19 +242,6 @@ impl eBpfProg {
             }));
         }
 
-        self.add(eBpfInsn::st(
-            StInfo::Reg {
-                src: BpfReg::A,
-                dst: BpfReg::CTX,
-                off: i16::try_from(offset_of!(retis_filter_ctx, ret))?,
-            },
-            BpfSize::Word,
-        ));
-
-        self.add(eBpfInsn::mov(MovInfo::Imm {
-            dst: BpfReg::A,
-            imm: 0x00000,
-        }));
         Ok(())
     }
 

--- a/src/core/filters/packets/ebpf.rs
+++ b/src/core/filters/packets/ebpf.rs
@@ -91,6 +91,9 @@ struct retis_filter_ctx {
 pub(crate) struct eBpfProg(Vec<eBpfInsn>);
 
 impl eBpfProg {
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
     pub(crate) fn add(&mut self, insn: eBpfInsn) {
         self.0.push(insn);
     }

--- a/src/core/filters/packets/ebpf.rs
+++ b/src/core/filters/packets/ebpf.rs
@@ -241,21 +241,16 @@ impl eBpfProg {
         // we return in ctx->ret as, for what it seems to be an issue,
         // the retval of the freplacing function cannot be a value
         // other than 0
-        if reg {
-            self.add(eBpfInsn::mov(MovInfo::Reg {
-                src: BpfReg::A,
-                dst: BpfReg::SCRATCH,
-            }));
-        } else {
+        if !reg {
             self.add(eBpfInsn::mov(MovInfo::Imm {
-                dst: BpfReg::SCRATCH,
+                dst: BpfReg::A,
                 imm: insn.k as i32,
             }));
         }
 
         self.add(eBpfInsn::st(
             StInfo::Reg {
-                src: BpfReg::SCRATCH,
+                src: BpfReg::A,
                 dst: BpfReg::CTX,
                 off: i16::try_from(offset_of!(retis_filter_ctx, ret))?,
             },

--- a/src/core/filters/packets/ebpf.rs
+++ b/src/core/filters/packets/ebpf.rs
@@ -69,7 +69,7 @@ impl BpfReg {
     pub const CTX: Self = Self::R6;
     pub const X: Self = Self::R7;
     pub const CTXDATA: Self = Self::R8;
-    pub const SCRATCH: Self = Self::R9;
+    pub const INLINE_FP: Self = Self::R9;
     pub const FP: Self = Self::R10;
 }
 
@@ -166,7 +166,7 @@ impl eBpfProg {
 
         // mov %fp, %arg1
         self.add(Insn::mov(MovInfo::Reg {
-            src: BpfReg::FP,
+            src: BpfReg::INLINE_FP,
             dst: BpfReg::ARG1,
         }));
         // add -8, %arg1
@@ -215,7 +215,7 @@ impl eBpfProg {
         // ldx -STACK_RESERVED(%r10), %r0
         self.add(Insn::ld(
             LdInfo::Reg {
-                src: BpfReg::FP,
+                src: BpfReg::INLINE_FP,
                 dst: BpfReg::A,
                 off: -STACK_RESERVED,
             },
@@ -372,7 +372,7 @@ impl TryFrom<BpfProg> for eBpfProg {
                 )),
                 t @ BpfInsnType::LdxMem | t @ BpfInsnType::LdMem => ebpf.add(Insn::ld(
                     LdInfo::Reg {
-                        src: BpfReg::FP,
+                        src: BpfReg::INLINE_FP,
                         dst: if let BpfInsnType::LdMem = t {
                             BpfReg::A
                         } else {
@@ -466,7 +466,7 @@ impl TryFrom<BpfProg> for eBpfProg {
                 BpfInsnType::St => ebpf.add(Insn::st(
                     StInfo::Reg {
                         src: BpfReg::A,
-                        dst: BpfReg::FP,
+                        dst: BpfReg::INLINE_FP,
                         off: -SCRATCH_MEM_START + (cbpf_insn.k as i16 * SCRATCH_MEM_SIZE),
                     },
                     BpfSize::Word,
@@ -474,7 +474,7 @@ impl TryFrom<BpfProg> for eBpfProg {
                 BpfInsnType::Stx => ebpf.add(Insn::st(
                     StInfo::Reg {
                         src: BpfReg::X,
-                        dst: BpfReg::FP,
+                        dst: BpfReg::INLINE_FP,
                         off: -SCRATCH_MEM_START + (cbpf_insn.k as i16 * SCRATCH_MEM_SIZE),
                     },
                     BpfSize::Word,

--- a/src/core/filters/packets/filter.rs
+++ b/src/core/filters/packets/filter.rs
@@ -8,10 +8,25 @@
 
 use std::mem;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use pcap::{Capture, Linktype};
 
-use crate::core::filters::{packets::cbpf::BpfProg, packets::ebpf::eBpfProg};
+use crate::core::{
+    bpf_sys,
+    filters::{
+        get_filter,
+        packets::{
+            cbpf::BpfProg,
+            ebpf::{eBpfProg, BpfReg},
+            ebpfinsn::{eBpfInsn, MovInfo},
+        },
+        Filter,
+    },
+};
+
+// please keep in sync with FILTER_MAX_INSNS in
+// src/core/probe/kernel/bpf/include/common.h
+const FILTER_MAX_INSNS: usize = 4096;
 
 #[derive(Clone)]
 pub(crate) struct FilterPacket(eBpfProg);
@@ -23,10 +38,72 @@ impl FilterPacket {
         let insns = program.get_instructions();
         let filter = BpfProg::try_from(unsafe { mem::transmute::<_, &[u8]>(insns) })?;
 
-        Ok(FilterPacket(eBpfProg::try_from(filter)?))
+        let ebpf_filter = eBpfProg::try_from(filter)?;
+        if ebpf_filter.len() > FILTER_MAX_INSNS {
+            bail!("Filter exceeds the maximum allowed size.");
+        }
+
+        Ok(FilterPacket(ebpf_filter))
     }
 
     pub(crate) fn to_bytes(&self) -> Result<Vec<u8>> {
         Ok(self.0.to_bytes())
     }
+}
+
+pub(crate) unsafe extern "C" fn prepare_load(
+    prog: *mut libbpf_sys::bpf_program,
+    _opts: *mut libbpf_sys::bpf_prog_load_opts,
+    cookie: ::std::os::raw::c_long,
+) -> std::os::raw::c_int {
+    let filter = get_filter(cookie as u32);
+
+    let f = if let Some(f) = filter {
+        match f {
+            Filter::Packet(bf) => bf.0,
+        }
+    } else {
+        let mut default_filter = eBpfProg::new();
+        default_filter.add(eBpfInsn::mov32(MovInfo::Imm {
+            dst: BpfReg::R0,
+            imm: 0x40000_i32,
+        }));
+        default_filter.to_bytes()
+    };
+
+    let filter: &[libbpf_sys::bpf_insn] = unsafe {
+        std::slice::from_raw_parts(
+            f.as_slice().as_ptr() as *const libbpf_sys::bpf_insn,
+            f.len() / std::mem::size_of::<libbpf_sys::bpf_insn>(),
+        )
+    };
+
+    let (insns, insns_cnt) = unsafe {
+        (
+            libbpf_sys::bpf_program__insns(prog),
+            libbpf_sys::bpf_program__insn_cnt(prog),
+        )
+    };
+
+    let insns = unsafe { std::slice::from_raw_parts(insns, insns_cnt as usize) };
+    let mut prog_ext = insns.to_vec().clone();
+    let mut inject_pos = 0;
+
+    for (pos, insn) in prog_ext.iter().enumerate() {
+        if insn.code == (bpf_sys::BPF_JMP | bpf_sys::BPF_CALL) as u8 && insn.imm == cookie as i32 {
+            inject_pos = pos;
+            break;
+        }
+    }
+
+    prog_ext.splice(
+        inject_pos..inject_pos + filter.len(),
+        filter.to_vec().iter().cloned(),
+    );
+
+    libbpf_sys::bpf_program__set_insns(
+        prog,
+        prog_ext.as_mut_slice().as_mut_ptr(),
+        prog_ext.len() as u64,
+    )
 }

--- a/src/core/filters/packets/mod.rs
+++ b/src/core/filters/packets/mod.rs
@@ -3,7 +3,3 @@ pub(crate) mod cbpf;
 pub(crate) mod ebpf;
 pub(crate) mod ebpfinsn;
 pub(crate) mod filter;
-
-pub(crate) mod filter_stub {
-    include!("bpf/.out/stub.rs");
-}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -12,3 +12,4 @@ pub(crate) mod probe;
 pub(crate) mod signals;
 pub(crate) mod tracking;
 pub(crate) mod user;
+pub(crate) mod workaround;

--- a/src/core/probe/builder.rs
+++ b/src/core/probe/builder.rs
@@ -2,14 +2,12 @@
 //!
 //! ProbeBuilder defines the ProbeBuider trait and some useful utility functions
 //!
-use std::{ffi::CString, os::fd::RawFd, ptr};
+use std::os::fd::RawFd;
 
-use anyhow::{anyhow, bail, Result};
-use btf_rs::{Btf, Type};
+use anyhow::{anyhow, Result};
 
 use crate::core::{
-    bpf_sys,
-    filters::{BpfFilter, Filter, register_filter},
+    filters::{Filter, register_filter},
     probe::*,
 };
 
@@ -49,60 +47,6 @@ pub(super) fn reuse_map_fds(
             continue;
         }
     }
-    Ok(())
-}
-
-/// Replaces raw bpf programs using both btf-rs and bpf_sys
-/// facilities. This is currently needed because libbpf-rs doesn't
-/// have loading nor replacing capabilities for non-ELF files.
-fn replace_raw_filter(filter: &BpfFilter, target: &str, fd: u32) -> Result<()> {
-    let btf_buff = bpf_sys::get_btf_from_fd(fd)?;
-    let btf = Btf::from_bytes(&btf_buff)?;
-    let tgt_btf_id = btf.resolve_id_by_name(target)?;
-
-    match btf.resolve_type_by_id(tgt_btf_id)? {
-        Type::Func(_) => (),
-        _ => bail!("Resolved type is not a function"),
-    }
-
-    let btf_fd = bpf_sys::load_btf(crate::core::filters::packets::filter_stub::BTF)?;
-
-    let btf = Btf::from_bytes(crate::core::filters::packets::filter_stub::BTF)?;
-    let (func_info_rec, rec_size, rec_count) =
-        bpf_sys::gen_dummy_func_info_rec(btf.resolve_id_by_name(target)?);
-
-    let mut attrs: bpf_sys::bpf_attr = unsafe { std::mem::zeroed() };
-    let load_attrs = unsafe { &mut attrs.__bindgen_anon_3 };
-
-    load_attrs.prog_type = bpf_sys::bpf_prog_type::BPF_PROG_TYPE_EXT as u32;
-    let prog_name = CString::new(format!("r_{}", target)).expect("new string for prog name failed");
-    unsafe {
-        ptr::copy_nonoverlapping(
-            prog_name.as_ptr(),
-            load_attrs.prog_name.as_mut_ptr(),
-            load_attrs.prog_name.len(),
-        )
-    };
-
-    let prog: &[u8] = &filter.0;
-    load_attrs.insn_cnt = (prog.len() / 8) as u32;
-    load_attrs.insns = prog.as_ptr() as u64;
-    let license = CString::new("GPL").expect("new string for license failed");
-    load_attrs.license = license.as_ptr() as u64;
-    load_attrs.attach_btf_id = tgt_btf_id;
-    load_attrs.__bindgen_anon_1.attach_prog_fd = fd;
-    load_attrs.prog_btf_fd = btf_fd;
-    load_attrs.func_info = &func_info_rec as *const _ as u64;
-    load_attrs.func_info_rec_size = rec_size as u32;
-    load_attrs.func_info_cnt = rec_count;
-
-    let load_fd = bpf_sys::bpf(bpf_sys::bpf_cmd::BPF_PROG_LOAD, &attrs)?;
-    let mut attrs: bpf_sys::bpf_attr = unsafe { std::mem::zeroed() };
-    let link_attr = unsafe { &mut attrs.link_create };
-    link_attr.prog_fd = load_fd;
-
-    bpf_sys::bpf(bpf_sys::bpf_cmd::BPF_LINK_CREATE, &attrs)?;
-
     Ok(())
 }
 

--- a/src/core/probe/builder.rs
+++ b/src/core/probe/builder.rs
@@ -9,7 +9,7 @@ use btf_rs::{Btf, Type};
 
 use crate::core::{
     bpf_sys,
-    filters::{BpfFilter, Filter},
+    filters::{BpfFilter, Filter, register_filter},
     probe::*,
 };
 
@@ -106,10 +106,10 @@ fn replace_raw_filter(filter: &BpfFilter, target: &str, fd: u32) -> Result<()> {
     Ok(())
 }
 
-pub(super) fn replace_filters(fd: RawFd, filters: &[Filter]) -> Result<()> {
+pub(super) fn replace_filters(filters: &[Filter]) -> Result<()> {
     for filter in filters.iter() {
         match filter {
-            Filter::Packet(f) => replace_raw_filter(f, "packet_filter", fd as u32)?,
+            Filter::Packet(_) => register_filter(0xdeadbeef, filter)?,
         }
     }
 

--- a/src/core/probe/builder.rs
+++ b/src/core/probe/builder.rs
@@ -7,7 +7,7 @@ use std::os::fd::RawFd;
 use anyhow::{anyhow, Result};
 
 use crate::core::{
-    filters::{Filter, register_filter},
+    filters::{register_filter, Filter},
     probe::*,
 };
 
@@ -53,7 +53,9 @@ pub(super) fn reuse_map_fds(
 pub(super) fn replace_filters(filters: &[Filter]) -> Result<()> {
     for filter in filters.iter() {
         match filter {
-            Filter::Packet(_) => register_filter(0xdeadbeef, filter)?,
+            Filter::Packet(_) => {
+                register_filter(0xdeadbeef, filter)?;
+            }
         }
     }
 

--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -140,16 +140,47 @@ HOOK(9)
 /* Keep in sync with its Rust counterpart in crate::core::probe::kernel */
 #define HOOK_MAX 10
 
+#define FILTER_MAX_INSNS 4096
+
+#define __s(v) #v
+#define s(v) __s(v)
+
+/* Reserve FILTER_MAX_INSNS - (instruction placeholder) */
+#define RESERVE_NOP				\
+	".rept " s(FILTER_MAX_INSNS) " - 1;"	\
+	"goto +0x0;"				\
+	".endr;"
+
 /* Always return true. Use 0x40000 as it's typically used by
  * generated filters while 0 means no match, instead.
  */
-__attribute__ ((noinline))
+static __always_inline
 unsigned int packet_filter(struct retis_filter_context *ctx)
 {
+	/* 8 bytes for probe_read_kernel() outcome plus 16 * 4 scratch
+	 * memory locations for cbpf filters. Aligned to u64 boundary. */
+	u64 stack[8 + (16 >> 1)];
+	register struct retis_filter_context *ctx_reg asm("r1");
+	register u64 *fp asm("r9");
+
 	if (!ctx)
 		return 0;
 
-	ctx->ret = 0x40000;
+	ctx_reg = ctx;
+	fp = (u64 *)((void *)stack + sizeof(stack));
+
+	asm volatile (
+		"call 0xdeadbeef;"
+		RESERVE_NOP
+		"*(u32 *)%0 = r0;"
+		: /* out */
+		  "=m" (ctx->ret)
+		: /* in */
+		  "r" (ctx_reg),
+		  "r" (fp)
+		: "r0", "r1", "r2", "r3",
+		  "r4", "r5", "r6", "r7",
+		  "r8", "r9");
 
 	return ctx->ret;
 }

--- a/src/core/probe/kernel/kprobe.rs
+++ b/src/core/probe/kernel/kprobe.rs
@@ -51,7 +51,7 @@ impl ProbeBuilder for KprobeBuilder {
             .ok_or_else(|| anyhow!("Couldn't get program"))?
             .as_fd()
             .as_raw_fd();
-        replace_filters(fd, &filters)?;
+        replace_filters(&filters)?;
         let mut links = replace_hooks(fd, &hooks)?;
         self.links.append(&mut links);
 

--- a/src/core/probe/kernel/kretprobe.rs
+++ b/src/core/probe/kernel/kretprobe.rs
@@ -55,7 +55,7 @@ impl ProbeBuilder for KretprobeBuilder {
             .ok_or_else(|| anyhow!("Couldn't get program"))?
             .as_fd()
             .as_raw_fd();
-        replace_filters(fd, &filters)?;
+        replace_filters(&filters)?;
         let mut links = replace_hooks(fd, &hooks)?;
         self.links.append(&mut links);
 

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -10,9 +10,11 @@ use std::os::fd::{AsFd, AsRawFd, RawFd};
 use anyhow::{anyhow, bail, Result};
 use libbpf_rs::skel::SkelBuilder;
 
-use crate::core::filters::Filter;
-use crate::core::probe::builder::*;
-use crate::core::probe::*;
+use crate::core::{
+    filters::{packets::filter::prepare_load, register_filter_handler, Filter},
+    probe::builder::*,
+    probe::*,
+};
 
 mod raw_tracepoint_bpf {
     include!("bpf/.out/raw_tracepoint.skel.rs");
@@ -42,7 +44,12 @@ impl ProbeBuilder for RawTracepointBuilder {
         self.map_fds = map_fds;
         self.hooks = hooks;
         self.filters = filters;
-        Ok(())
+
+        register_filter_handler(
+            "raw_tracepoint/probe",
+            libbpf_rs::ProgramType::RawTracepoint,
+            Some(prepare_load),
+        )
     }
 
     fn attach(&mut self, probe: &Probe) -> Result<()> {
@@ -60,12 +67,13 @@ impl ProbeBuilder for RawTracepointBuilder {
         let open_obj = skel.obj;
         reuse_map_fds(&open_obj, &self.map_fds)?;
 
+        replace_filters(&self.filters)?;
+
         let mut obj = open_obj.load()?;
         let prog = obj
             .prog_mut("probe_raw_tracepoint")
             .ok_or_else(|| anyhow!("Couldn't get program"))?;
 
-        replace_filters(&self.filters)?;
         let mut links = replace_hooks(prog.as_fd().as_raw_fd(), &self.hooks)?;
         self.links.append(&mut links);
 

--- a/src/core/probe/kernel/raw_tracepoint.rs
+++ b/src/core/probe/kernel/raw_tracepoint.rs
@@ -65,7 +65,7 @@ impl ProbeBuilder for RawTracepointBuilder {
             .prog_mut("probe_raw_tracepoint")
             .ok_or_else(|| anyhow!("Couldn't get program"))?;
 
-        replace_filters(prog.as_fd().as_raw_fd(), &self.filters)?;
+        replace_filters(&self.filters)?;
         let mut links = replace_hooks(prog.as_fd().as_raw_fd(), &self.hooks)?;
         self.links.append(&mut links);
 

--- a/src/core/workaround.rs
+++ b/src/core/workaround.rs
@@ -1,0 +1,79 @@
+/// # Workaround
+///
+/// Provides workarounds to circumvent some limitations of Rust and/or
+/// dependencies we use.
+///
+/// Currently libbpf_rs does not wrap libbpf_register_prog_handler.
+///
+/// For now we internally wrap it and consuming for inlining dynamic code.
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ProgHandlerOpts {
+    /// Custom user-provided value accessible in the callbacks, if needed.
+    pub cookie: i64,
+    pub setup_fn: libbpf_sys::libbpf_prog_setup_fn_t,
+    pub prepare_load_fn: libbpf_sys::libbpf_prog_prepare_load_fn_t,
+    pub attach_fn: libbpf_sys::libbpf_prog_attach_fn_t,
+    #[doc(hidden)]
+    pub _non_exhaustive: (),
+}
+
+impl From<ProgHandlerOpts> for libbpf_sys::libbpf_prog_handler_opts {
+    fn from(opts: ProgHandlerOpts) -> Self {
+        let ProgHandlerOpts {
+            cookie,
+            setup_fn,
+            prepare_load_fn,
+            attach_fn,
+            _non_exhaustive,
+        } = opts;
+
+        libbpf_sys::libbpf_prog_handler_opts {
+            sz: std::mem::size_of::<Self>() as u64,
+            cookie,
+            prog_setup_fn: setup_fn,
+            prog_prepare_load_fn: prepare_load_fn,
+            prog_attach_fn: attach_fn,
+        }
+    }
+}
+
+pub(crate) fn register_prog_handler(
+    sec: Option<String>,
+    prog_type: libbpf_rs::ProgramType,
+    exp_attach_type: libbpf_rs::ProgramAttachType,
+    opts: ProgHandlerOpts,
+) -> std::io::Result<u32> {
+    let opts = libbpf_sys::libbpf_prog_handler_opts::from(opts);
+    let ret;
+
+    match sec {
+        Some(s) => {
+            let c_str = std::ffi::CString::new(s)?;
+            ret = unsafe {
+                libbpf_sys::libbpf_register_prog_handler(
+                    c_str.as_ptr(),
+                    prog_type as u32,
+                    exp_attach_type as u32,
+                    &opts as *const _,
+                )
+            };
+        }
+        None => {
+            ret = unsafe {
+                libbpf_sys::libbpf_register_prog_handler(
+                    core::ptr::null(),
+                    prog_type as u32,
+                    exp_attach_type as u32,
+                    &opts as *const _,
+                )
+            };
+        }
+    }
+
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    Ok(0)
+}


### PR DESCRIPTION
The current strategy, to avoid other observed failures (like during hooks dynamic relinking) is to reserve space in the code (adding nops) and replace them before the actual load happens.
This has the benefit that jump offsets don't need to be fixed up.
This restriction could theoretically be lifted once hooks get inlined as well for fully supporting older kernels (namely rhel 8.4).

Some details probably need some more attention (nothing major) but I prefer to send this early to collect potential feedback (placement, workaround reintroduction, etc) and possibly validate the functioning.