### PR TITLE
[RFC] Python representation of events & post-processing interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "inventory"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,6 +1049,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1099,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a8b1990bd018761768d5e608a13df8bd1ac5f678456e0f301bb93e5f3ea16b"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "inventory",
+ "libc",
+ "memoffset 0.9.0",
+ "parking_lot",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650dca34d463b6cdbdb02b1d71bfd6eb6b6816afc708faebb3bac1380ff4aef7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a7da8fc04a8a2084909b59f29e1b8474decac98b951d77b80b26dc45f046ad"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8a199fce11ebb28e3569387228836ea98110e43a804a530a9fd83ade36d513"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fbbfd7eb553d10036513cb122b888dcd362a945a00b06c165f2ab480d4cc3b"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1171,6 +1253,7 @@ dependencies = [
  "pcap-file",
  "plain",
  "probe",
+ "pyo3",
  "rbpf",
  "regex",
  "retis-derive",
@@ -1534,6 +1617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1786,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4445909572dbd556c457c849c4ca58623d84b27c8fff1e74b0b4227d8b90d17b"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,10 +500,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "flate2"
@@ -873,6 +911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rbpf"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1314,7 @@ dependencies = [
  "rbpf",
  "regex",
  "retis-derive",
+ "rustyline",
  "serde",
  "serde_json",
  "serde_with",
@@ -1310,6 +1368,29 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.26.4",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
 
 [[package]]
 name = "ryu"
