### PR TITLE
Meta data: initial unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,7 @@ dependencies = [
  "serial_test",
  "signal-hook",
  "termcolor",
+ "test-case",
  "thiserror",
  "time 0.3.30",
 ]
@@ -1542,6 +1543,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+ "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ memmap2 = "0.9"
 [dev-dependencies]
 probe = "0.5"
 serial_test = "2.0"
+test-case = "3.2"

--- a/src/core/filters/meta/filter.rs
+++ b/src/core/filters/meta/filter.rs
@@ -288,6 +288,12 @@ fn walk_btf_node(btf: &Btf, r#type: &Type, node_name: &str, offset: u32) -> Opti
     for member in r#type.members.iter() {
         let fname = btf.resolve_name(member).unwrap();
         if fname.eq(node_name) {
+            if let Some(bfs) = member.bitfield_size() {
+                if bfs > 0 {
+                    return None;
+                }
+            }
+
             match btf.resolve_chained_type(member).ok() {
                 Some(ty) => return Some((offset + member.bit_offset(), ty)),
                 None => return None,
@@ -456,7 +462,7 @@ impl FilterMeta {
 
                     stored_offset = offset;
                 }
-                None => bail!("{field} not found!"),
+                None => bail!("{field} not found or is a bitfield!"),
             }
         }
 

--- a/src/process/series.rs
+++ b/src/process/series.rs
@@ -83,7 +83,7 @@ impl EventSorter {
             if self.series.iter().next().unwrap().0.skb.timestamp
                 < self
                     .untracked
-                    .get(0)
+                    .front()
                     .unwrap()
                     .get_section::<CommonEvent>(ModuleId::Common)
                     .map(|c| c.timestamp)


### PR DESCRIPTION
- picked the first patch from #328 (no reason that one over #329's other than order and avoiding creating a third version :)
- the second patch bails on bitfields match: there's no separate bail message, but it's fine as this is temporary and bitfields support is the next in line
- the third patch includes a bunch of tests