### PR TITLE
Some authors file (logical) updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,16 +44,6 @@ python_task:
     - python3 -m pip install black
     - python3 -m black --check --diff tests/*.py
 
-authors_task:
-  name: Authors file check
-  container:
-      image: debian:latest
-  setup_script:
-    - apt-get update
-    - apt-get -y install git
-  check_script:
-    - ./tools/authors.sh -c
-
 functional_task:
   # Run for PRs with a specific label
   required_pr_labels: run-functional-tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
 1. Release a new version of `retis-derive` and `btf-rs` if needed.
 1. Release a new version on GitHub.
    1. Make sure the README is up-to-date (collectors, build instructions, etc).
+   1. Add new authors to the authors file if needed, by running
+      `./tools/authors.sh` and committing the changes.
    1. Update the version in `Cargo.toml`.
    1. Update the version name in `src/main.rs`.
    1. Run `cargo publish --dry-run` to check for any issue.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,7 +96,6 @@ flavor coding style for the BPF parts.
    1. `cargo clippy -- -D warnings`
    1. `make test V=1`, or to include runtime tests,
       `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER=sudo CARGO_CMD_OPTS="--features=test_cap_bpf" make test V=1`
-   1. `./tools/authors.sh -c`
 1. Make sure commits are
    [signed off](https://www.kernel.org/doc/html/latest/process/submitting-patches.html?highlight=signed%20off#developer-s-certificate-of-origin-1-1).
 1. Use a clear, concise and descriptive title.

--- a/tools/authors.sh
+++ b/tools/authors.sh
@@ -20,7 +20,7 @@ done
 shift $(($OPTIND - 1))
 
 authors_file=$(git rev-parse --show-toplevel)/AUTHORS.md
-authors_list="$(git log --no-merges --format='- %aN' | grep -v dependabot | sort -u)"
+authors_list="$(git log --no-merges --format='- %aN' | grep -v dependabot | sort -fu)"
 
 out=$(cat <<-EOM
 # Authors

--- a/tools/authors.sh
+++ b/tools/authors.sh
@@ -7,13 +7,13 @@ help() {
 	echo "  Generate an alphabetically ordered list of authors and update the authors file"
 	echo ""
 	echo "  Options:"
-	echo "    -c		Checks the authors file is valid without modifying it."
+	echo "    -n		Dry run (show what would be modified)."
 	echo "    -h		Show this help."
 }
 
-while getopts "ch" opt; do
+while getopts "hn" opt; do
 	case $opt in
-	c) check_only=1 ;;
+	n) dry_run=1 ;;
 	*) help; exit ;;
 	esac
 done
@@ -32,9 +32,9 @@ $authors_list
 EOM
 )
 
-if [ "$check_only" == "1" ]; then
+if [ "$dry_run" == "1" ]; then
 	authors=$(cat $authors_file)
-	diff <(echo "$authors") <(echo -e "$out")
+	diff -u <(echo "$authors") <(echo -e "$out")
 else
 	echo -e "$out" > $authors_file
 fi

--- a/tools/authors.sh
+++ b/tools/authors.sh
@@ -20,7 +20,7 @@ done
 shift $(($OPTIND - 1))
 
 authors_file=$(git rev-parse --show-toplevel)/AUTHORS.md
-authors_list="$(git log --no-merges --format='%aN' | grep -v dependabot | sort -u)"
+authors_list="$(git log --no-merges --format='- %aN' | grep -v dependabot | sort -u)"
 
 out=$(cat <<-EOM
 # Authors
@@ -28,7 +28,7 @@ out=$(cat <<-EOM
 Many thanks to everyone who contributed to Retis!
 
 In alphabetical order:
-- ${authors_list//$'\n'/\\n- }
+$authors_list
 EOM
 )
 


### PR DESCRIPTION
This makes first contributions easier for people. Also removes the burden from the contributors and makes us update the authors file (using a GH action).

Note that for this to work we must enable `Settings > Actions > General > Workflow permissions > Read and write permissions`. IMO that's OK, but feel free to disagree.

For an example of this in action, see https://github.com/atenart/test. Generated commits look like:

```
Author: github-actions <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Wed Apr 17 12:10:25 2024 +0000

    Update authors file
```