### PR TITLE
collect: support collect sub command auto complete

### DIFF
--- a/src/generate/completion.rs
+++ b/src/generate/completion.rs
@@ -50,7 +50,7 @@ impl SubCommand for Complete {
         self
     }
 
-    fn full(&self) -> Result<Command> {
+    fn full(&mut self) -> Result<Command> {
         Ok(<Self as clap::CommandFactory>::command())
     }
 


### PR DESCRIPTION
When generating the auto-complete file, we need to get full command parameters after `get_cli()?.build()`. But the collect subcommand only has a default collector setting at the first build round. It only generates all command parameters after running the subcommand specifically.

To generate all the parameters in the first round, we need to update the SubCommand full implementation to register all modules during building. With this, we can auto-complete all collect sub-parameters.

After update, there is no need to register again in command run.

At the same time, since we registered all modules during command build. In testing, if the collector only has a part of the modules, the init will fail with error "unknown collector {}". There is no need to initialize all collectors from args. We only need to initialize the collectors from the current modules.

---

Here is the output:

```Bash
# retis collect -<Tab>
-p                      -c                      --probe                 --filter-packet         --skb-sections          --help
-o                      -h                      --out                   --filter-meta           --nft-verdicts          
-f                      --stack                 --print                 --probe-stack           --ovs-track             
-m                      --cmd                   --format                --allow-system-changes  --collectors            
# retis collect --skb-sections <Tab>
all      eth      arp      ip       tcp      udp      icmp     dev      ns       meta     dataref  packet   
# retis collect --nft-verdicts <Tab>
all       continue  break     jump      goto      return    drop      accept    stolen    queue     repeat    
# retis collect --collectors <Tab>
skb-drop      skb           ct            nft           skb-tracking  ovs           
```