### PR TITLE
module: ovs: do not return -1 on usdt hook.

### DIFF
--- a/src/module/ovs/bpf/user_recv_upcall.bpf.c
+++ b/src/module/ovs/bpf/user_recv_upcall.bpf.c
@@ -45,7 +45,7 @@ DEFINE_USDT_HOOK (
 
 	batch = batch_process_recv(ctx->timestamp, queue_id, skip_event);
 	if (!batch)
-		return -1;
+		return 0;
 
 	if (skip_event)
 		return 0;


### PR DESCRIPTION
Recent kernels enforce certain return values for ebpf programs.

In the case of USDT probes, it seems this value is zero, so loading the current ovs module fails with:

    At program exit the register R0 has smin=-1 smax=-1 should have been in [0, 0]

Fix it by always returning 0.

More information about this here:
682c94be module: ovs: fix return value in raw tracepoint program

Fixes #366 