### PR TITLE
[RFC] treewide: remove usage of packed

### DIFF
--- a/src/core/filters/packets/bpf/include/packet_filter.h
+++ b/src/core/filters/packets/bpf/include/packet_filter.h
@@ -12,6 +12,6 @@ struct retis_filter_context {
 	unsigned int len;	/* linear length. */
 	/* Output */
 	unsigned int ret;	/* outcome of the match (zero if miss). */
-} __attribute__((packed));
+};
 
 #endif

--- a/src/core/filters/packets/ebpf.rs
+++ b/src/core/filters/packets/ebpf.rs
@@ -80,7 +80,7 @@ const SCRATCH_MEM_START: i16 = 16 * SCRATCH_MEM_SIZE + STACK_RESERVED;
 
 // This should be kept in sync with struct retis_filter_context in
 // src/core/filter/packets/bpf/include/packet_filter.h
-#[repr(C, packed)]
+#[repr(C)]
 struct retis_filter_ctx {
     data: *mut i8,
     len: u32,

--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -12,13 +12,16 @@
 #include <packet_filter.h>
 #include <skb_tracking.h>
 
-/* Kernel section of the event data. */
+/* Kernel section of the event data.
+ * Note that order matters both in terms of padding and in terms of parsing.
+ * Any change MUST be reflected into its Rust counterpart.
+ */
 struct kernel_event {
 	u64 symbol;
+	long stack_id;
 	/* values from enum kernel_probe_type */
 	u8 type;
-	long stack_id;
-} __attribute__((packed));
+};
 
 /* Per-probe configuration; keep in sync with its Rust counterpart in
  * core::probe::kernel::config.

--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -26,7 +26,7 @@ struct kernel_event {
 struct retis_probe_config {
 	struct retis_probe_offsets offsets;
 	u8 stack_trace;
-} __attribute__((packed));
+};
 
 /* Probe configuration; the key is the target symbol address */
 struct {

--- a/src/core/probe/kernel/bpf/include/retis_context.h
+++ b/src/core/probe/kernel/bpf/include/retis_context.h
@@ -20,7 +20,7 @@ struct retis_probe_offsets {
 	s8 net;	 /* netns */
 	s8 nft_pktinfo;
 	s8 nft_traceinfo;
-} __attribute__((packed));
+};
 
 /* Common representation of the register values provided to the probes, as this
  * is done in a per-probe type fashion.

--- a/src/core/probe/kernel/config.rs
+++ b/src/core/probe/kernel/config.rs
@@ -7,7 +7,7 @@ use crate::core::probe::PROBE_MAX;
 /// Per-probe parameter offsets; keep in sync with its BPF counterpart in
 /// bpf/include/common.h
 #[derive(Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub(super) struct ProbeOffsets {
     pub(super) sk_buff: i8,
     pub(super) skb_drop_reason: i8,
@@ -34,7 +34,7 @@ impl Default for ProbeOffsets {
 /// Per-probe configuration; keep in sync with its BPF counterpart in
 /// bpf/include/common.h
 #[derive(Default, Clone)]
-#[repr(C, packed)]
+#[repr(C)]
 pub(crate) struct ProbeConfig {
     pub(super) offsets: ProbeOffsets,
     pub(super) stack_trace: u8,

--- a/src/core/probe/kernel/config.rs
+++ b/src/core/probe/kernel/config.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::core::probe::PROBE_MAX;
 
 /// Per-probe parameter offsets; keep in sync with its BPF counterpart in
-/// bpf/include/common.h
+/// bpf/include/retis_context.h
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub(super) struct ProbeOffsets {

--- a/src/core/probe/user/bpf/include/user_common.h
+++ b/src/core/probe/user/bpf/include/user_common.h
@@ -17,7 +17,7 @@ struct user_event {
 	u64 symbol;
 	u64 pid;
 	u8  event_type;
-} __attribute__((packed));
+};
 
 /* Userspace context */
 struct user_ctx {

--- a/src/core/probe/user/user.rs
+++ b/src/core/probe/user/user.rs
@@ -11,6 +11,9 @@ use crate::core::{
 };
 use crate::{event_section, event_section_factory};
 
+// 17 bytes of actual data + tail padding.
+const DATA_SIZE: usize = 17 + 7;
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct UsdtProbe {
     /// The provider name.
@@ -107,16 +110,16 @@ impl RawEventSectionFactory for UserEventFactory {
         // Unwrap as we just checked the vector contains 1 element.
         let raw = raw_sections.pop().unwrap();
 
-        if raw.data.len() != 17 {
+        if raw.data.len() != DATA_SIZE {
             bail!(
-                "Section data is not the expected size {} != 17",
+                "Section data is not the expected size {} != {DATA_SIZE}",
                 raw.data.len()
             );
         }
 
-        let symbol = u64::from_ne_bytes(raw.data[0..8].try_into()?);
-        let pid_tid = u64::from_ne_bytes(raw.data[8..16].try_into()?);
-        let r#type = u8::from_ne_bytes(raw.data[16..17].try_into()?);
+        let symbol = u64::from_ne_bytes(raw.data[0..=7].try_into()?);
+        let pid_tid = u64::from_ne_bytes(raw.data[8..=15].try_into()?);
+        let r#type = raw.data[16];
 
         // Split pid and tid
         let pid = (pid_tid & 0xFFFFFFFF) as i32;

--- a/src/core/tracking/bpf/include/skb_tracking.h
+++ b/src/core/tracking/bpf/include/skb_tracking.h
@@ -26,7 +26,7 @@ struct tracking_config {
 	 * probe. We can still read existing tracking data.
 	 */
 	u8 no_tracking;
-} __attribute__((packed));
+};
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(max_entries, PROBE_MAX);

--- a/src/core/tracking/skb_tracking.rs
+++ b/src/core/tracking/skb_tracking.rs
@@ -251,7 +251,7 @@ pub(crate) fn init_tracking(
 }
 
 // Please keep in sync with its BPF counterpart.
-#[repr(C, packed)]
+#[repr(C)]
 struct TrackingConfig {
     free: u8,
     partial_free: u8,
@@ -263,7 +263,7 @@ unsafe impl Plain for TrackingConfig {}
 
 // Please keep in sync with its BPF counterpart.
 #[derive(Default)]
-#[repr(C, packed)]
+#[repr(C)]
 struct TrackingInfo {
     timestamp: u64,
     last_seen: u64,

--- a/src/module/ct/bpf.rs
+++ b/src/module/ct/bpf.rs
@@ -31,7 +31,7 @@ pub(super) const RETIS_CT_PROTO_UDP: u32 = 1 << 5;
 pub(super) const RETIS_CT_PROTO_ICMP: u32 = 1 << 6;
 
 #[derive(Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 union IP {
     ipv4: u32,
     ipv6: u128,
@@ -44,21 +44,21 @@ impl Default for IP {
 }
 
 #[derive(Clone, Copy, Default)]
-#[repr(C, packed)]
+#[repr(C)]
 struct IpProto {
     addr: IP,
     data: u16,
 }
 
 #[derive(Clone, Copy, Default)]
-#[repr(C, packed)]
+#[repr(C)]
 struct NfConnTuple {
     src: IpProto,
     dst: IpProto,
 }
 
 #[derive(Default)]
-#[repr(C, packed)]
+#[repr(C)]
 struct RawCtEvent {
     flags: u32,
     zone_id: u16,

--- a/src/module/ct/bpf/ct.bpf.c
+++ b/src/module/ct/bpf/ct.bpf.c
@@ -33,12 +33,12 @@ struct nf_conn_addr_proto {
 	} addr;
 	/* per-protocol generic data */
 	u16 data;
-} __attribute__((packed));
+};
 
 struct nf_conn_tuple {
 	struct nf_conn_addr_proto src;
 	struct nf_conn_addr_proto dst;
-} __attribute__((packed));
+};
 
 /* Conntrack event information */
 struct ct_event {
@@ -49,7 +49,7 @@ struct ct_event {
 	u8 state;
 	u8 tcp_state;
 
-} __attribute__((packed));
+};
 
 static __always_inline bool ct_protocol_is_supported(u16 l3num, u8 protonum)
 {

--- a/src/module/nft/bpf.rs
+++ b/src/module/nft/bpf.rs
@@ -1,7 +1,7 @@
 /// Nft specific parameter offsets; keep in sync with its BPF counterpart in
 /// bpf/nft.bpf.c
 #[derive(Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C)]
 pub(super) struct NftOffsets {
     pub(super) nft_chain: i8,
     pub(super) nft_rule: i8,
@@ -22,7 +22,7 @@ impl Default for NftOffsets {
 
 /// Global configuration passed down the BPF part.
 #[derive(Default)]
-#[repr(C, packed)]
+#[repr(C)]
 pub(super) struct NftConfig {
     /// Bitfield of events to collect based on the verdict.
     /// The values follow the kernel definitions as they are uapi.

--- a/src/module/nft/bpf/nft.bpf.c
+++ b/src/module/nft/bpf/nft.bpf.c
@@ -47,7 +47,7 @@ struct nft_event {
 	s64 c_handle;
 	s64 r_handle;
 	u8 policy;
-} __attribute__((packed));
+};
 
 struct nft_rule_dp___5_17_0 {
 	u64	is_last:1,

--- a/src/module/nft/bpf/nft.bpf.c
+++ b/src/module/nft/bpf/nft.bpf.c
@@ -25,11 +25,11 @@ struct nft_offsets {
 	s8 nft_rule;
 	s8 nft_verdict;
 	s8 nft_type;
-} __attribute__((packed));
+};
 struct nft_config {
 	u64 verdicts;
 	struct nft_offsets offsets;
-} __attribute__((packed));
+};
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);

--- a/src/module/nft/event.rs
+++ b/src/module/nft/event.rs
@@ -58,7 +58,7 @@ impl EventFmt for NftEvent {
 
 // Please keep in sync with its bpf counterpart under
 // src/modules/nft/bpf/nft.bpf.c
-#[repr(C, packed)]
+#[repr(C)]
 struct NftBpfEvent {
     /// Table name.
     tn: NftName,

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -38,7 +38,7 @@ pub(super) struct RawConfig {
 }
 
 /// Ethernet data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawEthEvent {
     /// Source MAC address.
     src: [u8; 6],
@@ -59,7 +59,7 @@ pub(super) fn unmarshal_eth(raw_section: &BpfRawSection) -> Result<SkbEthEvent> 
 }
 
 /// ARP data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawArpEvent {
     /// Operation. Stored in network order.
     operation: u16,
@@ -92,7 +92,7 @@ pub(super) fn unmarshal_arp(raw_section: &BpfRawSection) -> Result<SkbArpEvent> 
 }
 
 /// IPv4 data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawIpv4Event {
     /// Source IP address. Stored in network order.
     src: u32,
@@ -136,7 +136,7 @@ pub(super) fn unmarshal_ipv4(raw_section: &BpfRawSection) -> Result<SkbIpEvent> 
 }
 
 /// IPv6 data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawIpv6Event {
     /// Source IP address. Stored in network order.
     src: u128,
@@ -171,7 +171,7 @@ pub(super) fn unmarshal_ipv6(raw_section: &BpfRawSection) -> Result<SkbIpEvent> 
 }
 
 /// TCP data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawTcpEvent {
     /// Source port. Stored in network order.
     sport: u16,
@@ -204,7 +204,7 @@ pub(super) fn unmarshal_tcp(raw_section: &BpfRawSection) -> Result<SkbTcpEvent> 
 }
 
 /// UDP data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawUdpEvent {
     /// Source port. Stored in network order.
     sport: u16,
@@ -225,7 +225,7 @@ pub(super) fn unmarshal_udp(raw_section: &BpfRawSection) -> Result<SkbUdpEvent> 
 }
 
 /// ICMP data retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawIcmpEvent {
     /// ICMP type.
     r#type: u8,
