### PR TITLE
cli: add shell completion subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97aeaa95557bd02f23fbb662f981670c3d20c5a26e69f7354b28f57092437fcd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1153,7 @@ dependencies = [
  "byteorder",
  "caps",
  "clap",
+ "clap_complete",
  "elf",
  "flate2",
  "libbpf-cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ btf-rs = "1.0"
 byteorder = "1.5"
 caps = "0.5"
 clap = { version = "4.0", features = ["derive", "string"] }
+clap_complete = "4.4"
 elf = "0.7"
 flate2 = "1.0"
 libbpf-rs = "0.22"

--- a/docs/install.md
+++ b/docs/install.md
@@ -106,3 +106,10 @@ only and Retis won't be able to fully filter probes.
 $ sudo setcap cap_sys_admin,cap_bpf,cap_syslog=ep $(which retis)
 $ retis collect
 ```
+
+### Shell auto-completion
+
+Retis can generate completion files for shells (Bash, Zsh, Fish...).
+For example to enable auto-completion of Retis command in Bash, you can
+add line `source <(retis sh-complete --shell bash)` in .bashrc, then
+the command parameter could be auto-completed when pressing <Tab>.

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -93,9 +93,6 @@ pub(crate) trait SubCommand {
     /// subcommand-specific functionality.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
-    /// Generate the clap Command to be used for "thin" parsing.
-    fn thin(&self) -> Result<Command>;
-
     /// Generate the clap Command to be used for "full" parsing.
     ///
     /// This method should be called after all dynamic options have been registered.
@@ -158,10 +155,6 @@ where
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
-    }
-
-    fn thin(&self) -> Result<Command> {
-        Ok(<Self as clap::CommandFactory>::command())
     }
 
     fn full(&self) -> Result<Command> {
@@ -270,9 +263,9 @@ impl ThinCli {
             .disable_help_subcommand(true)
             .infer_subcommands(true)
             .subcommand_required(true);
-        // Add thin subcommands so that the main help shows them.
+        // Add full subcommands so that the main help shows them.
         for sub in self.subcommands.iter() {
-            command = command.subcommand(sub.thin().expect("thin command failed"));
+            command = command.subcommand(sub.full().expect("full command failed"));
         }
 
         // Determine the subcommand that was run while ignoring errors from yet-to-be-defined
@@ -458,9 +451,6 @@ mod tests {
         }
         fn as_any_mut(&mut self) -> &mut dyn Any {
             self
-        }
-        fn thin(&self) -> Result<Command> {
-            Ok(Command::new("sub1").about("does some things"))
         }
         fn full(&self) -> Result<Command> {
             Ok(Sub1::augment_args(

--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -19,6 +19,7 @@ use super::dynamic::DynamicCommand;
 use crate::benchmark::cli::Benchmark;
 use crate::{
     collect::cli::Collect,
+    generate::Complete,
     module::{ModuleId, Modules},
     process::cli::*,
     profiles::{cli::ProfileCmd, Profile},
@@ -386,6 +387,10 @@ impl FullCli {
     pub(crate) fn get_subcommand_mut(&mut self) -> Result<&mut dyn SubCommand> {
         Ok(self.subcommand.as_mut())
     }
+
+    pub(crate) fn get_command(&self) -> Command {
+        self.command.clone()
+    }
 }
 
 /// CliConfig represents the result of the Full CLI parsing
@@ -421,6 +426,7 @@ pub(crate) fn get_cli() -> Result<ThinCli> {
     cli.add_subcommand(Box::new(Sort::new()?))?;
     cli.add_subcommand(Box::new(Pcap::new()?))?;
     cli.add_subcommand(Box::new(ProfileCmd::new()?))?;
+    cli.add_subcommand(Box::new(Complete::new()?))?;
 
     #[cfg(feature = "benchmark")]
     cli.add_subcommand(Box::new(Benchmark::new()?))?;

--- a/src/collect/cli.rs
+++ b/src/collect/cli.rs
@@ -148,10 +148,6 @@ impl SubCommand for Collect {
         })
     }
 
-    fn thin(&self) -> Result<Command> {
-        Ok(Command::new("collect").about("Collect network events"))
-    }
-
     fn name(&self) -> String {
         "collect".to_string()
     }
@@ -180,7 +176,7 @@ impl SubCommand for Collect {
             .collectors
             .command()
             .to_owned()
-            .about("Collect events")
+            .about("Collect network events")
             .long_about(long_about)
             .mut_arg("collectors", |a| {
                 a.value_parser(PossibleValuesParser::new(possible_collectors.clone()))

--- a/src/generate/completion.rs
+++ b/src/generate/completion.rs
@@ -1,0 +1,98 @@
+//! # Completion
+//!
+//! Generate a completions file for a specified shell at runtime.
+
+use std::{any::Any, io::Write, path::PathBuf};
+
+use anyhow::Result;
+use clap::{
+    error::Error as ClapError,
+    {value_parser, ArgMatches, Command, Parser},
+};
+use clap_complete::{generate, Generator, Shell};
+
+use crate::{cli::*, module::Modules};
+
+/// Generate completion file for a specified shell
+#[derive(Parser, Debug, Default)]
+#[command(name = "sh-complete")]
+pub(crate) struct Complete {
+    /// Specify shell to complete for
+    // We use an Option and require the parameter to be set here to allow
+    // deriving Default on Complete.
+    #[arg(long, required = true, value_parser(value_parser!(Shell)))]
+    shell: Option<Shell>,
+
+    /// Path to write completion-registration to
+    #[arg(long)]
+    register: Option<PathBuf>,
+}
+
+impl SubCommand for Complete {
+    fn new() -> Result<Self>
+    where
+        Self: Sized,
+    {
+        Ok(Self::default())
+    }
+
+    fn name(&self) -> String {
+        <Self as clap::CommandFactory>::command()
+            .get_name()
+            .to_string()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn full(&self) -> Result<Command> {
+        Ok(<Self as clap::CommandFactory>::command())
+    }
+
+    fn update_from_arg_matches(&mut self, args: &ArgMatches) -> Result<(), ClapError> {
+        <Self as clap::FromArgMatches>::update_from_arg_matches(self, args)
+    }
+
+    fn runner(&self) -> Result<Box<dyn SubCommandRunner>> {
+        Ok(Box::new(CompleteRunner {}))
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct CompleteRunner {}
+
+impl SubCommandRunner for CompleteRunner {
+    fn check_prerequisites(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn run(&mut self, cli: FullCli, _modules: Modules) -> Result<()> {
+        let mut cmd = cli.get_command();
+        let matches = cli.get_command().get_matches();
+
+        if let Some(sub_m) = matches.subcommand_matches("sh-complete") {
+            if let Some(generator) = sub_m.get_one::<Shell>("shell") {
+                let mut buf = Vec::new();
+                let name = cmd.get_name().to_string();
+
+                generate(*generator, &mut cmd, name.clone(), &mut buf);
+                if let Some(out_path) = sub_m.get_one::<PathBuf>("register") {
+                    if out_path.is_dir() {
+                        let out_path = out_path.join(generator.file_name(&name));
+                        let _ = std::fs::write(out_path, buf);
+                    } else {
+                        let _ = std::fs::write(out_path, buf);
+                    }
+                } else {
+                    let _ = std::io::stdout().write_all(&buf);
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,0 +1,6 @@
+//! # Generate
+//!
+//! Generate a completions file for a specified shell at runtime.
+
+pub(crate) mod completion;
+pub(crate) use self::completion::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use log::{info, trace, warn, LevelFilter};
 mod cli;
 mod collect;
 mod core;
+mod generate;
 mod module;
 mod process;
 mod profiles;


### PR DESCRIPTION
As the clap_complete dynamic module is unstable and hard-codes the
subcommand as `complete`, which conflicts with the current `collect`
subcommand. Let's still use the legacy static way to generate the
completion file.

Usage:
$ retis generate -h
Generate completions file for a specified shell

Usage: retis generate [OPTIONS]

Options:
      --shell <SHELL>        Specify shell to complete for [possible values: bash, elvish, fish, powershell, zsh]
      --register <REGISTER>  Path to write completion-registration to
  -h, --help                 Print help

$ retis generate --shell bash --register .
$ source retis.bash

Close: #68
---
v5: Remove `fn thin()` from `impl SubCommand`. Update doc description.
v4: Update docs/install.md about how to auto-complete. Fix `collect` subcommand auto-completion.
v3: Rename subcommand to `sh-complete`. Move the generate.rs to new folder generate/completion.rs. Rename `struct Generate` to `struct Complete` as we rename generate.rs to completion.rs. 
v2: Use static generator as dynamic generator use hard-code parameter `complete`, which conflicts with `collect`.