### PR TITLE
pcap-ng support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +405,17 @@ checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -957,6 +977,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1156,7 @@ dependencies = [
  "once_cell",
  "path-clean",
  "pcap",
+ "pcap-file",
  "plain",
  "probe",
  "rbpf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ nix = { version = "0.27", features = ["feature", "time", "user"] }
 once_cell = "1.15"
 path-clean = "1.0"
 pcap = "1.0"
+pcap-file = "2.0"
 plain = "0.2"
 rbpf = {version = "0.2", optional = true}
 regex = "1.7"

--- a/profiles/pcap.yaml
+++ b/profiles/pcap.yaml
@@ -1,0 +1,7 @@
+version: 1.0
+name: pcap
+about: Minimum set of options to properly collect data for later PCAP generation
+collect:
+  - args:
+      collectors: skb
+      skb_sections: packet,dev,ns

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -20,8 +20,7 @@ use crate::benchmark::cli::Benchmark;
 use crate::{
     collect::cli::Collect,
     module::{ModuleId, Modules},
-    process::cli::Print,
-    process::cli::Sort,
+    process::cli::*,
     profiles::{cli::ProfileCmd, Profile},
     VERSION_NAME,
 };
@@ -432,6 +431,7 @@ pub(crate) fn get_cli() -> Result<ThinCli> {
     cli.add_subcommand(Box::new(Print::new()?))?;
     cli.add_subcommand(Box::new(Sort::new()?))?;
     cli.add_subcommand(Box::new(ProfileCmd::new()?))?;
+    cli.add_subcommand(Box::new(Pcap::new()?))?;
 
     #[cfg(feature = "benchmark")]
     cli.add_subcommand(Box::new(Benchmark::new()?))?;

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -124,7 +124,7 @@ static __always_inline int process_skb_arp(struct retis_raw_event *event,
 					   struct skb_config *cfg,
 					   struct sk_buff *skb,
 					   unsigned char *head,
-					   u16 etype, u16 mac, u16 network)
+					   u16 mac, u16 network)
 {
 	struct skb_arp_event *e;
 	struct arphdr *arp;
@@ -182,7 +182,7 @@ static __always_inline int process_skb_ip(struct retis_raw_event *event,
 					  struct skb_config *cfg,
 					  struct sk_buff *skb,
 					  unsigned char *head,
-					  u16 etype, u16 mac, u16 network)
+					  u16 mac, u16 network)
 {
 	u8 protocol, ip_version;
 	u16 transport;
@@ -362,10 +362,10 @@ static __always_inline int process_skb_l2(struct retis_raw_event *event,
 
 	/* IPv4/IPv6 and upper layers */
 	if (etype == bpf_ntohs(ETH_P_IP) || etype == bpf_ntohs(ETH_P_IPV6))
-		return process_skb_ip(event, cfg, skb, head, etype, mac, network);
+		return process_skb_ip(event, cfg, skb, head, mac, network);
 	/* ARP */
 	else if (etype == bpf_ntohs(ETH_P_ARP))
-		return process_skb_arp(event, cfg, skb, head, etype, mac, network);
+		return process_skb_arp(event, cfg, skb, head, mac, network);
 
 	/* Unsupported etype */
 	return 0;

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -5,6 +5,7 @@
 #include <common.h>
 
 #define BIT(x) (1 << (x))
+#define min(a, b) ((a) < (b) ? (a) : (b))
 
 #define ETH_P_IP	0x0800
 #define ETH_P_ARP	0x0806
@@ -25,6 +26,7 @@
 #define COLLECT_NS		8
 #define COLLECT_META		9
 #define COLLECT_DATA_REF	10
+#define COLLECT_PACKET		11
 
 /* Skb hook configuration. A map is used to set the config from userspace.
  *
@@ -117,6 +119,15 @@ struct skb_data_ref_event {
 	u8 fclone;
 	u8 users;
 	u8 dataref;
+} __attribute__((packed));
+/* Please keep the following structs in sync with its Rust counterpart in
+ * module::skb::event.
+ */
+struct skb_packet_event {
+	u32 len;
+	u32 capture_len;
+#define PACKET_CAPTURE_SIZE	256
+	u8 packet[PACKET_CAPTURE_SIZE];
 } __attribute__((packed));
 
 /* Must be called with a valid skb pointer */
@@ -371,6 +382,85 @@ static __always_inline int process_skb_l2(struct retis_raw_event *event,
 	return 0;
 }
 
+static __always_inline int process_packet(struct retis_raw_event *event,
+					  struct sk_buff *skb)
+{
+	unsigned char *head, *data;
+	struct skb_packet_event *e;
+	int size, data_offset;
+	u32 len, linear_len;
+	u16 mac, network;
+
+	data = BPF_CORE_READ(skb, data);
+	head = BPF_CORE_READ(skb, head);
+
+	data_offset = data - head;
+	if (data_offset < 0) /* Keep the verifier happy */
+		return 0;
+
+	mac = BPF_CORE_READ(skb, mac_header);
+	network = BPF_CORE_READ(skb, network_header);
+	len = BPF_CORE_READ(skb, len);
+	linear_len = len - BPF_CORE_READ(skb, data_len); /* Linear buffer size */
+
+	/* Best case: mac offset is set and valid */
+	if (mac != (u16)~0U && (!network || (network && mac != network))) {
+		int mac_offset;
+
+		mac_offset = mac - data_offset;
+		size = min(linear_len - mac_offset, PACKET_CAPTURE_SIZE);
+		if (size <= 0)
+			return 0;
+
+		e = get_event_section(event, COLLECTOR_SKB, COLLECT_PACKET,
+				      sizeof(*e));
+		if (!e)
+			return 0;
+
+		e->len = len - mac_offset;
+		bpf_probe_read_kernel(e->packet, size, head + mac);
+	/* Valid network offset with an unset or invalid mac offset: we can fake
+	 * the eth header.
+	 */
+	} else if (network && network != (u16)~0U) {
+		u16 etype = BPF_CORE_READ(skb, protocol);
+		struct ethhdr *eth;
+		int network_offset;
+
+		/* We do need the ethertype to be set at the skb level here,
+		 * otherwise we can't guess what kind of packet this is.
+		 */
+		if (!etype)
+			return 0;
+
+		network_offset = network - data_offset;
+		size = min(linear_len - network_offset, PACKET_CAPTURE_SIZE);
+		size -= sizeof(struct ethhdr);
+		if (size <= 0)
+			return 0;
+
+		e = get_event_section(event, COLLECTOR_SKB, COLLECT_PACKET,
+				      sizeof(*e));
+		if (!e)
+			return 0;
+
+		/* Fake eth header */
+		eth = (struct ethhdr *)e->packet;
+		__builtin_memset(eth, 0, sizeof(*eth));
+		eth->h_proto = etype;
+
+		e->len = len - network_offset + sizeof(*eth);
+		bpf_probe_read_kernel(e->packet + sizeof(*eth), size,
+				      head + network);
+	/* Can't guess any useful packet offset */
+	} else {
+		return 0;
+	}
+
+	e->capture_len = size;
+	return 0;
+}
+
 /* Must be called with a valid skb pointer */
 static __always_inline int process_skb(struct retis_raw_event *event,
 				       struct sk_buff *skb)
@@ -387,6 +477,9 @@ static __always_inline int process_skb(struct retis_raw_event *event,
 
 	dev = BPF_CORE_READ(skb, dev);
 	head = BPF_CORE_READ(skb, head);
+
+	if (cfg->sections & BIT(COLLECT_PACKET))
+		process_packet(event, skb);
 
 	if (cfg->sections & BIT(COLLECT_DEV) && dev) {
 		int ifindex = BPF_CORE_READ(dev, ifindex);

--- a/src/module/skb/event.rs
+++ b/src/module/skb/event.rs
@@ -34,6 +34,8 @@ pub(crate) struct SkbEvent {
     pub(crate) meta: Option<SkbMetaEvent>,
     /// Skb data-related and refcnt information, if any.
     pub(crate) data_ref: Option<SkbDataRefEvent>,
+    /// Raw packet and related metadata.
+    pub(crate) packet: Option<SkbPacketEvent>,
 }
 
 impl EventFmt for SkbEvent {
@@ -419,6 +421,17 @@ pub(crate) struct SkbDataRefEvent {
     pub(crate) dataref: u8,
 }
 
+/// Raw packet and related metadata extracted from skbs.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub(crate) struct SkbPacketEvent {
+    /// Length of the packet.
+    pub(crate) len: u32,
+    /// Lenght of the capture. <= len.
+    pub(crate) capture_len: u32,
+    /// Raw packet data.
+    pub(crate) packet: Vec<u8>,
+}
+
 #[derive(Default)]
 #[event_section_factory(SkbEvent)]
 pub(crate) struct SkbEventFactory {}
@@ -440,6 +453,7 @@ impl RawEventSectionFactory for SkbEventFactory {
                 SECTION_NS => event.ns = Some(unmarshal_ns(section)?),
                 SECTION_META => event.meta = Some(unmarshal_meta(section)?),
                 SECTION_DATA_REF => event.data_ref = Some(unmarshal_data_ref(section)?),
+                SECTION_PACKET => event.packet = Some(unmarshal_packet(section)?),
                 _ => bail!("Unknown data type"),
             }
         }

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -21,7 +21,7 @@ use crate::{
 pub(crate) struct SkbCollectorArgs {
     #[arg(
         long,
-        value_parser=PossibleValuesParser::new(["all", "eth", "arp", "ip", "tcp", "udp", "icmp", "dev", "ns", "meta", "dataref"]),
+        value_parser=PossibleValuesParser::new(["all", "eth", "arp", "ip", "tcp", "udp", "icmp", "dev", "ns", "meta", "dataref", "packet"]),
         value_delimiter=',',
         default_value="ip,arp,tcp,udp,icmp,dev",
         help = "Comma separated list of data to collect from skbs"
@@ -56,7 +56,8 @@ impl Collector for SkbModule {
         let mut sections: u64 = 0;
         for category in args.skb_sections.iter() {
             match category.as_str() {
-                "all" => sections |= !0_u64,
+                // Do not include the raw packet in 'all'.
+                "all" => sections |= !(1_u64 << SECTION_PACKET),
                 "eth" => sections |= 1 << SECTION_ETH,
                 "arp" => sections |= 1 << SECTION_ARP,
                 "ip" => sections |= 1 << SECTION_IPV4 | 1 << SECTION_IPV6,
@@ -67,6 +68,7 @@ impl Collector for SkbModule {
                 "ns" => sections |= 1 << SECTION_NS,
                 "meta" => sections |= 1 << SECTION_META,
                 "dataref" => sections |= 1 << SECTION_DATA_REF,
+                "packet" => sections |= 1 << SECTION_PACKET,
                 x => bail!("Unknown skb_collect value ({})", x),
             }
         }

--- a/src/process/cli/mod.rs
+++ b/src/process/cli/mod.rs
@@ -2,6 +2,9 @@
 //!
 //! Provides cli commands to perform some post-processing.
 
+pub(crate) mod pcap;
+pub(crate) use self::pcap::*;
+
 pub(crate) mod print;
 pub(crate) use print::*;
 

--- a/src/process/cli/pcap.rs
+++ b/src/process/cli/pcap.rs
@@ -1,0 +1,324 @@
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fs::OpenOptions,
+    io::Write,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use anyhow::{anyhow, bail, Result};
+use clap::{arg, Parser};
+use log::{info, warn};
+use pcap_file::{
+    pcapng::{
+        blocks::{
+            enhanced_packet::{EnhancedPacketBlock, EnhancedPacketOption},
+            interface_description::{InterfaceDescriptionBlock, InterfaceDescriptionOption},
+        },
+        PcapNgBlock, PcapNgWriter,
+    },
+    DataLink,
+};
+
+use crate::{
+    cli::*,
+    core::{
+        events::{bpf::CommonEvent, file::FileEventsFactory, *},
+        kernel::Symbol,
+        probe::kernel::KernelEvent,
+        signals::Running,
+    },
+    module::{skb::SkbEvent, ModuleId, Modules},
+};
+
+/// Statistics of the event parser about events (processed, skipped, etc).
+#[derive(Default)]
+struct EventParserStats {
+    /// Events that were processed by the parser. Aka. all events that were
+    /// matched by the filter.
+    processed: u32,
+    /// Events w/o an skb section (skipped).
+    missing_skb: u32,
+    /// Events w/o a packet section (skipped).
+    missing_packet: u32,
+    /// Events w/o a dev section (fake one was used instead).
+    missing_dev: u32,
+    /// Events w/o a netns section (fake one was used instead).
+    missing_ns: u32,
+}
+
+/// Events parser: handles the logic to convert our events to the PCAP format
+/// that is represented by the internal writer.
+struct EventParser<'a, W: Write> {
+    writer: &'a mut PcapNgWriter<W>,
+    /// Known network interfaces and their PCAP id: netns|ifindex -> pcap id.
+    ifaces: HashMap<u64, u32>,
+    /// Statistics.
+    stats: EventParserStats,
+}
+
+// Unwrap a Some(_) value or return from the function.
+macro_rules! some_or_return {
+    ($section: expr, $stat: expr) => {
+        match $section {
+            Some(val) => val,
+            None => {
+                $stat += 1;
+                return Ok(());
+            }
+        }
+    };
+}
+
+impl<'a, W: Write> EventParser<'a, W> {
+    /// Creates a new EventParser from a PcapNgWriter<W: Write>.
+    fn from(writer: &'a mut PcapNgWriter<W>) -> Self {
+        Self {
+            writer,
+            ifaces: HashMap::new(),
+            stats: EventParserStats::default(),
+        }
+    }
+
+    /// Parse & process a single Retis event.
+    fn parse(&mut self, event: &Event) -> Result<()> {
+        // Having a common & a kernel section is mandatory for now, seeing a
+        // filtered event w/o one of those is bogus.
+        let common = event
+            .get_section::<CommonEvent>(ModuleId::Common)
+            .ok_or_else(|| anyhow!("No common section in event"))?;
+        let kernel = event
+            .get_section::<KernelEvent>(ModuleId::Kernel)
+            .ok_or_else(|| anyhow!("No skb section in event"))?;
+
+        self.stats.processed += 1;
+
+        // The skb & packet sections are mandatory for us to generate PCAP
+        // events, but they might not be present in some filtered events. Stats
+        // are kept here to inform the user.
+        let skb = some_or_return!(
+            event.get_section::<SkbEvent>(ModuleId::Skb),
+            self.stats.missing_skb
+        );
+        let packet = some_or_return!(skb.packet.as_ref(), self.stats.missing_packet);
+
+        // The dev & ns sections are best to have but not mandatory to generate
+        // an event. If not found, fake them.
+        let (ifindex, ifname) = match skb.dev.as_ref() {
+            Some(dev) => (dev.ifindex, dev.name.as_str()),
+            None => {
+                self.stats.missing_dev += 1;
+                (0, "?")
+            }
+        };
+        let netns = match skb.ns.as_ref() {
+            Some(ns) => ns.netns,
+            None => {
+                self.stats.missing_ns += 1;
+                0
+            }
+        };
+
+        // If we see this iface for the first time, add a description block.
+        let key: u64 = (netns as u64) << 32 | ifindex as u64;
+        let id = match self.ifaces.contains_key(&key) {
+            // Unwrap if contains is true.
+            true => *self.ifaces.get(&key).unwrap(),
+            false => {
+                self.writer.write_block(
+                    &InterfaceDescriptionBlock {
+                        linktype: DataLink::ETHERNET,
+                        snaplen: 0xffff,
+                        options: vec![
+                            InterfaceDescriptionOption::IfName(Cow::Owned(format!(
+                                "{} ({})",
+                                ifname, netns
+                            ))),
+                            InterfaceDescriptionOption::IfDescription(Cow::Owned(match ifindex {
+                                0 => "Fake interface".to_string(),
+                                _ => format!("ifindex={}", ifindex),
+                            })),
+                        ],
+                    }
+                    .into_block(),
+                )?;
+
+                let id = self.ifaces.len() as u32;
+                self.ifaces.insert(key, id);
+                id
+            }
+        };
+
+        // Add the packet itself.
+        self.writer.write_block(
+            &EnhancedPacketBlock {
+                interface_id: id,
+                timestamp: Duration::from_nanos(common.timestamp),
+                original_len: packet.len,
+                data: Cow::Borrowed(&packet.packet),
+                options: vec![EnhancedPacketOption::Comment(Cow::Owned(format!(
+                    "probe={}:{}",
+                    &kernel.probe_type, &kernel.symbol
+                )))],
+            }
+            .into_block(),
+        )?;
+
+        Ok(())
+    }
+
+    /// Report parser statistics. Should be called after processing was
+    /// completed.
+    fn report_stats(&self) {
+        info!("{} event(s) were processed", self.stats.processed);
+
+        if self.stats.missing_skb != 0 {
+            warn!(
+                "{} event(s) were skipped because of missing skb information",
+                self.stats.missing_skb
+            );
+        }
+        if self.stats.missing_packet != 0 {
+            warn!(
+                "{} event(s) were skipped because of missing raw packet",
+                self.stats.missing_packet
+            );
+        }
+        if self.stats.missing_dev != 0 {
+            warn!(
+                "{} event(s) are using a fake net device (no device information was found)",
+                self.stats.missing_dev
+            );
+        }
+        if self.stats.missing_ns != 0 {
+            warn!(
+                "{} event(s) are using a fake netns (no netns information was found)",
+                self.stats.missing_ns
+            );
+        }
+    }
+}
+
+/// Generate a PCAP file from a collection of recorded events.
+#[derive(Parser, Debug, Default)]
+#[command(name = "pcap")]
+pub(crate) struct Pcap {
+    #[arg(
+        short,
+        long,
+        help = "Filter events from this probe. Probes should follow the TYPE:TARGET pattern. See `retis collect --help` for more details on the probe format."
+    )]
+    pub(super) probe: String,
+    #[arg(
+        short,
+        long,
+        help = "Write the generated PCAP output to a file rather than stdio"
+    )]
+    pub(super) out: Option<PathBuf>,
+    #[arg(help = "File from which to read events")]
+    pub(super) input: PathBuf,
+}
+
+impl SubCommandParserRunner for Pcap {
+    fn run(&mut self, modules: Modules) -> Result<()> {
+        let (probe_type, target) = match self.probe.split_once(':') {
+            Some((r#type, target)) => (r#type, target),
+            None => {
+                info!(
+                    "Invalid probe format, no TYPE given in '{}', using 'kprobe:{}'. See the help.",
+                    self.probe, self.probe
+                );
+                ("kprobe", self.probe.as_str())
+            }
+        };
+        let symbol = Symbol::from_name_no_inspect(target);
+
+        // Convert the user-given probe type to the event ones, so both are
+        // supported. This helps users to either use the collect format or what
+        // is reported in the event itself.
+        //
+        // E.g. --probe tp:skb:kfree_skb == --probe raw_tracepoint:skb:kfree_skb
+        let probe_type = match probe_type {
+            "tp" => "raw_tracepoint",
+            x => x,
+        };
+
+        // Create a PCAP writer to push our events / metadata.
+        let mut writer = PcapNgWriter::new(match &self.out {
+            Some(file) => OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(file)
+                .or_else(|_| bail!("Could not create or open '{}'", file.display()))?,
+            None => OpenOptions::new()
+                .write(true)
+                .open("/proc/self/fd/1")
+                .or_else(|_| bail!("Could not open stdout"))?,
+        })?;
+
+        // Filtering logic.
+        let filter = |r#type: &str, name: &str| -> bool {
+            if name == symbol.name() && r#type == probe_type {
+                return true;
+            }
+            false
+        };
+
+        handle_events(
+            self.input.as_path(),
+            modules.section_factories()?,
+            &filter,
+            &mut EventParser::from(&mut writer),
+        )
+    }
+}
+
+/// Internal logic to retrieve our events to feed the parser.
+fn handle_events<W>(
+    input: &Path,
+    factories: SectionFactories,
+    filter: &dyn Fn(&str, &str) -> bool,
+    parser: &mut EventParser<W>,
+) -> Result<()>
+where
+    W: Write,
+{
+    // Create running instance that will handle signal termination.
+    let mut run = Running::new();
+    run.register_term_signals()?;
+
+    // Start our events factory.
+    let mut factory = FileEventsFactory::new(input)?;
+    factory.start(factories)?;
+
+    // See if we matched (not processed!) at least one event.
+    let mut matched = false;
+
+    use EventResult::*;
+    while run.running() {
+        match factory.next_event(Some(Duration::from_secs(1)))? {
+            Event(event) => {
+                if let Some(kernel) = event.get_section::<KernelEvent>(ModuleId::Kernel) {
+                    // Check the event is matching the requested symbol.
+                    if !filter(&kernel.probe_type, &kernel.symbol) {
+                        continue;
+                    }
+                    matched = true;
+
+                    parser.parse(&event)?;
+                }
+            }
+            Eof => break,
+            Timeout => continue,
+        }
+    }
+
+    if !matched {
+        bail!("Probe not found in the events");
+    }
+
+    parser.report_stats();
+    Ok(())
+}

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # Run the Retis container.
-$runtime run $extra_args -e TERM --privileged --rm --pid=host \
+exec $runtime run $extra_args -e TERM --privileged --rm --pid=host \
       --cap-add SYS_ADMIN --cap-add BPF --cap-add SYSLOG \
       -v /sys/kernel/btf:/sys/kernel/btf:ro \
       -v /sys/kernel/debug:/sys/kernel/debug:ro \

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # Run the Retis container.
-$runtime run $extra_args --privileged --rm -it --pid=host \
+$runtime run $extra_args -e TERM --privileged --rm --pid=host \
       --cap-add SYS_ADMIN --cap-add BPF --cap-add SYSLOG \
       -v /sys/kernel/btf:/sys/kernel/btf:ro \
       -v /sys/kernel/debug:/sys/kernel/debug:ro \


### PR DESCRIPTION
Fixes #224. Marking as RFC to get avoid merging it while waiting for feedback; but code is in a good shape.

Two majors changes:

1. The `skb` module gained support for reporting raw packets from the BPF probes. This is disabled by default and enabled by using the `--skb-sections packet` option (note the recommendation and what is used in the new `pcap` profile is `packet,dev,ns`).
2. A post-processing command was added, `pcap`, to generate a `pcap-ng` formatted output (stdout or a file) from a *single* probe. This probe is selected at post-processing time (a single set of collected events can be used to generate different pcap outputs).

The pcap-ng output includes a definition of net devices seen in the events, including a name of the form `<name> (<netns>)` and a description of the form `ifindex=<i>`. A fake interface and/or netns is used if the event did not contained one (as the interface definition is mandatory in pcap-ng).

The pcap-ng packets include a comment of the form `probe=<probe def>`.

This works as follow:

```
$ retis -p pcap,generic collect -o retis.data --cmd 'dig google.com @8.8.8.8'

$ retis pcap --probe tp:net:netif_receive_skb -o retis.pcap retis.data
15:13:42 [INFO] 1 event(s) were processed
$ wireshark retis.pcap
...
$ tcpdump -nnr retis.pcap
reading from file retis.pcap, link-type EN10MB (Ethernet), snapshot length 65535
18:40:40.598012 IP 8.8.8.8.53 > 192.168.0.42.12345: 59700 1/0/1 A 216.58.214.78 (55)

$ retis pcap --probe kprobe:udp_rcv retis.data | tcpdump -nnr -
15:14:10 [INFO] 1 event(s) were processed
reading from file -, link-type EN10MB (Ethernet), snapshot length 65535
18:40:40.610832 IP 8.8.8.8.53 > 192.168.0.42.12345: 59700 1/0/1 A 216.58.214.78 (55)
$ retis pcap --probe tp:net:net_dev_start_xmit retis.data | tcpdump -nnr -
15:14:10 [INFO] 1 event(s) were processed
reading from file -, link-type EN10MB (Ethernet), snapshot length 65535
18:40:26.575099 IP 192.168.0.42.12345 > 8.8.8.8.53: 59700+ [1au] A? google.com. (51)
```

Currently at max 256 bytes are reported from the BPF probes. The exact value should be better defined, but the idea is to report headers from the packets, not necessarily their content. We could as a follow-up look into user-defined capture length.

All comments are welcomed, including non-code reviews.