### PR TITLE
Remove no longer needed macro

### DIFF
--- a/src/module/ovs/bpf/include/ovs_common.h
+++ b/src/module/ovs/bpf/include/ovs_common.h
@@ -2,15 +2,9 @@
 #define __MODULE_OVS_COMMON__
 
 #include <bpf/bpf_core_read.h>
+#include <bpf/bpf_helpers.h>
 
 #include "jhash.h"
-
-/* <bpf/bpf_helpers.h> now includes the below definition, define it here if not
- * found for the time being to allow a smooth transition.
- */
-#ifndef barrier_var
-#define barrier_var(var) asm volatile("" : "=r"(var) : "0"(var))
-#endif
 
 /* Please keep in sync with its Rust counterpart in crate::module::ovs::bpf.rs. */
 enum trace_ovs_data_type {


### PR DESCRIPTION
The macro is provided by the header we consume.
There's no longer a need to define a local version.