### PR TITLE
Auto-probe mode

### DIFF
--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -39,6 +39,12 @@ pub fn derive_event_section(input: TokenStream) -> TokenStream {
                 self
             }
 
+            fn as_any_mut(&mut self) -> &mut dyn std::any::Any
+                where Self: Sized,
+            {
+                self
+            }
+
             fn to_json(&self) -> serde_json::Value
                 where Self: serde::Serialize,
             {

--- a/src/collect/cli.rs
+++ b/src/collect/cli.rs
@@ -98,6 +98,24 @@ Examples of meta filters:
     #[arg(
         long,
         default_value = "false",
+        help = "When set, evaluates where Retis could add additional probes based on functions reported
+in the events stack traces (their display is still controlled by --stack). All matching
+functions are probed at runtime using kprobes.
+
+Notes:
+- Using a filter is required (--filter-packet and/or --filter-meta).
+- If no explicit probe is given, tp:skb:kfree_skb and tp:skb:consume_skb are used as a
+  starting point.
+- Additional probes are added only after events including them in their stack trace are
+  reported; this means the first packets hitting a probe won't be reported.
+- Packets will only be followed prior to the initial set of probes (as this mode uses
+  stack traces). This also means the filter must match packets as they appear in the
+  initial set of probes; packet transformation can't be automatically detected."
+    )]
+    pub(crate) probe_stack: bool,
+    #[arg(
+        long,
+        default_value = "false",
         help = r#"Allow the tool to setup all the system changes needed to make the tracing
 fully operational.
 

--- a/src/collect/collector.rs
+++ b/src/collect/collector.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         inspect::check::collection_prerequisites,
         kernel::symbol::{matching_events_to_symbols, matching_functions_to_symbols},
-        probe::{self, Probe, ProbeManager},
+        probe::*,
         signals::Running,
         tracking::{gc::TrackingGC, skb_tracking::init_tracking},
     },
