### PR TITLE
Add an authors file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,6 +44,16 @@ python_task:
     - python3 -m pip install black
     - python3 -m black --check --diff tests/*.py
 
+authors_task:
+  name: Authors file check
+  container:
+      image: debian:latest
+  setup_script:
+    - apt-get update
+    - apt-get -y install git
+  check_script:
+    - ./tools/authors.sh -c
+
 functional_task:
   # Run for PRs with a specific label
   required_pr_labels: run-functional-tests

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,10 @@
+# Authors
+
+Many thanks to everyone who contributed to Retis!
+
+In alphabetical order:
+- Adrian Moreno
+- Antoine Tenart
+- Daniel Mendes
+- Hangbin Liu
+- Paolo Valerio

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,6 +95,7 @@ flavor coding style for the BPF parts.
    1. `cargo clippy -- -D warnings`
    1. `make test V=1`, or to include runtime tests,
       `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=sudo CARGO_CMD_OPTS="--features=test_cap_bpf" make test V=1`
+   1. `./tools/authors.sh -c`
 1. Make sure commits are
    [signed off](https://www.kernel.org/doc/html/latest/process/submitting-patches.html?highlight=signed%20off#developer-s-certificate-of-origin-1-1).
 1. Use a clear, concise and descriptive title.

--- a/tools/authors.sh
+++ b/tools/authors.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+help() {
+	echo "Usage:"
+	echo "  $0 [opts]"
+	echo ""
+	echo "  Generate an alphabetically ordered list of authors and update the authors file"
+	echo ""
+	echo "  Options:"
+	echo "    -c		Checks the authors file is valid without modifying it."
+	echo "    -h		Show this help."
+}
+
+while getopts "ch" opt; do
+	case $opt in
+	c) check_only=1 ;;
+	*) help; exit ;;
+	esac
+done
+shift $(($OPTIND - 1))
+
+authors_file=$(git rev-parse --show-toplevel)/AUTHORS.md
+authors_list="$(git log --no-merges --format='%aN' | grep -v dependabot | sort -u)"
+
+out=$(cat <<-EOM
+# Authors
+
+Many thanks to everyone who contributed to Retis!
+
+In alphabetical order:
+- ${authors_list//$'\n'/\\n- }
+EOM
+)
+
+if [ "$check_only" == "1" ]; then
+	authors=$(cat $authors_file)
+	diff <(echo "$authors") <(echo -e "$out")
+else
+	echo -e "$out" > $authors_file
+fi


### PR DESCRIPTION
Add a script to auto-generate and check an AUTHORS.md file and add a CI job to check if the authors file is up-to-date so we don't miss new contributors.

Currently the authors file lists authors based on their git name in alphabetical order, which value depends on how the author configured its git name (could be name, first name, surname, random, etc). Feel free to make any suggestion if you feel this should be done otherwise (by # of commits, first contribution date[1], etc).

[1] Note: using `awk '!x[$0]++'` instead of `sort`.