@@ -243,7 +243,7 @@ pub(super) fn unmarshal_icmp(raw_section: &BpfRawSection) -> Result<SkbIcmpEvent
 }
 
 /// Net device information retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawDevEvent {
     /// Net device name.
     dev_name: [u8; 16],
@@ -281,7 +281,7 @@ pub(super) fn unmarshal_dev(raw_section: &BpfRawSection) -> Result<Option<SkbDev
 }
 
 /// Net namespace information retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawNsEvent {
     /// Net namespace id.
     netns: u32,
@@ -294,7 +294,7 @@ pub(super) fn unmarshal_ns(raw_section: &BpfRawSection) -> Result<SkbNsEvent> {
 }
 
 /// Skb metadata & related.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawMetaEvent {
     len: u32,
     data_len: u32,
@@ -316,7 +316,7 @@ pub(super) fn unmarshal_meta(raw_section: &BpfRawSection) -> Result<SkbMetaEvent
 }
 
 /// Data & refcount information retrieved from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 struct RawDataRefEvent {
     nohdr: u8,
     /// Is the skb a clone?
@@ -342,7 +342,7 @@ pub(super) fn unmarshal_data_ref(raw_section: &BpfRawSection) -> Result<SkbDataR
 }
 
 /// Raw packet and related metadata extracted from skbs.
