### PR TITLE
probe: add barrier to pass_threshold.

### DIFF
--- a/src/core/probe/kernel/bpf/include/common.h
+++ b/src/core/probe/kernel/bpf/include/common.h
@@ -279,6 +279,7 @@ static __always_inline int chain(struct retis_context *ctx)
 		k->stack_id = -1;
 
 	pass_threshold = get_event_size(event);
+	barrier_var(pass_threshold);
 
 /* Defines the logic to call hooks one by one.
  *

--- a/src/core/probe/user/bpf/usdt.bpf.c
+++ b/src/core/probe/user/bpf/usdt.bpf.c
@@ -101,6 +101,7 @@ int probe_usdt(struct pt_regs *ctx)
 	u->event_type = USDT;
 
 	pass_threshold = get_event_size(event);
+	barrier_var(pass_threshold);
 
 	/* UST only supports a single hook. */
 	hook0(&uctx, event);


### PR DESCRIPTION
It seems declaring the variable as volatile is not enough and it was being optimized.

Although it was only observed to be optimized out in the case of usdt probes, we use the exact same mechanism in kernel probes so also adding the barrier there to void discarding events.

Fixes #368 