### PR TITLE
process: cli: drop path-clean dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,12 +1009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "path-clean"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
 name = "pcap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,7 +1280,6 @@ dependencies = [
  "nix 0.28.0",
  "once_cell",
  "pager",
- "path-clean",
  "pcap",
  "pcap-file",
  "plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ memoffset = "0.9"
 nix = { version = "0.28", features = ["feature", "time", "user"] }
 once_cell = "1.15"
 pager = "0.16"
-path-clean = "1.0"
 pcap = "2.0"
 pcap-file = "2.0"
 plain = "0.2"

--- a/src/process/cli/sort.rs
+++ b/src/process/cli/sort.rs
@@ -3,7 +3,6 @@
 //! Sort rearranges the events so they are grouped by skb tracking id (or OVS queue_id if present)
 
 use std::{
-    env,
     fs::OpenOptions,
     io::{stdout, BufWriter},
     path::PathBuf,
@@ -11,7 +10,6 @@ use std::{
 
 use anyhow::{bail, Result};
 use clap::Parser;
-use path_clean::PathClean;
 
 use crate::{
     cli::*,
@@ -79,19 +77,13 @@ impl SubCommandParserRunner for Sort {
         if let Some(out) = &self.out {
             let out = match out.canonicalize() {
                 Ok(out) => out,
-                // If the file doesn't exist we can't use fs::canonicalize() and
-                // need to clean it another way.
-                Err(_) => {
-                    let mut canonicalized = env::current_dir()?;
-                    // If out is an absolute directory, push() will replace the
-                    // current value.
-                    canonicalized.push(out.clean());
-                    canonicalized
-                }
+                // If the file doesn't exist we can't use fs::canonicalize() but it is not needed
+                // as that means it is not the input file.
+                Err(_) => out.clone(),
             };
 
             // Make sure we don't use the same file as the result will be the deletion of the
-            // original files.
+            // original files. If the input file doesn't exist we will raise an error.
             if out.eq(&self.input.canonicalize()?) {
                 bail!("Cannot sort a file in-place. Please specify an output file that's different to the input one.");
             }


### PR DESCRIPTION
Path-clean is a low-activity simple library that can be imported in our code directly to avoid adding it as a dependency. As we want to package Retis in Fedora we need to reduce the number of dependencies to the minimum possible, otherwise we would need to own and maintain them too in Fedora.