@@ -1576,6 +1657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1873,18 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unindent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ pyo3 = { version = "0.21", features = ["auto-initialize", "multiple-pymethods"] 
 rbpf = {version = "0.2", optional = true}
 regex = "1.7"
 retis-derive = {version = "1.3", path = "./retis-derive"}
+rustyline = "12.0"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_with = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ path-clean = "1.0"
 pcap = "1.0"
 pcap-file = "2.0"
 plain = "0.2"
+pyo3 = { version = "0.21", features = ["auto-initialize", "multiple-pymethods"] }
 rbpf = {version = "0.2", optional = true}
 regex = "1.7"
 retis-derive = {version = "1.3", path = "./retis-derive"}

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -422,6 +422,7 @@ pub(crate) fn get_cli() -> Result<ThinCli> {
     cli.add_subcommand(Box::new(Collect::new()?))?;
     cli.add_subcommand(Box::new(Print::new()?))?;
     cli.add_subcommand(Box::new(Sort::new()?))?;
+    cli.add_subcommand(Box::new(PythonCli::new()?))?;
     cli.add_subcommand(Box::new(Pcap::new()?))?;
     cli.add_subcommand(Box::new(Inspect::new()?))?;
     cli.add_subcommand(Box::new(ProfileCmd::new()?))?;

--- a/src/core/events/events.rs
+++ b/src/core/events/events.rs
@@ -85,6 +85,11 @@ impl Event {
         }
     }
 
+    #[allow(clippy::borrowed_box)]
+    pub(super) fn get(&self, owner: ModuleId) -> Option<&Box<dyn EventSection>> {
+        self.0.get(&owner)
+    }
+
     pub(crate) fn to_json(&self) -> serde_json::Value {
         let mut event = serde_json::Map::new();
 
@@ -200,6 +205,7 @@ pub(crate) trait EventSectionInternal {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn to_json(&self) -> serde_json::Value;
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject;
 }
 
 // We need this as the value given as the input when deserializing something
@@ -215,6 +221,10 @@ impl EventSectionInternal for () {
 
     fn to_json(&self) -> serde_json::Value {
         serde_json::Value::Null
+    }
+
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
+        py.None().into()
     }
 }
 

--- a/src/core/events/mod.rs
+++ b/src/core/events/mod.rs
@@ -20,3 +20,4 @@ pub(crate) use display::*;
 
 pub(crate) mod bpf;
 pub(crate) mod file;
+pub(crate) mod python;

--- a/src/core/events/python.rs
+++ b/src/core/events/python.rs
@@ -1,0 +1,147 @@
+use std::{collections::HashMap, rc::Rc};
+
+use pyo3::{
+    exceptions::PyKeyError,
+    prelude::{PyAnyMethods, PyListMethods},
+    types::{PyList, PyString},
+    *,
+};
+
+use crate::{
+    core::events::{Event, EventDisplay},
+    module::ModuleId,
+};
+
+/// Python representation of an Event.
+///
+/// We can't directly convert an Event to a Python representation because it
+/// contains a map of trait implementation. We could just represent it as a
+/// Python map, but using an object around it makes implementing custom methods
+/// possible.
+#[pyclass(unsendable)]
+#[derive(Clone)]
+pub(crate) struct PyEvent(Rc<Event>);
+
+impl PyEvent {
+    pub(crate) fn new(event: Event) -> Self {
+        Self(Rc::new(event))
+    }
+}
+
+impl ToPyObject for PyEvent {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.clone().into_py(py)
+    }
+}
+
+#[pymethods]
+impl PyEvent {
+    /// Controls how the PyEvent is represented, eg. what is the output of
+    /// `print(e)`.
+    fn __repr__<'a>(&'a self, py: Python<'a>) -> String {
+        let raw = self.raw(py);
+        let dict: &Bound<'_, PyAny> = raw.bind(py);
+        dict.repr().unwrap().to_string()
+    }
+
+    /// Allows to use the object as a dictionary, eg. `e['skb']`.
+    fn __getitem__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
+        if let Ok(id) = ModuleId::from_str(attr) {
+            if let Some(section) = self.0.get(id) {
+                return Ok(section.to_py(py));
+            }
+        }
+        Err(PyKeyError::new_err(attr.to_string()))
+    }
+
+    /// Returns a dictionary with all key<>data stored (recursively) in the
+    /// event, eg. `e.raw()['skb']['dev']`.
+    fn raw(&self, py: Python<'_>) -> PyObject {
+        to_pyobject(&self.0.to_json(), py)
+    }
+
+    /// Maps to our own logic to show the event, so we can print it like Retis
+    /// would do in collect or print.
+    fn show(&self) -> String {
+        format!("{}", self.0.display(super::DisplayFormat::MultiLine))
+    }
+}
+
+/// Python representation of a Vec<Event>.
+///
+/// Implementing our own object allows to provide custom methods.
+#[pyclass]
+#[derive(Clone)]
+pub(crate) struct PyEventList(PyObject);
+
+impl PyEventList {
+    pub(crate) fn new(py: Python<'_>, elements: Vec<PyEvent>) -> Self {
+        Self(PyList::new_bound(py, elements).into())
+    }
+}
+
+#[pymethods]
+impl PyEventList {
+    /// Controls how the PyEventList is represented, eg. what is the output of
+    /// `print(events)`.
+    fn __repr__<'a>(&'a self, py: Python<'a>) -> PyResult<Bound<'a, PyString>> {
+        let events: &Bound<'_, PyList> = self.0.downcast_bound::<PyList>(py).unwrap();
+        events.repr()
+    }
+
+    /// Allows to use the object as a dictionary, eg. `events[0]`.
+    fn __getitem__<'a>(&'a self, py: Python<'a>, attr: usize) -> PyResult<Bound<'a, PyAny>> {
+        let events: &Bound<'_, PyList> = self.0.downcast_bound::<PyList>(py).unwrap();
+        events.get_item(attr)
+    }
+
+    /// Allows to get the len of the object as a dictionary, eg. `len(events)`.
+    fn __len__(&self, py: Python<'_>) -> usize {
+        let events = self.0.downcast_bound::<PyList>(py).unwrap();
+        events.len()
+    }
+
+    /// Returns a dictionary with all key<>data stored (recursively) in the
+    /// event, eg. `events.raw()[0]['skb']['dev']`.
+    fn raw(&self, py: Python<'_>) -> PyObject {
+        let events = self.0.downcast_bound::<PyList>(py).unwrap();
+        let mut list = Vec::new();
+
+        for event in events.iter() {
+            let raw = event.call_method("raw", (), None).unwrap();
+            list.push(raw);
+        }
+
+        PyList::new_bound(py, list).into()
+    }
+}
+
+impl ToPyObject for PyEventList {
+    fn to_object(&self, py: Python<'_>) -> PyObject {
+        self.clone().into_py(py)
+    }
+}
+
+/// Converts a serde_json::Value to a PyObject.
+pub(crate) fn to_pyobject(val: &serde_json::Value, py: Python<'_>) -> PyObject {
+    use serde_json::Value;
+    match val {
+        Value::Null => py.None().into(),
+        Value::Bool(b) => b.to_object(py),
+        Value::Number(n) => n
+            .as_i64()
+            .map(|x| x.to_object(py))
+            .or(n.as_u64().map(|x| x.to_object(py)))
+            .or(n.as_f64().map(|x| x.to_object(py)))
+            .expect("Cannot convert number to Python object"),
+        Value::String(s) => s.to_object(py),
+        Value::Array(a) => {
+            let vec: Vec<_> = a.iter().map(|x| to_pyobject(x, py)).collect();
+            vec.to_object(py)
+        }
+        Value::Object(o) => {
+            let map: HashMap<_, _> = o.iter().map(|(k, v)| (k, to_pyobject(v, py))).collect();
+            map.to_object(py)
+        }
+    }
+}

