### PR TITLE
cli: fix error messages on --help and --version

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -272,7 +272,7 @@ impl ThinCli {
         let matches = command
             .clone()
             .ignore_errors(true)
-            .try_get_matches_from(args.iter())?;
+            .get_matches_from(args.iter());
 
         let ran_subcommand = matches.subcommand_name();
 


### PR DESCRIPTION
Fixes #221. 

As far as I can tell the issue should apply to all versions of Retis, not just those build on copr. The issue is that try_get_matches_from() returns an error for --help and --version arguments which bubbles up through the ?, leading main() to exit early.

The version and help information currently being shown is actually the formatted error message of either ErrorKind::DisplayHelp or ErrorKind::DisplayVersion being printed by the rust runtime upon main() exiting.

All the other command processing behavior should be preserved because ignore_errors() made it so that only help and version options were being caught by try_get_matches_from() anyway.