### PR TITLE
module: ovs: fix return value in raw tracepoint program

### DIFF
--- a/src/module/ovs/bpf/kernel_exec_actions.bpf.c
+++ b/src/module/ovs/bpf/kernel_exec_actions.bpf.c
@@ -10,7 +10,7 @@ DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 
 	skb = retis_get_sk_buff(ctx);
 	if (!skb)
-		return -1;
+		return 0;
 
 	queue_id = queue_id_gen_skb(skb);
 
@@ -25,9 +25,9 @@ DEFINE_HOOK(F_AND, RETIS_F_PACKET_PASS,
 	bpf_map_delete_elem(&flow_exec_tracking, &queue_id);
 	ectx.skb = skb;
 
-	if (!bpf_map_update_elem(&inflight_exec, &tid, &ectx, BPF_ANY)) {
-		return -1;
-	}
+	if (!bpf_map_update_elem(&inflight_exec, &tid, &ectx, BPF_ANY))
+		return 0;
+
 	return 0;
 )
 

--- a/src/module/ovs/bpf/kernel_upcall_tp.bpf.c
+++ b/src/module/ovs/bpf/kernel_upcall_tp.bpf.c
@@ -35,9 +35,8 @@ DEFINE_HOOK(F_AND, RETIS_ALL_FILTERS,
 	uctx.ts = ctx->timestamp;
 	uctx.cpu = upcall_event->cpu;
 
-	if (!bpf_map_update_elem(&inflight_upcalls, &tid, &uctx, BPF_ANY)) {
-		return -1;
-	}
+	if (!bpf_map_update_elem(&inflight_upcalls, &tid, &uctx, BPF_ANY))
+		return 0;
 
 	return 0;
 )


### PR DESCRIPTION
With the upcoming Linux v6.8 and commit c871d0e00f0e ("bpf: enforce precise retval range on program exit") returned value of programs are enforced to be in specific ranges. For tracepoints the range is [0, 0]; meaning programs should always return 0.

This is an issue in Retis as we load hooks as programs and they sometimes return non-0 values. When this happens and the hook is used in a raw tracepoint, the following error message is issued:

  At program exit the register R0 has smin=-1 smax=-1 should have been in [0, 0]

So far only a single hook is problematic, kernel_upcall_tp. For completeness, this patch also converts other kernel hooks to not return custom values. This fixes our runtime CI tests on Rawhide.

This alone is not sufficient. While returning custom errors is problematic even for Retis (those are not handled), we allow hooks to return -ENOMSG. This should be handled in another rework. Luckily the only user is quite contained for now and is a kprobe (nft module).