-#[repr(C, packed)]
+#[repr(C)]
 pub(super) struct RawPacketEvent {
     /// Length of the packet.
     len: u32,

--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -30,7 +30,7 @@ pub(super) const SECTION_DATA_REF: u64 = 10;
 pub(super) const SECTION_PACKET: u64 = 11;
 
 /// Global configuration passed down the BPF part.
-#[repr(C, packed)]
+#[repr(C)]
 pub(super) struct RawConfig {
     /// Bitfield of what to collect from skbs. Currently `1 << SECTION_x` is
     /// used to trigger retrieval of a given section.

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -34,7 +34,7 @@
  */
 struct skb_config {
 	u64 sections;
-} __attribute__((packed));
+};
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -49,14 +49,14 @@ struct skb_eth_event {
 	u8 dst[6];
 	u8 src[6];
 	u16 etype;
-} __attribute__((packed));
+};
 struct skb_arp_event {
 	u16 operation;
 	u8 sha[6];
 	u32 spa;
 	u8 tha[6];
 	u32 tpa;
-} __attribute__((packed));
+};
 struct skb_ipv4_event {
 	u32 src;
 	u32 dst;
@@ -68,7 +68,7 @@ struct skb_ipv4_event {
 	u8 ecn;
 	u16 offset;
 	u8 flags;
-} __attribute__((packed));
+};
 struct skb_ipv6_event {
 	u128 src;
 	u128 dst;
@@ -77,7 +77,7 @@ struct skb_ipv6_event {
 	u8 protocol;
 	u8 ttl;
 	u8 ecn;
-} __attribute__((packed));
+};
 struct skb_tcp_event {
 	u16 sport;
 	u16 dport;
@@ -87,39 +87,39 @@ struct skb_tcp_event {
 	/* TCP flags: fin, syn, rst, psh, ack, urg, ece, cwr. */
 	u8 flags;
 	u8 doff;
-} __attribute__((packed));
+};
 struct skb_udp_event {
 	u16 sport;
 	u16 dport;
 	u16 len;
-} __attribute__((packed));
+};
 struct skb_icmp_event {
 	u8 type;
 	u8 code;
-} __attribute__((packed));
+};
 struct skb_netdev_event {
 #define IFNAMSIZ	16
 	u8 dev_name[IFNAMSIZ];
 	u32 ifindex;
 	u32 iif;
-} __attribute__((packed));
+};
 struct skb_netns_event {
 	u32 netns;
-} __attribute__((packed));
+};
 struct skb_meta_event {
 	u32 len;
 	u32 data_len;
 	u32 hash;
 	u32 csum;
 	u32 priority;
-} __attribute__((packed));
+};
 struct skb_data_ref_event {
 	u8 nohdr;
 	u8 cloned;
 	u8 fclone;
 	u8 users;
 	u8 dataref;
-} __attribute__((packed));
+};
 /* Please keep the following structs in sync with its Rust counterpart in
  * module::skb::event.
  */
