### PR TITLE
mailmap: add one more entry for Adrián

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,3 +1,4 @@
+Adrian Moreno <amorenoz@redhat.com>
 Adrian Moreno <amorenoz@redhat.com> <52785490+amorenoz@users.noreply.github.com>
 Antoine Tenart <atenart@redhat.com> <atenart@users.noreply.github.com>
 Paolo Valerio <pvalerio@redhat.com>


### PR DESCRIPTION
The current one was covering the GH generated email, but an additional one is needed to cover the different writings of the @redhat.com ones.

I chose the current way of writing your name (w/o the accent), but of course it's your choice and we can use the real one :)