### PR TITLE
Revert "Default the event file to retis.data"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target
 .out
 __pycache__/
-retis.data

--- a/src/collect/cli.rs
+++ b/src/collect/cli.rs
@@ -51,15 +51,7 @@ Valid TYPEs:
 Example: --probe tp:skb:kfree_skb --probe kprobe:consume_skb"
     )]
     pub(super) probes: Vec<String>,
-    #[arg(
-        short,
-        long,
-        num_args = 0..=1,
-        require_equals = true,
-        default_missing_value = "retis.data",
-        help = "Write the events to a file rather than to sdout. If the flag is used without a file name,
-defaults to \"retis.data\"."
-    )]
+    #[arg(short, long, help = "Write the events to a file rather than to sdout.")]
     pub(super) out: Option<PathBuf>,
     #[arg(
         long,

--- a/src/core/events/file.rs
+++ b/src/core/events/file.rs
@@ -22,15 +22,13 @@ pub(crate) struct FileEventsFactory {
 }
 
 impl FileEventsFactory {
-    pub(crate) fn new<P>(file: P) -> Result<Self>
+    #[allow(dead_code)] // FIXME
+    pub(crate) fn new<P>(filename: P) -> Result<Self>
     where
         P: AsRef<Path>,
     {
         Ok(FileEventsFactory {
-            reader: BufReader::new(
-                File::open(&file)
-                    .map_err(|e| anyhow!("Could not open {}: {e}", file.as_ref().display()))?,
-            ),
+            reader: BufReader::new(File::open(filename)?),
             factories: HashMap::new(),
         })
     }

--- a/src/process/cli/print.rs
+++ b/src/process/cli/print.rs
@@ -23,7 +23,7 @@ use crate::{
 #[command(name = "print")]
 pub(crate) struct Print {
     /// File from which to read events.
-    #[arg(default_value = "retis.data")]
+    #[arg()]
     pub(super) input: PathBuf,
     #[arg(long, help = "Format used when printing an event.")]
     #[clap(value_enum, default_value_t=DisplayFormat::MultiLine)]

--- a/src/process/cli/sort.rs
+++ b/src/process/cli/sort.rs
@@ -35,7 +35,7 @@ const DEFAULT_BUFFER: usize = 1000;
 #[command(name = "sort")]
 pub(crate) struct Sort {
     /// File from which to read events.
-    #[arg(default_value = "retis.data")]
+    #[arg()]
     pub(super) input: PathBuf,
 
     /// Maximum number of events to buffer


### PR DESCRIPTION
Reverts retis-org/retis#266

This introduced a requirement for the `--out` parameter to use `=` when setting a value, which we find not practical. The other commits are OK but for now let's revert all those patches and spend some time to think about what could be done and do better tests.