@@ -73,7 +73,7 @@ pub(crate) trait Collector {
     /// will make the whole program to fail. In general collectors should try
     /// hard to run in various setups, see the `crate::collector` top
     /// documentation for more information.
-    fn init(&mut self, cli: &CliConfig, probes: &mut probe::ProbeManager) -> Result<()>;
+    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()>;
     /// Start the collector.
     fn start(&mut self) -> Result<()> {
         Ok(())
@@ -87,7 +87,7 @@ pub(crate) trait Collector {
 /// Main collectors object and API.
 pub(crate) struct Collectors {
     modules: Modules,
-    probes: probe::ProbeManager,
+    probes: ProbeManager,
     factory: BpfEventsFactory,
     known_kernel_types: HashSet<String>,
     run: Running,
@@ -98,14 +98,9 @@ pub(crate) struct Collectors {
 }
 
 impl Collectors {
-    #[allow(unused_mut)] // For tests.
-    fn new(mut modules: Modules) -> Result<Self> {
+    fn new(modules: Modules) -> Result<Self> {
         let factory = BpfEventsFactory::new()?;
-
-        #[cfg(not(test))]
-        let mut probes = probe::ProbeManager::new()?;
-        #[cfg(test)]
-        let probes = probe::ProbeManager::new()?;
+        let probes = ProbeManager::new()?;
 
         Ok(Collectors {
             modules,
@@ -134,7 +129,7 @@ impl Collectors {
     }
 
     /// Setup user defined input filter.
-    fn setup_filters(probes: &mut ProbeManager, collect: &Collect) -> Result<()> {
+    fn setup_filters(probes: &mut ProbeBuilderManager, collect: &Collect) -> Result<()> {
         if let Some(f) = &collect.args()?.packet_filter {
             // L2 filter MUST always succeed. Any failure means we need to bail.
             let fb = FilterPacket::from_string_opt(f.to_string(), FilterPacketType::L2)?;
@@ -190,7 +185,9 @@ impl Collectors {
             .ok_or_else(|| anyhow!("wrong subcommand"))?;
 
         if collect.args()?.stack {
-            self.probes.set_probe_opt(probe::ProbeOption::StackTrace)?;
+            self.probes
+                .builder_mut()?
+                .set_probe_opt(probe::ProbeOption::StackTrace)?;
         }
 
         // --allow-system-changes requires root.
@@ -218,7 +215,7 @@ impl Collectors {
                 }
             }
 
-            if let Err(e) = c.init(cli, &mut self.probes) {
+            if let Err(e) = c.init(cli, self.probes.builder_mut()?) {
                 bail!("Could not initialize the {} collector: {}", id, e);
             }
 
@@ -247,11 +244,11 @@ impl Collectors {
 
         // Initialize tracking & filters.
         if !cfg!(test) && self.known_kernel_types.contains("struct sk_buff *") {
-            let (gc, map) = init_tracking(&mut self.probes)?;
+            let (gc, map) = init_tracking(self.probes.builder_mut()?)?;
             self.tracking_gc = Some(gc);
             self.tracking_config_map = Some(map);
         }
-        Self::setup_filters(&mut self.probes, collect)?;
+        Self::setup_filters(self.probes.builder_mut()?, collect)?;
 
         // Setup user defined probes.
         collect
@@ -261,7 +258,7 @@ impl Collectors {
             .try_for_each(|p| -> Result<()> {
                 self.parse_probe(p)?
                     .drain(..)
-                    .try_for_each(|p| self.probes.register_probe(p))?;
+                    .try_for_each(|p| self.probes.builder_mut()?.register_probe(p))?;
                 Ok(())
             })?;
 
@@ -278,8 +275,12 @@ impl Collectors {
         #[cfg(not(test))]
         {
             let sm = init_stack_map()?;
-            self.probes.reuse_map("stack_map", sm.as_fd().as_raw_fd())?;
-            self.probes.reuse_map("events_map", self.factory.map_fd())?;
+            self.probes
+                .builder_mut()?
+                .reuse_map("stack_map", sm.as_fd().as_raw_fd())?;
+            self.probes
+                .builder_mut()?
+                .reuse_map("events_map", self.factory.map_fd())?;
             match section_factories.get_mut(&ModuleId::Kernel) {
                 Some(kernel_factory) => {
                     kernel_factory
@@ -300,8 +301,12 @@ impl Collectors {
         // Start factory
         self.factory.start(section_factories)?;
 
-        // Attach probes and start collectors.
-        self.probes.attach()?;
+        // Attach probes and start collectors. We're using an open coded take &
+        // replace combination. We could use a Cell<> instead but that would
+        // complicate the use of self.probes (additional .get() calls) while
+        // behaving the same.
+        let probes = std::mem::take(&mut self.probes);
+        let _ = std::mem::replace(&mut self.probes, probes.into_runtime()?);
 
         for id in &self.loaded {
             let c = self
@@ -322,8 +327,8 @@ impl Collectors {
     /// their `stop()` function. All the collectors are in charge to clean-up
     /// their temporary side effects and exit gracefully.
     fn stop(&mut self) -> Result<()> {
-        self.probes.detach()?;
-        self.probes.report_counters()?;
+        self.probes.runtime_mut()?.detach()?;
+        self.probes.runtime_mut()?.report_counters()?;
 
         for id in &self.loaded {
             let c = self
@@ -486,7 +491,10 @@ impl SubCommandRunner for CollectRunner {
 mod tests {
     use super::*;
     use crate::{
-        core::events::{bpf::BpfRawSection, *},
+        core::{
+            events::{bpf::BpfRawSection, *},
+            probe::ProbeBuilderManager,
+        },
         event_section, event_section_factory,
         module::Module,
     };
@@ -504,7 +512,7 @@ mod tests {
         fn register_cli(&self, cli: &mut DynamicCommand) -> Result<()> {
             cli.register_module_noargs(ModuleId::Skb)
         }
-        fn init(&mut self, _: &CliConfig, _: &mut probe::ProbeManager) -> Result<()> {
+        fn init(&mut self, _: &CliConfig, _: &mut ProbeBuilderManager) -> Result<()> {
             Ok(())
         }
         fn start(&mut self) -> Result<()> {
@@ -531,7 +539,7 @@ mod tests {
         fn register_cli(&self, cli: &mut DynamicCommand) -> Result<()> {
             cli.register_module_noargs(ModuleId::Ovs)
         }
-        fn init(&mut self, _: &CliConfig, _: &mut probe::ProbeManager) -> Result<()> {
+        fn init(&mut self, _: &CliConfig, _: &mut ProbeBuilderManager) -> Result<()> {
             bail!("Could not initialize")
         }
         fn start(&mut self) -> Result<()> {
@@ -602,7 +610,7 @@ mod tests {
         group.register(ModuleId::Ovs, Box::new(DummyCollectorB::new()?))?;
 
         let mut collectors = Collectors::new(group)?;
-        let mut mgr = probe::ProbeManager::new()?;
+        let mut mgr = ProbeBuilderManager::new()?;
         let mut config = collectors.register_cli(get_cli()?)?;
 
         assert!(dummy_a.init(&config, &mut mgr).is_ok());

--- a/src/core/events/display.rs
+++ b/src/core/events/display.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, Default, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, clap::ValueEnum)]
 pub(crate) enum DisplayFormat {
     SingleLine,
     #[default]

--- a/src/core/events/events.rs
+++ b/src/core/events/events.rs
@@ -74,6 +74,17 @@ impl Event {
         }
     }
 
+    /// Get a reference to an event field by its owner and key.
+    pub(crate) fn get_section_mut<T: EventSection + 'static>(
+        &mut self,
+        owner: ModuleId,
+    ) -> Option<&mut T> {
+        match self.0.get_mut(&owner) {
+            Some(section) => section.as_any_mut().downcast_mut::<T>(),
+            None => None,
+        }
+    }
+
     pub(crate) fn to_json(&self) -> serde_json::Value {
         let mut event = serde_json::Map::new();
 
@@ -187,6 +198,7 @@ impl<T> EventSection for T where T: EventSectionInternal + for<'a> EventDisplay<
 /// There should not be a need to have per-object implementations for this.
 pub(crate) trait EventSectionInternal {
     fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
     fn to_json(&self) -> serde_json::Value;
 }
 
@@ -194,6 +206,10 @@ pub(crate) trait EventSectionInternal {
 // into an event could be mapped to (), e.g. serde_json::Value::Null.
 impl EventSectionInternal for () {
     fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 

--- a/src/core/probe/kernel/kernel.rs
+++ b/src/core/probe/kernel/kernel.rs
@@ -95,6 +95,12 @@ impl EventFmt for KernelEvent {
 #[derive(Default)]
 pub(crate) struct StackTrace(Vec<String>);
 
+impl StackTrace {
+    pub(crate) fn raw(&self) -> &Vec<String> {
+        &self.0
+    }
+}
+
 impl EventFmt for StackTrace {
     fn event_fmt(&self, f: &mut fmt::Formatter, format: DisplayFormat) -> fmt::Result {
         let last = self.0.len() - 1;

--- a/src/core/probe/kernel/mod.rs
+++ b/src/core/probe/kernel/mod.rs
@@ -23,7 +23,10 @@ pub(crate) mod kernel;
 pub(crate) use kernel::*;
 
 pub(crate) mod config;
+pub(crate) mod probe_stack;
+
 mod inspect;
+
 pub(in crate::core::probe) mod kprobe;
 pub(in crate::core::probe) mod kretprobe;
 pub(in crate::core::probe) mod raw_tracepoint;

--- a/src/core/probe/kernel/probe_stack.rs
+++ b/src/core/probe/kernel/probe_stack.rs
@@ -1,0 +1,129 @@
+#![cfg_attr(test, allow(unused_imports, unused_variables, unused_mut))]
+
+use std::collections::HashSet;
+
+use anyhow::Result;
+use btf_rs::Type;
+use log::{debug, warn};
+
+use crate::{
+    core::{
+        events::Event,
+        inspect::inspector,
+        kernel::Symbol,
+        probe::{kernel::KernelEvent, Probe, ProbeRuntimeManager},
+    },
+    module::ModuleId,
+};
+
+/// Probe-stack consume stack traces and add additional probes for compatible
+/// functions found there.
+pub(crate) struct ProbeStack {
+    /// Local cache of functions that were already considered, probed or not.
+    /// Used to optimize the event processing.
+    probes: HashSet<String>,
+    /// Should the stack stay in the event?
+    keep_stack: bool,
+    /// Set of kernel types known by collectors, so we only probe functions that
+    /// can generate an event.
+    known_kernel_types: HashSet<String>,
+}
+
+impl ProbeStack {
+    pub(crate) fn new(
+        keep_stack: bool,
+        attached_probes: Vec<String>,
+        known_kernel_types: HashSet<String>,
+    ) -> Self {
+        // Stack probe mode works with kprobes only and keeps track of the
+        // function name.
+        let attached_probes = attached_probes
+            .iter()
+            .filter_map(|p| p.strip_prefix("kprobe:"))
+            .map(|p| p.to_string())
+            .collect::<Vec<String>>();
+
+        Self {
+            probes: HashSet::from_iter(attached_probes),
+            keep_stack,
+            known_kernel_types,
+        }
+    }
+
+    /// Process a new event and detect additional functions to add a probe too.
+    /// This is called in the event retrieval logic and should try not to
+    /// propagate non-fatal errors.
+    pub(crate) fn process_event(
+        &mut self,
+        mgr: &mut ProbeRuntimeManager,
+        event: &mut Event,
+    ) -> Result<()> {
+        let kernel = match event.get_section_mut::<KernelEvent>(ModuleId::Kernel) {
+            Some(kernel) => kernel,
+            None => return Ok(()),
+        };
+        let stack = match &kernel.stack_trace {
+            Some(stack) => stack,
+            None => return Ok(()),
+        };
+
+        stack.raw().iter().try_for_each(|line| -> Result<()> {
+            let func = match line.split_once('+') {
+                Some((func, _)) => func,
+                _ => return Ok(()),
+            };
+
+            if self.probes.insert(func.to_string()) {
+                // Filter out functions not having a BTF representation.
+                let types = inspector()?.kernel.btf.resolve_types_by_name(func);
+                if types.is_err()
+                    || !types
+                        .unwrap()
+                        .iter()
+                        .any(|(_, t)| matches!(t, Type::Func(_)))
+                {
+                    return Ok(());
+                }
+
+                let symbol = match Symbol::from_name(func) {
+                    Ok(symbol) => symbol,
+                    _ => return Ok(()),
+                };
+
+                // Filter out symbols not operating on a type we can retrieve
+                // data from.
+                if !self
+                    .known_kernel_types
+                    .iter()
+                    .any(|t| match symbol.parameter_offset(t) {
+                        Ok(ret) => ret.is_some(),
+                        _ => false,
+                    })
+                {
+                    return Ok(());
+                }
+
+                let mut probe = match Probe::kprobe(symbol) {
+                    Ok(probe) => probe,
+                    _ => return Ok(()),
+                };
+
+                #[cfg(not(test))]
+                if let Err(e) = mgr.attach_generic_probe(&mut probe) {
+                    warn!("Could not attach additional probe {probe}: {e}");
+                    return Ok(());
+                }
+
+                debug!("Added probe to {}", func);
+            }
+
+            Ok(())
+        })?;
+
+        if !self.keep_stack {
+            kernel.stack_trace = None;
+        }
+
+        Ok(())
+    }
+}

--- a/src/core/probe/manager.rs
+++ b/src/core/probe/manager.rs
@@ -515,6 +515,11 @@ impl ProbeRuntimeManager {
         Self::attach_probe(builder, &mut self.config_map, &mut self.counters_map, probe)
     }
 
+    /// Get the list of all currently attached probes.
+    pub(crate) fn attached_probes(&self) -> Vec<String> {
+        self.probes.clone().into_iter().collect()
+    }
+
     /// Detach all probes.
     pub(crate) fn detach(&mut self) -> Result<()> {
         self.generic_builders

--- a/src/core/probe/mod.rs
+++ b/src/core/probe/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod kernel;
 
 pub(crate) mod manager;
 // Re-export manager
-pub(crate) use manager::{ProbeBuilderManager, ProbeManager, PROBE_MAX};
+pub(crate) use manager::*;
 
 #[allow(clippy::module_inception)]
 pub(crate) mod probe;

--- a/src/core/probe/mod.rs
+++ b/src/core/probe/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod kernel;
 
 pub(crate) mod manager;
 // Re-export manager
-pub(crate) use manager::{ProbeManager, PROBE_MAX};
+pub(crate) use manager::{ProbeBuilderManager, ProbeManager, PROBE_MAX};
 
 #[allow(clippy::module_inception)]
 pub(crate) mod probe;

--- a/src/core/probe/user/user.rs
+++ b/src/core/probe/user/user.rs
@@ -42,6 +42,17 @@ impl UsdtProbe {
         })
     }
 
+    /// Creates a dummy UsdtProbe. Using it like a valid one is buggy.
+    pub(crate) fn dummy() -> Self {
+        Self {
+            provider: "".to_string(),
+            name: "".to_string(),
+            ksym: 0,
+            path: PathBuf::new(),
+            pid: -1,
+        }
+    }
+
     /// Return a printable name.
     pub(crate) fn name(&self) -> String {
         format!("usdt:{}:{}", self.provider, self.name)

--- a/src/core/tracking/skb_tracking.rs
+++ b/src/core/tracking/skb_tracking.rs
@@ -92,7 +92,7 @@ use super::gc::TrackingGC;
 use crate::core::{
     kernel::Symbol,
     probe::{
-        manager::{ProbeManager, PROBE_MAX},
+        manager::{ProbeBuilderManager, PROBE_MAX},
         Probe, ProbeOption,
     },
 };
@@ -144,7 +144,7 @@ fn tracking_map() -> Result<libbpf_rs::MapHandle> {
 }
 
 pub(crate) fn init_tracking(
-    probes: &mut ProbeManager,
+    probes: &mut ProbeBuilderManager,
 ) -> Result<(TrackingGC, libbpf_rs::MapHandle)> {
     let config_map = config_map()?;
     let tracking_map = tracking_map()?;

--- a/src/module/ct/ct.rs
+++ b/src/module/ct/ct.rs
@@ -7,7 +7,7 @@ use crate::{
     core::{
         events::EventSectionFactory,
         inspect,
-        probe::{Hook, ProbeManager},
+        probe::{Hook, ProbeBuilderManager},
     },
     module::{Module, ModuleId},
 };
@@ -50,7 +50,7 @@ impl Collector for CtModule {
         Ok(())
     }
 
-    fn init(&mut self, _cli: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, _cli: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         // Register our generic conntrack hook.
         probes.register_kernel_hook(Hook::from(ct_hook::DATA))?;
         self.init = true;

--- a/src/module/nft/nft.rs
+++ b/src/module/nft/nft.rs
@@ -17,7 +17,7 @@ use crate::{
         events::EventSectionFactory,
         inspect,
         kernel::Symbol,
-        probe::{Hook, Probe, ProbeManager},
+        probe::{Hook, Probe, ProbeBuilderManager},
     },
     module::{Module, ModuleId},
 };
@@ -172,7 +172,7 @@ impl Collector for NftModule {
         Ok(())
     }
 
-    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         if self.install_chain {
             // Ignore if delete fails here as the table might not exist
             let _ = self.delete_table(NFT_TRACE_TABLE.to_owned());

--- a/src/module/ovs/ovs.rs
+++ b/src/module/ovs/ovs.rs
@@ -16,7 +16,7 @@ use crate::{
         events::EventSectionFactory,
         inspect,
         kernel::Symbol,
-        probe::{user::UsdtProbe, Hook, Probe, ProbeManager, ProbeOption},
+        probe::{user::UsdtProbe, Hook, Probe, ProbeBuilderManager, ProbeOption},
         signals::Running,
         tracking::gc::TrackingGC,
         user::proc::{Process, ThreadInfo},
@@ -92,7 +92,7 @@ impl Collector for OvsModule {
         Ok(())
     }
 
-    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         self.track = cli
             .get_section::<OvsCollectorArgs>(ModuleId::Ovs)?
             .ovs_track;
@@ -294,7 +294,7 @@ impl OvsModule {
     }
 
     /// Add upcall hooks.
-    fn add_upcall_hooks(&self, probes: &mut ProbeManager) -> Result<()> {
+    fn add_upcall_hooks(&self, probes: &mut ProbeBuilderManager) -> Result<()> {
         let inflight_upcalls_map = self
             .inflight_upcalls_map
             .as_ref()
@@ -331,7 +331,7 @@ impl OvsModule {
     }
 
     /// Add exec hooks.
-    fn add_exec_hooks(&mut self, probes: &mut ProbeManager) -> Result<()> {
+    fn add_exec_hooks(&mut self, probes: &mut ProbeBuilderManager) -> Result<()> {
         let inflight_exec_map = Self::create_inflight_exec_map()?;
 
         // ovs_execute_actions kprobe
@@ -366,7 +366,7 @@ impl OvsModule {
     }
 
     /// Add USDT hooks.
-    fn add_usdt_hooks(&mut self, probes: &mut ProbeManager) -> Result<()> {
+    fn add_usdt_hooks(&mut self, probes: &mut ProbeBuilderManager) -> Result<()> {
         let ovs = Process::from_cmd("ovs-vswitchd")?;
         if !ovs.is_usdt("main::run_start")? {
             bail!(

--- a/src/module/skb/skb.rs
+++ b/src/module/skb/skb.rs
@@ -12,7 +12,7 @@ use crate::{
     collect::Collector,
     core::{
         events::EventSectionFactory,
-        probe::{Hook, ProbeManager},
+        probe::{Hook, ProbeBuilderManager},
     },
     module::{Module, ModuleId},
 };
@@ -49,7 +49,7 @@ impl Collector for SkbModule {
         cmd.register_module::<SkbCollectorArgs>(ModuleId::Skb)
     }
 
-    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, cli: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         // First, get the cli parameters.
         let args = cli.get_section::<SkbCollectorArgs>(ModuleId::Skb)?;
 

--- a/src/module/skb_drop/skb_drop.rs
+++ b/src/module/skb_drop/skb_drop.rs
@@ -9,7 +9,7 @@ use crate::{
         events::EventSectionFactory,
         inspect::{inspector, kernel_version::KernelVersionReq},
         kernel::Symbol,
-        probe::{Hook, Probe, ProbeManager},
+        probe::{Hook, Probe, ProbeBuilderManager},
     },
     module::{Module, ModuleId},
 };
@@ -74,7 +74,7 @@ impl Collector for SkbDropModule {
         Ok(())
     }
 
-    fn init(&mut self, _: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, _: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         let mut probe = Probe::raw_tracepoint(Symbol::from_name("skb:kfree_skb")?)?;
         let hook = Hook::from(skb_drop_hook::DATA);
 

--- a/src/module/skb_tracking/skb_tracking.rs
+++ b/src/module/skb_tracking/skb_tracking.rs
@@ -6,7 +6,7 @@ use crate::{
     collect::Collector,
     core::{
         events::EventSectionFactory,
-        probe::{manager::ProbeManager, Hook},
+        probe::{manager::ProbeBuilderManager, Hook},
     },
     module::{Module, ModuleId},
 };
@@ -27,7 +27,7 @@ impl Collector for SkbTrackingModule {
         cmd.register_module_noargs(ModuleId::SkbTracking)
     }
 
-    fn init(&mut self, _: &CliConfig, probes: &mut ProbeManager) -> Result<()> {
+    fn init(&mut self, _: &CliConfig, probes: &mut ProbeBuilderManager) -> Result<()> {
         probes.register_kernel_hook(Hook::from(tracking_hook::DATA))
     }
 }


### PR DESCRIPTION
This enables collection to use a new "auto-probe" mode, working as follow: stack traces are requested and functions found in those stack traces are evaluated and additional probes are added if they fit the requirements. Using this mode can help building a list of probes to use for following a given flow. More details about the implementation in the commit messages.

Part of this series is another rework of the probe manager. But fear not, there is no big functional changes and the code is very close to what it was. But the logic is better defined and that allows additional things, such as runtime registration of probes.

This is based on a few patches that are in other PRs (btf-rs update patches mainly). This is fine as they're all targeted at an earlier milestone.

One future possibility is the generation of a profile at the end of the collection, so it could be reused once where to probe is known.

`$ retis collect -a -f 'icmp and host 1.1.1.1' --cmd 'ping 1.1.1.1'`

Fixes #88.