### PR TITLE
Treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ CLANG := clang
 OBJCOPY := llvm-objcopy
 
 CARGO := cargo
+RUSTFLAGS ?= -D warnings
 RELEASE_VERSION = $(shell tools/localversion)
 RELEASE_NAME ?= $(shell $(CARGO) metadata --no-deps --format-version=1 | jq -r '.packages | .[] | select(.name=="retis") | .metadata.misc.release_name')
 
-export LLC CLANG OBJCOPY RELEASE_NAME RELEASE_VERSION
+export LLC CLANG OBJCOPY RELEASE_NAME RELEASE_VERSION RUSTFLAGS
 
 PRINT = echo
 

--- a/src/core/probe/manager.rs
+++ b/src/core/probe/manager.rs
@@ -124,6 +124,7 @@ impl ProbeManager {
                 Filter::Packet(magic, _) => {
                     filters::register_filter(*magic as u32, filter)?;
                 }
+                #[allow(unused_variables)]
                 Filter::Meta(ops) =>
                 {
                     #[cfg(not(test))]

--- a/src/core/probe/probe.rs
+++ b/src/core/probe/probe.rs
@@ -128,6 +128,7 @@ impl Probe {
     }
 
     /// Is this probe generic (aimed at hosting generic hooks only)?
+    #[cfg(not(test))]
     pub(crate) fn is_generic(&self) -> bool {
         self.hooks.is_empty() && self.supports_generic_hooks()
     }


### PR DESCRIPTION
Addressed a few warnings (test build) inadvertently introduced in a recent patch and enforces treating warnings as errors to prevent future oversights