### PR TITLE
[RFC] profile: allow manually loading a profile

### DIFF
--- a/src/profiles/cli.rs
+++ b/src/profiles/cli.rs
@@ -33,7 +33,7 @@ impl SubCommandParserRunner for ProfileCmd {
                 for path in get_profile_paths()?.iter().filter(|p| p.as_path().exists()) {
                     for entry in path.read_dir()? {
                         let entry = entry?;
-                        match Profile::load(entry.path()) {
+                        match Profile::load(&entry.path()) {
                             Ok(mut profiles) => {
                                 if !profiles.is_empty() {
                                     println!("{}:", entry.path().to_str().unwrap_or("unknown"));

--- a/src/profiles/profiles.rs
+++ b/src/profiles/profiles.rs
@@ -132,18 +132,18 @@ pub(crate) struct Profile {
 
 impl Profile {
     /// Supported api version
-    pub fn api_version() -> Result<ApiVersion> {
+    pub(crate) fn api_version() -> Result<ApiVersion> {
         ApiVersion::parse(API_VERSION_STR)
     }
     /// Find a profile
-    pub fn find(name: &str) -> Result<Profile> {
+    pub(crate) fn find(name: &str) -> Result<Profile> {
         for path in get_profile_paths()?.iter().filter(|p| p.as_path().exists()) {
             for entry in path.read_dir()? {
                 // Profile conflict is performed per-path to allow overriding
                 // global profiles in the $HOME location.
                 let mut found = None;
                 let entry = entry?;
-                match Profile::load(entry.path()) {
+                match Profile::load(&entry.path()) {
                     Ok(mut profiles) => {
                         for profile in profiles.drain(..) {
                             if profile.name.eq(name) {
@@ -173,7 +173,7 @@ impl Profile {
 
     /// Load a profile from a path.
     /// A file can contain multiple yaml objects so we return a list of objects.
-    pub fn load(path: PathBuf) -> Result<Vec<Profile>> {
+    pub(crate) fn load(path: &PathBuf) -> Result<Vec<Profile>> {
         let mut result = Vec::new();
         let contents = read_to_string(path.clone())?;
         for document in serde_yaml::Deserializer::from_str(&contents) {
@@ -203,12 +203,12 @@ impl Profile {
 
     /// Load a profile from a string.
     #[cfg(test)]
-    pub fn from_str(contents: &str) -> Result<Profile> {
+    pub(crate) fn from_str(contents: &str) -> Result<Profile> {
         Ok(serde_yaml::from_str(contents)?)
     }
 
     /// Evaluate collect profiles and return the one that matches.
-    pub fn match_collect(&self) -> Result<Option<&SubcommandProfile>> {
+    pub(crate) fn match_collect(&self) -> Result<Option<&SubcommandProfile>> {
         if self.collect.is_empty() {
             return Ok(None);
         }
@@ -222,7 +222,7 @@ impl Profile {
     }
 
     /// Evaluate pcap profiles and return the one that matches.
-    pub fn match_pcap(&self) -> Result<Option<&SubcommandProfile>> {
+    pub(crate) fn match_pcap(&self) -> Result<Option<&SubcommandProfile>> {
         if self.pcap.is_empty() {
             return Ok(None);
         }
@@ -237,7 +237,7 @@ impl Profile {
 
     /// Generate cli arguments from a profile. The result is a list of arguments that can be
     /// concatenated to the ones provided by the user.
-    pub fn cli_args(&self, subcommand: &str) -> Result<Vec<OsString>> {
+    pub(crate) fn cli_args(&self, subcommand: &str) -> Result<Vec<OsString>> {
         let mut result = Vec::new();
         let args = match subcommand {
             "collect" => {
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn load_file() {
-        let p = &Profile::load(PathBuf::from("test_data/profiles/example.yaml")).unwrap()[0];
+        let p = &Profile::load(&PathBuf::from("test_data/profiles/example.yaml")).unwrap()[0];
         assert_eq!(p.name, "example-profile");
         assert_eq!(p.version, ApiVersion::parse("1.0").unwrap());
     }


### PR DESCRIPTION
This enables the Retis --profile cli parameter to load a profile from a file directly. This is useful when developing new profiles or when using a custom profile in a specific situation.

I'm not 100% sure if we want this, or want this in the current form. Some comments:

- As we support 1:n profiles in a single YAML definition, we can't use custom profiles with more than one defined profile. This makes the `--profile` cli command to be a little bit confusing, and makes using this option to develop profiles we'd like to integrate later a bit cumbersome.
- We already provide `.config/retis/profile` for use defined ones. The reasoning here is this could be handy for users to maintain their own set of profiles and share them in their own repositories. But still, for the above reason this might be preferred over this PR.
- This addition makes `--profile` values to have different meanings, files vs profile names, which is a bit of an issue.
- We could add an optional syntax in the `--profile` argument, eg `--profile ./foo.yaml:name` but that is a bit complex IMHO for an argument designed to symplify things.

Thoughts?