### PR TITLE
Raw packet capture fixes

### DIFF
--- a/src/module/skb/bpf.rs
+++ b/src/module/skb/bpf.rs
@@ -349,7 +349,7 @@ pub(super) struct RawPacketEvent {
     /// Lenght of the capture. <= len.
     capture_len: u32,
     /// Raw packet data.
-    packet: [u8; 256],
+    packet: [u8; 255],
 }
 
 pub(super) fn unmarshal_packet(raw_section: &BpfRawSection) -> Result<SkbPacketEvent> {

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -126,7 +126,7 @@ struct skb_data_ref_event {
 struct skb_packet_event {
 	u32 len;
 	u32 capture_len;
-#define PACKET_CAPTURE_SIZE	256
+#define PACKET_CAPTURE_SIZE	255
 	u8 packet[PACKET_CAPTURE_SIZE];
 } __attribute__((packed));
 

--- a/src/module/skb/bpf/skb_hook.bpf.c
+++ b/src/module/skb/bpf/skb_hook.bpf.c
@@ -404,6 +404,10 @@ static __always_inline int process_packet(struct retis_raw_event *event,
 	len = BPF_CORE_READ(skb, len);
 	linear_len = len - BPF_CORE_READ(skb, data_len); /* Linear buffer size */
 
+	/* No data in the linear len, nothing to report */
+	if (!linear_len)
+		return 0;
+
 	/* Best case: mac offset is set and valid */
 	if (is_mac_data_valid(skb)) {
 		int mac_offset;


### PR DESCRIPTION
Two raw packet capture fixes for when:

- Capture length is the max allowed (was converted to 0...).
- No data lies in the skb linear buffer part.