### PR TITLE
Update btf-rs to 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,9 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "btf-rs"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b07a07ac6d874d5082be6b68f0e8ebe3c285405144ae384def5ee07574491d"
+checksum = "f1e4d11d3ab5f700c880746603ae231e62dcfdfd29a3a0977f6022a35fc50285"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ debug = ["dep:rbpf"]
 [dependencies]
 anyhow = "1.0"
 bimap = "0.6"
-btf-rs = "1.0"
+btf-rs = "1.1"
 byteorder = "1.5"
 caps = "0.5"
 clap = { version = "4.0", features = ["derive", "string"] }


### PR DESCRIPTION
`btf-rs` 1.1 has a fix where resolution of types by name was not working in rare cases. We could have encountered it while using user defined probes.