@@ -128,7 +128,7 @@ struct skb_packet_event {
 	u32 capture_len;
 #define PACKET_CAPTURE_SIZE	256
 	u8 packet[PACKET_CAPTURE_SIZE];
-} __attribute__((packed));
+};
 
 /* Must be called with a valid skb pointer */
 static __always_inline int process_skb_arp(struct retis_raw_event *event,

--- a/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
+++ b/src/module/skb_drop/bpf/skb_drop_hook.bpf.c
@@ -6,7 +6,7 @@
 
 struct skb_drop_event {
 	s32 drop_reason;
-} __attribute__((packed));
+};
 
 DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 	struct skb_drop_event *e;

--- a/src/module/skb_drop/event.rs
+++ b/src/module/skb_drop/event.rs
@@ -167,7 +167,7 @@ impl RawEventSectionFactory for SkbDropEventFactory {
     }
 }
 
-#[repr(C, packed)]
+#[repr(C)]
 struct BpfSkbDropEvent {
     drop_reason: i32,
 }


### PR DESCRIPTION
The notable exception at the moment is RawEvent and BpfRawSectionHeader.
The motivation comes basically from the fact that packed structure imposes byte access to avoid unaligned access and this is normally a performance penalty.
Also, potential unaligned accesses (for the platforms that support UA) lead to a performance penalty.

In general, it is not required to have structures packed, and padding (but also UA) can be mitigated by carefully rearranging fields.

TL;DR: two strategies are preferable here, remove `packed` or simply rearrange (and maintain this as a hard rule) ds assuming sizes and orders allow to avoid unaligned accesses.

Edit: the benchmark blob needs to be updated.