### PR TITLE
Allow all (user defined) probe types to be defnied using wildcard

### DIFF
--- a/src/collect/cli.rs
+++ b/src/collect/cli.rs
@@ -44,9 +44,11 @@ not released. If exhausted, no stack trace will be included."
 follow the [TYPE:]TARGET pattern. When TYPE is not set 'kprobe' is used.
 
 Valid TYPEs:
-- kprobe: kernel probes. Wildcards (*) can be used, eg. \"tcp_*\".
+- kprobe: kernel probes.
 - kretprobe: kernel return probes.
 - tp: kernel tracepoints.
+
+Wildcards (*) can be used, eg. \"kprobe:tcp_*\" or \"tp:skb:*\".
 
 Example: --probe tp:skb:kfree_skb --probe kprobe:consume_skb"
     )]

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -30,7 +30,7 @@ use crate::{
             packets::filter::FilterPacket,
         },
         inspect::check::collection_prerequisites,
-        kernel::{symbol::matching_functions_to_symbols, Symbol},
+        kernel::symbol::{matching_events_to_symbols, matching_functions_to_symbols},
         probe::{self, Probe, ProbeManager},
         signals::Running,
         tracking::{gc::TrackingGC, skb_tracking::init_tracking},
@@ -429,7 +429,8 @@ impl Collectors {
         // supporting it.
         let mut symbols = match type_str {
             "kprobe" | "kretprobe" => matching_functions_to_symbols(target)?,
-            _ => vec![Symbol::from_name(target)?],
+            "tp" => matching_events_to_symbols(target)?,
+            x => bail!("Invalid TYPE {}. See the help.", x),
         };
 
         let mut probes = Vec::new();

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -645,11 +645,16 @@ mod tests {
         assert!(collectors.parse_probe("tcp_v6_*").is_ok());
         assert!(collectors.parse_probe("kprobe:tcp_v6_*").is_ok());
         assert!(collectors.parse_probe("kprobe:tcp_v6_*")?.len() > 0);
+        assert!(collectors.parse_probe("kretprobe:tcp_*").is_ok());
+        assert!(collectors.parse_probe("tp:skb:kfree_*").is_ok());
+        assert!(collectors.parse_probe("tp:*skb*").is_ok());
 
         // Invalid probe: symbol does not exist.
         assert!(collectors.parse_probe("foobar").is_err());
         assert!(collectors.parse_probe("kprobe:foobar").is_err());
         assert!(collectors.parse_probe("tp:42:foobar").is_err());
+        assert!(collectors.parse_probe("tp:kfree_*").is_err());
+        assert!(collectors.parse_probe("*foo*").is_err());
 
         // Invalid probe: wrong TYPE.
         assert!(collectors.parse_probe("kprobe:skb:kfree_skb").is_err());
@@ -662,10 +667,6 @@ mod tests {
         assert!(collectors.parse_probe("tp:").is_err());
         assert!(collectors.parse_probe("tp:skb:").is_err());
         assert!(collectors.parse_probe(":kfree_skb_reason").is_err());
-
-        // Invalid probe: wildcard not supported.
-        assert!(collectors.parse_probe("kretprobe:tcp_*").is_err());
-        assert!(collectors.parse_probe("tp:kfree_*").is_err());
 
         Ok(())
     }

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -428,7 +428,7 @@ impl Collectors {
         // Convert the target to a list of matching ones for probe types
         // supporting it.
         let mut symbols = match type_str {
-            "kprobe" => matching_functions_to_symbols(target)?,
+            "kprobe" | "kretprobe" => matching_functions_to_symbols(target)?,
             _ => vec![Symbol::from_name(target)?],
         };
 

--- a/src/core/kernel/symbol.rs
+++ b/src/core/kernel/symbol.rs
@@ -85,9 +85,9 @@ impl Symbol {
         // Check if the symbol is a tracepoint.
         let name = match target.strip_prefix("__tracepoint_") {
             Some(strip) => {
-                match inspector()?.kernel.find_matching_event(strip) {
-                    Some(event) => event,
-                    None => {
+                match inspector()?.kernel.matching_events(&format!("*:{strip}")) {
+                    Ok(mut events) if events.len() == 1 => events.pop().unwrap(),
+                    _ => {
                         // Not much we can do, we know it's a valid one. Let's
                         // still return an object.
                         return Ok(Symbol::Event(format!("unknow:{strip}")));

--- a/src/core/kernel/symbol.rs
+++ b/src/core/kernel/symbol.rs
@@ -188,9 +188,33 @@ impl fmt::Display for Symbol {
     }
 }
 
+pub(crate) fn matching_events_to_symbols(target: &str) -> Result<Vec<Symbol>> {
+    let symbols = inspector()?
+        .kernel
+        .matching_events(target)?
+        .iter()
+        .filter_map(|t| {
+            // Filter valid tracepoints, eg. ones where we can find an address
+            // using our Symbol logic.
+            if let Ok(sym) = Symbol::from_name(t) {
+                if sym.addr().is_ok() {
+                    return Some(sym);
+                }
+            }
+            None
+        })
+        .collect::<Vec<Symbol>>();
+
+    if symbols.is_empty() {
+        bail!("Could not find a tracepoint matching '{target}'");
+    }
+
+    Ok(symbols)
+}
+
 pub(crate) fn matching_functions_to_symbols(target: &str) -> Result<Vec<Symbol>> {
     let inspector = inspector()?;
-    let symbols: Vec<Symbol> = inspector
+    let symbols = inspector
         .kernel
         .matching_functions(target)?
         .iter()
@@ -202,10 +226,10 @@ pub(crate) fn matching_functions_to_symbols(target: &str) -> Result<Vec<Symbol>>
             }
             None
         })
-        .collect();
+        .collect::<Vec<Symbol>>();
 
     if symbols.is_empty() {
-        bail!("Could not get traceable symbols matching '{target}'");
+        bail!("Could not find a traceable function matching '{target}'");
     }
 
     Ok(symbols)


### PR DESCRIPTION
Currently Retis supports `--probe kprobe:tcp_*` but not for `kretprobe` nor `tp`. This PR adds support for those.