### PR TITLE
Allow pcap sub-command in profiles

### DIFF
--- a/profiles/drop.yaml
+++ b/profiles/drop.yaml
@@ -5,6 +5,9 @@ collect:
   - args:
       collectors: skb-drop,skb
       stack: ~
+pcap:
+  - args:
+      probe: tp:skb:kfree_skb
 ---
 version: 1.0
 name: nft-dropmon
@@ -14,3 +17,6 @@ collect:
       collectors: nft,skb
       nft_verdicts: drop
       stack: ~
+pcap:
+  - args:
+      probe: kprobe:__nft_trace_packet

--- a/src/profiles/profiles.rs
+++ b/src/profiles/profiles.rs
@@ -52,7 +52,7 @@ impl SymbolCondition {
     }
 }
 
-/// Specifies a condition that must be met for a CollectProfile to be applied.
+/// Specifies a condition that must be met for a SubcommandProfile to be applied.
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type")]
 pub(crate) enum ProfileCondition {
@@ -82,7 +82,7 @@ pub(crate) enum ArgValue {
 /// Collect profile.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "snake_case")]
-pub(crate) struct CollectProfile {
+pub(crate) struct SubcommandProfile {
     /// Name of this collect profile
     #[serde(default = "default_name")]
     pub(crate) name: String,
@@ -93,7 +93,7 @@ pub(crate) struct CollectProfile {
     pub(crate) args: BTreeMap<String, ArgValue>,
 }
 
-impl CollectProfile {
+impl SubcommandProfile {
     fn matches(&self) -> Result<bool> {
         if self.when.is_empty() {
             return Ok(true);
@@ -124,7 +124,7 @@ pub(crate) struct Profile {
     pub(crate) about: Option<String>,
     /// Collect Profiles
     #[serde(default = "Vec::new")]
-    pub(crate) collect: Vec<CollectProfile>,
+    pub(crate) collect: Vec<SubcommandProfile>,
 }
 
 impl Profile {
@@ -205,7 +205,7 @@ impl Profile {
     }
 
     /// Evaluate collect profiles and return the one that matches.
-    pub fn match_collect(&self) -> Result<Option<&CollectProfile>> {
+    pub fn match_collect(&self) -> Result<Option<&SubcommandProfile>> {
         if self.collect.is_empty() {
             return Ok(None);
         }

--- a/src/profiles/profiles.rs
+++ b/src/profiles/profiles.rs
@@ -55,18 +55,18 @@ impl SymbolCondition {
 /// Specifies a condition that must be met for a CollectProfile to be applied.
 #[derive(Deserialize, Debug)]
 #[serde(tag = "type")]
-pub(crate) enum CollectCondition {
+pub(crate) enum ProfileCondition {
     #[serde(rename = "version")]
     Version(VersionCondition),
     #[serde(rename = "symbol")]
     Symbol(SymbolCondition),
 }
 
-impl CollectCondition {
+impl ProfileCondition {
     fn matches(&self) -> Result<bool> {
         match self {
-            CollectCondition::Version(v) => v.matches(),
-            CollectCondition::Symbol(s) => s.matches(),
+            ProfileCondition::Version(v) => v.matches(),
+            ProfileCondition::Symbol(s) => s.matches(),
         }
     }
 }
@@ -88,7 +88,7 @@ pub(crate) struct CollectProfile {
     pub(crate) name: String,
     /// Set of conditions associated with the profile
     #[serde(default = "Vec::default")]
-    pub(crate) when: Vec<CollectCondition>,
+    pub(crate) when: Vec<ProfileCondition>,
     /// Arguments to be appended to the CLI if this profile is active
     pub(crate) args: BTreeMap<String, ArgValue>,
 }
@@ -298,7 +298,7 @@ mod tests {
                 .pop()
                 .unwrap()
             {
-                CollectCondition::Version(v) => return v,
+                ProfileCondition::Version(v) => return v,
                 _ => panic!("Wrong condition type"),
             }
         }


### PR DESCRIPTION
Allows to do things like:

```
$ retis -p dropmon,pcap collect -o retis.data
or
$ retis -p generic,pcap collect -o retis.data
```

And then,
```
$ retis -p dropmon pcap retis.data | tcpdump -nnr -
```