--- a/src/module/ct/event.rs
+++ b/src/module/ct/event.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{core::events::*, event_section, event_type};
+use crate::{core::events::*, event_section, event_type, event_type_no_py};
 
 #[event_type]
 #[derive(Default)]
@@ -41,7 +41,7 @@ pub(crate) struct CtIcmp {
     pub(crate) id: u16,
 }
 
-#[event_type]
+#[event_type_no_py]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum CtProto {
     Tcp(CtTcp),

--- a/src/module/ovs/event.rs
+++ b/src/module/ovs/event.rs
@@ -6,7 +6,7 @@ use serde::{de::Error as Derror, ser::Error as Serror, Deserialize, Deserializer
 use super::bpf::*;
 use crate::{
     core::events::{bpf::BpfRawSection, *},
-    event_section, event_section_factory, event_type,
+    event_section, event_section_factory, event_type, event_type_no_py,
 };
 
 ///The OVS Event
@@ -51,7 +51,7 @@ impl RawEventSectionFactory for OvsEventFactory {
     }
 }
 
-#[event_type]
+#[event_type_no_py]
 #[serde(tag = "event_type")]
 #[derive(Default, PartialEq)]
 pub(crate) enum OvsEventType {
@@ -424,7 +424,7 @@ impl EventFmt for ActionEvent {
     }
 }
 
-#[event_type]
+#[event_type_no_py]
 #[serde(tag = "action")]
 #[derive(Default, PartialEq)]
 pub(crate) enum OvsAction {

--- a/src/module/skb/event.rs
+++ b/src/module/skb/event.rs
@@ -8,7 +8,7 @@ use crate::{
         events::{bpf::BpfRawSection, *},
         helpers,
     },
-    event_section, event_section_factory, event_type,
+    event_section, event_section_factory, event_type, event_type_no_py,
 };
 
 /// Skb event section.
@@ -340,7 +340,7 @@ pub(crate) struct SkbIpEvent {
 }
 
 /// IP version and specific fields.
