### PR TITLE
tree: add skb offset validation helpers

### DIFF
--- a/src/core/probe/kernel/bpf/include/helpers.h
+++ b/src/core/probe/kernel/bpf/include/helpers.h
@@ -32,4 +32,69 @@ static __always_inline u64 kprobe_get_func_ip(struct pt_regs *ctx) {
 		return PT_REGS_IP(ctx) - 1;
 }
 
+/* The following helpers validate skb offsets (mac, network & transport) as they
+ * can be unset or invalid.
+ *
+ * The logic is the following:
+ * - Most offsets can be invalidated using the special value ~0U.
+ * - Some offsets can be initialized to 0, the value being invalid.
+ * - All offsets can be reset using `skb->data - skb->head` (aka. headroom),
+ *   which can be valid and a proper way to set the offset.
+ *
+ * `is_<offset>_valid` helpers check the offset value is valid but does not
+ * check if the data pointed by that offset is. `is_<offset>_data_valid` do
+ * check both.
+ */
+
+#define IS_UNSET(x)		((x) == (typeof(x))~0U)
+#define IS_RESET(x, headroom)	((x) == (headroom))
+
+static __always_inline bool is_mac_valid(u16 mac)
+{
+	/* Only check the mac offset was set, as it's the first of the offsets
+	 * and could be equal to 0.
+	 */
+	return !IS_UNSET(mac);
+}
+static __always_inline bool is_network_valid(u16 network)
+{
+	return network && !IS_UNSET(network);
+}
+#define is_transport_valid is_network_valid
+
+static __always_inline bool is_mac_data_valid(struct sk_buff *skb)
+{
+	u16 mac, network;
+
+	mac = BPF_CORE_READ(skb, mac_header);
+	network = BPF_CORE_READ(skb, network_header);
+
+	return is_mac_valid(mac) &&
+	       !(is_network_valid(network) && network == mac &&
+		 BPF_CORE_READ(skb, mac_len) == 0);
+}
+
+static __always_inline bool is_network_data_valid(struct sk_buff *skb)
+{
+	u16 mac, network;
+
+	mac = BPF_CORE_READ(skb, mac_header);
+	network = BPF_CORE_READ(skb, network_header);
+
+	return is_network_valid(network) &&
+	       !(is_mac_valid(mac) && mac == network &&
+		 BPF_CORE_READ(skb, mac_len) != 0);
+}
+
+static __always_inline bool is_transport_data_valid(struct sk_buff *skb)
+{
+	u16 network, transport;
+
+	network = BPF_CORE_READ(skb, network_header);
+	transport = BPF_CORE_READ(skb, transport_header);
+
+	return is_transport_valid(transport) &&
+	       !(is_network_valid(network) && network == transport);
+}
+
 #endif /* __CORE_PROBE_KERNEL_BPF_HELPERS__ */

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -384,18 +384,14 @@ static __always_inline int process_skb_l2(struct retis_raw_event *event,
 static __always_inline int process_packet(struct retis_raw_event *event,
 					  struct sk_buff *skb)
 {
+	u32 len, linear_len, headroom;
 	unsigned char *head, *data;
 	struct skb_packet_event *e;
-	u32 len, linear_len;
-	int size, headroom;
 	u16 mac, network;
+	int size;
 
-	data = BPF_CORE_READ(skb, data);
 	head = BPF_CORE_READ(skb, head);
-
-	headroom = data - head;
-	if (headroom < 0) /* Keep the verifier happy */
-		return 0;
+	headroom = BPF_CORE_READ(skb, data) - head;
 
 	mac = BPF_CORE_READ(skb, mac_header);
 	network = BPF_CORE_READ(skb, network_header);


### PR DESCRIPTION
Validating offsets in an skb is no easy task. Add helpers to make checks more consistent in our probes and do the best we can do to guess if offsets are valid or not.

Note that this cannot be 100% failsafe. When converting Retis to parse packets in the Rust side we'll be able to improve further offset detection by using the BPF side as a hint only.