### PR TITLE
Wait for all probes to be installed before starting the collection

### DIFF
--- a/src/core/probe/bpf/include/common_defs.h
+++ b/src/core/probe/bpf/include/common_defs.h
@@ -47,4 +47,12 @@ static __always_inline void err_report(u64 sym_addr, u32 pid)
 		__sync_fetch_and_add(&err_counters->dropped_events, 1);
 }
 
+#ifndef likely
+#define likely(x) __builtin_expect(!!(x), 1)
+#endif
+
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
 #endif /* __CORE_PROBE_COMMON_DEFS__ */

--- a/src/core/probe/bpf/include/common_defs.h
+++ b/src/core/probe/bpf/include/common_defs.h
@@ -8,6 +8,27 @@
 /* Keep in sync with its Rust counterpart in crate::core::probe */
 #define PROBE_MAX	1024
 
+/* Global probe configuration, shared between kernel and user probes. Please
+ * keep in sync with its Rust counterpart in crate::core::probe::common.
+ */
+struct retis_global_config {
+	u8 enabled;
+};
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 1);
+	__type(key, u8);
+	__type(value, struct retis_global_config);
+} global_config_map SEC(".maps");
+
+static __always_inline bool collection_enabled() {
+	struct retis_global_config *cfg;
+	u8 key = 0;
+
+	cfg = bpf_map_lookup_elem(&global_config_map, &key);
+	return cfg && !!cfg->enabled;
+}
+
 #define COMMON_SECTION_CORE	0
 #define COMMON_SECTION_TASK	1
 

--- a/src/core/probe/common.rs
+++ b/src/core/probe/common.rs
@@ -5,7 +5,31 @@ use anyhow::Result;
 
 use crate::core::probe::PROBE_MAX;
 
-// please keep in sync with its BPF counterpart in bpf/include/common_defs.h
+// Please keep in sync with its BPF counterpart in bpf/include/common_defs.h
+#[repr(C)]
+pub(crate) struct GlobalConfig {
+    pub(crate) enabled: u8,
+}
+unsafe impl plain::Plain for GlobalConfig {}
+
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn init_global_config_map() -> Result<libbpf_rs::MapHandle> {
+    let opts = libbpf_sys::bpf_map_create_opts {
+        sz: std::mem::size_of::<libbpf_sys::bpf_map_create_opts>() as libbpf_sys::size_t,
+        ..Default::default()
+    };
+
+    Ok(libbpf_rs::MapHandle::create(
+        libbpf_rs::MapType::Hash,
+        Some("global_config_map"),
+        std::mem::size_of::<u8>() as u32,
+        std::mem::size_of::<GlobalConfig>() as u32,
+        1,
+        &opts,
+    )?)
+}
+
+// Please keep in sync with its BPF counterpart in bpf/include/common_defs.h
 #[derive(Default)]
 #[repr(C)]
 pub(crate) struct CountersKey {
@@ -15,10 +39,9 @@ pub(crate) struct CountersKey {
     /// kernel as it is normally reserved the swapper task.
     pub(crate) pid: u64,
 }
-
 unsafe impl plain::Plain for CountersKey {}
 
-// please keep in sync with its BPF counterpart in bpf/include/common_defs.h
+// Please keep in sync with its BPF counterpart in bpf/include/common_defs.h
 /// Contains the counters of the error path.  This is then processed
 /// and reported from user-space. */
 #[derive(Default)]
@@ -26,7 +49,6 @@ unsafe impl plain::Plain for CountersKey {}
 pub(crate) struct Counters {
     pub(crate) dropped_events: u64,
 }
-
 unsafe impl plain::Plain for Counters {}
 
 #[cfg_attr(test, allow(dead_code))]

--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -210,9 +210,19 @@ static __always_inline int chain(struct retis_context *ctx)
 	 * event usage length read before and after the hook chain.
 	 */
 	struct common_task_event *ti;
+	static bool enabled = false;
 	volatile u16 pass_threshold;
 	struct common_event *e;
 	struct kernel_event *k;
+
+	/* Check if the collection is enabled, otherwise bail out. Once we have
+	 * a positive result, cache it.
+	 */
+	if (unlikely(!enabled)) {
+		enabled = collection_enabled();
+		if (!enabled)
+			return 0;
+	}
 
 	cfg = bpf_map_lookup_elem(&config_map, &ctx->ksym);
 	if (!cfg)


### PR DESCRIPTION
Not doing so lead to various issues such as:
- Inconsistency about what events are reported for a given flow.
- Tracking issues as not all tracking probes are installed (leading to unrelated flows sharing the same tracking id, or stalled entries in the tracking map).
    
This also opens the door for having other shared configuration options among all probes.
    
Fixes #312. Includes the same probe manager reworks as #309 but does not depend on it.