-#[event_type]
+#[event_type_no_py]
 pub(crate) enum SkbIpVersion {
     #[serde(rename = "v4")]
     V4(SkbIpv4Event),

--- a/src/module/skb_tracking/event.rs
+++ b/src/module/skb_tracking/event.rs
@@ -32,6 +32,7 @@ pub(crate) struct SkbTrackingEvent {
 }
 
 #[allow(dead_code)]
+#[pyo3::pymethods]
 impl SkbTrackingEvent {
     /// Get the tracking id.
     pub(crate) fn tracking_id(&self) -> u128 {

--- a/src/process/cli/mod.rs
+++ b/src/process/cli/mod.rs
@@ -8,5 +8,8 @@ pub(crate) use self::pcap::*;
 pub(crate) mod print;
 pub(crate) use print::*;
 
+pub(crate) mod python;
+pub(crate) use python::*;
+
 pub(crate) mod sort;
 pub(crate) use sort::*;

--- a/src/process/cli/python.rs
+++ b/src/process/cli/python.rs
@@ -1,0 +1,139 @@
+use std::{fs, path::PathBuf, time::Duration};
+
+use anyhow::Result;
+use clap::{arg, Parser};
+use pyo3::{exceptions::PySyntaxError, prelude::*, types::PyDict};
+use rustyline::{error::ReadlineError, DefaultEditor};
+
+use crate::{
+    cli::*,
+    core::events::{
+        file::FileEventsFactory,
+        python::{PyEvent, PyEventList},
+        Event, EventFactory, EventResult,
+    },
+    module::Modules,
+};
+
+/// Launches a Python interactive cli with events imported.
+#[derive(Parser, Debug, Default)]
+#[command(name = "python")]
+pub(crate) struct PythonCli {
+    #[arg(default_value = "retis.data", help = "File from which to read events")]
+    pub(super) input: PathBuf,
+    #[arg(long, help = "Python script to execute")]
+    pub(super) exec: Option<PathBuf>,
+}
+
+impl SubCommandParserRunner for PythonCli {
+    fn run(&mut self, modules: Modules) -> Result<()> {
+        // Create event factory.
+        let mut factory = FileEventsFactory::new(self.input.as_path())?;
+        factory.start(modules.section_factories()?)?;
+
+        let mut events = Vec::new();
+        use EventResult::*;
+        loop {
+            match factory.next_event(Some(Duration::from_secs(1)))? {
+                Event(event) => events.push(event),
+                Eof => break,
+                Timeout => continue,
+            }
+        }
+
+        Python::with_gil(|py| -> PyResult<()> {
+            let shell = PyShell::new(py, events)?;
+            match &self.exec {
+                Some(script) => shell.run(&fs::read_to_string(script)?),
+                None => shell.interactive(),
+            }
+        })?;
+
+        Ok(())
+    }
+}
+
+struct PyShell<'a> {
+    py: Python<'a>,
+    globals: Bound<'a, PyDict>,
+}
+
+impl<'a> PyShell<'a> {
+    fn new(py: Python<'a>, mut events: Vec<Event>) -> PyResult<Self> {
+        let globals = PyDict::new_bound(py);
+        globals.set_item(
+            "events",
+            &PyEventList::new(py, events.drain(..).map(PyEvent::new).collect::<Vec<_>>()),
+        )?;
+
+        Ok(Self { py, globals })
+    }
+
+    fn interactive(&self) -> PyResult<()> {
+        let mut rl = DefaultEditor::new().expect("Could not create readline obj");
+
+        let mut input = String::new();
+        loop {
+            let prefix = if input.is_empty() { ">>> " } else { "... " };
+
+            let line = match rl.readline(prefix) {
+                Ok(line) => line,
+                Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => break,
+                Err(e) => {
+                    println!("{e}");
+                    continue;
+                }
+            };
+
+            input.push_str(&line);
+
+            match self.try_run(&input) {
+                RunResult::Ok => {
+                    rl.add_history_entry(input.as_str())
+                        .expect("Couldn't add to history");
+                    input.clear();
+                }
+                RunResult::Continue => {
+                    input.push('\n');
+                }
+                RunResult::Err(e) => {
+                    println!("{e}");
+                    input.clear();
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn run(&self, script: &str) -> PyResult<()> {
+        self.py
+            .run_bound(script, Some(&self.globals.as_borrowed()), None)
+    }
+
+    fn try_run(&self, input: &str) -> RunResult {
+        match self.run(input) {
+            Ok(_) => RunResult::Ok,
+            Err(e) => {
+                if e.is_instance_of::<PySyntaxError>(self.py)
+                    && unsafe {
+                        pyo3::ffi::PyObject_IsInstance(
+                            e.to_object(self.py).as_ptr(),
+                            pyo3::ffi::PyExc_IndentationError,
+                        )
+                    } != 0
+                {
+                    return RunResult::Continue;
+                }
+
+                RunResult::Err(e)
+            }
+        }
+    }
+}
+
+enum RunResult {
+    Ok,
+    Continue,
+    Err(PyErr),
+}


### PR DESCRIPTION
This is aimed at v1.4, to leave time to experiment with the feature and make it production ready. Having said that the current state is IMHO in a good shape and already allows to work with events in Python at post-processing time.

Events are parsed all at once and exported in the `events` variable. This is an object we control that provides some custom methods but also acts as a list of events. Those events are a Python representation of Retis events, with their own methods, and also act as a dict. Sub-sections and following types are not all supported, some like the skb tracking one are and export custom methods (e.g. `tracking_id()` or `match()`). For a few examples of what can be done, see `demo.py`.

There are two modes of operation:

- The interactive interpreter: `retis python`
- The execution of a script: `retis python --exec foo.py`

Current limitations or open questions:

- Enum with data cannot currently be converted to Python objects, but `pyo3` has currently a PR opened and it seems like this is moving forward nicely. Because of this not all sub-sections were converted as a Python object and none got automatic get implementation (see pyo3 `get_all`) which would allow to use them as dict. The later could be done for some by adding an extra derive macro, but for this RFC that seemed enough. Because of this all objects implement a `raw()` method to get a raw list or dict representation.
- Events are parsed at startup time, meaning a very large set of events might be an issue. IMHO by default the current behavior is fine (otherwise each access to `events` would mean parsing the whole set) but we could introduce a lazy mode for very large sets, so the user can for example iter on events w/o having all of them in memory at once. Or automatically choose based on the events size and issue an INFO msg.
- On top of this we could, similarly to profiles, distribute scripts for specific post-processing cases. It also opens the question of moving our current post-processing commands to Python (not saying we should do it, but it's a possibility). This, combined with profiles, would allow things like: `retis -p csum python`. Or we could parse the sub-command and use it as a Python script if not a built-in one, eg. `retis csum` mapping internally to `retis python --exec /etc/retis/python/csum.py`.
- Some extra care is needed to look at how the Python interpreter is being called and how if this could be improved (eg. configured better). But note that current implementation made the release binary to grow to from 6.8M to 7.7M.

Fixes #35.