### PR TITLE
skb tracking improvements / fixes

### DIFF
--- a/profiles/generic.yaml
+++ b/profiles/generic.yaml
@@ -25,7 +25,7 @@ collect:
         - kprobe:icmp_rcv
         - kprobe:icmpv6_rcv
         - tp:net:net_dev_queue
-        - tp:net:net_dev_xmit
+        - tp:net:net_dev_start_xmit
         - kprobe:ip_output
         - kprobe:ip6_output
         - kprobe:skb_scrub_packet

--- a/src/core/tracking/skb_tracking.rs
+++ b/src/core/tracking/skb_tracking.rs
@@ -198,7 +198,7 @@ pub(crate) fn init_tracking(
     p.set_option(ProbeOption::NoGenericHook)?;
     probes.register_probe(p)?;
 
-    // Special case for skb_release_head_state, which can be tracked as it is
+    // Special case for skb_release_head_state, which can't be tracked as it is
     // being called by kfree_skb_partial where we have a hook removing the
     // tracking id.
     let symbol = Symbol::from_name("skb_release_head_state")?;


### PR DESCRIPTION
Properly taking care of the `net:net_dev_xmit` tracepoint, which can access already freed skbs.

Before this PR, tracking entries were being removed by the tracking gc when using a probe on `net:net_dev_xmit`, like the `generic` profile does.