### PR TITLE
Meta adv matches

### DIFF
--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -70,10 +70,26 @@ INFO  L2 packet filter(s) loaded
 
 Metadata filtering instead allows to write filters that match packets based
 on their metadata.
-These filters can match against any subfield of the `sk_buff` and subsequent
-inner data structures.
+These filters can match against any subfield of the `sk_buff` and
+subsequent inner data structures.
 Meta filtering also automatically follows struct pointers, so indirect access to
 structures pointed by an `sk_buff` field is possible.
+A filter expression is represented by the pseudo EBNF grammar below:
+
+```none
+EXPR ::= LHS ' ' OP_RHS | LHS
+OP_RHS ::= OP ' ' RHS_NUM | EQ_NE ' ' RHS_STR
+LHS ::= 'sk_buff' MEMBER
+MEMBER ::= IDENTIFIER MEMBER | IDENTIFIER
+IDENTIFIER ::= '.' #'[a-zA-Z_][a-zA-Z0-9_]*'
+OP ::= EQ_NE | '<' | '<=' | '>' | '>='
+EQ_NE ::= '==' | '!='
+RHS_STR ::= '"' ASCII '"' | '\'' ASCII '\''
+ASCII ::= #'[:ascii:]*'
+RHS_NUM ::= #'0x[a-fA-F0-9]+' | ('-')? #'[0-9]+'
+```
+
+An example of filter that respect a previous definition is:
 
 ```none
 $ retis collect -m 'sk_buff.dev.nd_net.net.ns.inum == 4026531840'
@@ -86,6 +102,7 @@ The comparison operators are:
 2. "!=" for *not equal to*
 3. "<" and "<=" for *less than* and *less than or equal to*
 4. ">" and ">=" for *greater than* and *greater than or equal to*
+5. if OP and RHS are omitted, a *not equal to* zero numeric comparison is assumed
 
 At the moment, only number and string comparisons are supported.
 The right-hand side (rhs) of numeric matches must be expressed as

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -80,8 +80,9 @@ A filter expression is represented by the pseudo EBNF grammar below:
 EXPR ::= LHS ' ' OP_RHS | LHS
 OP_RHS ::= OP ' ' RHS_NUM | EQ_NE ' ' RHS_STR
 LHS ::= 'sk_buff' MEMBER
-MEMBER ::= IDENTIFIER MEMBER | IDENTIFIER
-IDENTIFIER ::= '.' #'[a-zA-Z_][a-zA-Z0-9_]*' (':' MASK)?
+MEMBER ::= NEXTIDENT MEMBER | NEXTIDENT
+NEXTIDENT ::= '.' IDENT (':' MASK (':' IDENT)?)?
+IDENT ::= #'[a-zA-Z_][a-zA-Z0-9_]*'
 OP ::= EQ_NE | '<' | '<=' | '>' | '>='
 EQ_NE ::= '==' | '!='
 MASK ::= ('~')? MASK_NUM
@@ -146,6 +147,21 @@ $ retis collect -m 'sk_buff.dev.name == "eth0"'
 
 The example above shows how strings can be matched and how they are
 required to be quoted.
+
+Another useful feature meta filtering expose is the ability to follow
+pointers embedded in members with a different defined type.
+For example, the filter below:
+
+```none
+$ retis collect -m sk_buff._nfct:~0x7:nf_conn.mark
+...
+```
+
+is equivalent to the following:
+
+```none
+(nf_conn *)(skb->_nfct & NFCT_PTRMASK)->mark != 0
+```
 
 Metadata filtering, being a BTF-based way of filtering, is theoretically
 not limited to `sk_buff`, so from a generic point of view it can support

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,0 +1,129 @@
+# Filtering
+
+Retis offers two distinct methods for filtering packets, both of which
+can operate simultaneously:
+
+- packet-based filtering which filters packets based on their content
+  (headers).
+- metadata-based filtering which filters packets based on their
+  associated metadata.
+
+These filtering mechanisms ensure that only relevant packets are
+reported, so reducing the volume of uninteresting events and
+improving the efficiency of packet tracing.
+
+## Packet
+
+Packet filtering uses a pcap-filter syntax. See `man pcap-filter` for an
+overview on the syntax. Upon execution the pcap-filter gets compiled in cBPF
+and subsequently translated into an eBPF program which in turn gets consumed by
+the probes.
+
+```none
+$ retis collect -f 'tcp port 443'
+...
+```
+
+Packet filtering can be of two types: L2 and L3. Retis automatically detects and
+generates L2/L3 filters based on the expression. This allows to match both packets
+fully formed and packets not having a valid L2 header yet (`sk_buff` having invalid
+`mac_header` but valid and set `network_header`). One advantage of this approach is
+the ability to match locally generated packets while still allowing matches based
+on L2 criteria.
+
+For example, the following filter:
+
+```none
+$ retis collect -f 'arp or tcp port 443'
+L2+L3 packet filter(s) loaded
+...
+```
+
+Internally generates two filters. For probes where only the `network_header`
+is valid and set in the `sk_buff` the filter would match packets with tcp
+source or destination port 443. For `sk_buff` with valid `mac_header` both arp
+and tcp packets would be matched.
+Please note that some limitations exist and they are a direct consequence of
+libpcap capabilities.
+For example filters like:
+
+```none
+$ retis collect -f 'ether broadcast or tcp port 443'
+L2 packet filter(s) loaded
+...
+```
+
+Will only generate L2 filters, that is, packets will be matched only if
+`mac_header` is set.
+For further information about the reason an L3 filter gets skipped, please
+use the `--log-level debug` option, i.e.:
+
+```none
+$ retis --log-level debug collect -f 'ether broadcast or tcp port 443'
+...
+DEBUG Skipping L3 filter generation (Could not compile the filter: libpcap error: not a broadcast link).
+INFO  L2 packet filter(s) loaded
+...
+```
+
+## Metadata
+
+Metadata filtering instead allows to write filters that match packets based
+on their metadata.
+These filters can match against any subfield of the `sk_buff` and subsequent
+inner data structures.
+Meta filtering also automatically follows struct pointers, so indirect access to
+structures pointed by an `sk_buff` field is possible.
+
+```none
+$ retis collect -m 'sk_buff.dev.nd_net.net.ns.inum == 4026531840'
+...
+```
+
+The comparison operators are:
+
+1. "==" for *equal to*
+2. "!=" for *not equal to*
+3. "<" and "<=" for *less than* and *less than or equal to*
+4. ">" and ">=" for *greater than* and *greater than or equal to*
+
+At the moment, only number and string comparisons are supported.
+The right-hand side (rhs) of numeric matches must be expressed as
+literal and can be represented in either base 10 or base 16, with the
+latter starting with `0x` prefix.
+All the comparison operators support numbers (both signed and unsigned).
+Bitfields are supported as well (both signed and unsigned) and they
+are treated as regular numbers.
+
+For strings only the operators *equal to* and *not equal to* are supported,
+furthermore, the string (rhs) must be enclosed between *quotes*.
+
+```none
+$ retis collect -m 'sk_buff.dev.name == "eth0"'
+...
+```
+
+The example above shows how strings can be matched and how they are
+required to be quoted.
+
+Metadata filtering, being a BTF-based way of filtering, is theoretically
+not limited to `sk_buff`, so from a generic point of view it can support
+all filters under the form *struct_type_name.field1.field2.field3* with
+the above constraints, but for the time being only `struct sk_buff` is
+supported.
+This implies that the `sk_buff` keyword **MUST** always be present and **MUST**
+always appear first.
+
+It is possible to combine packet and meta filtering, and doing so is just a
+matter of specifying their respective options and filters.
+
+```none
+$ retis collect -f 'tcp port 443' -m 'sk_buff.dev.name == "eth0"'
+...
+```
+
+The above options will be concatenated, meaning that both filters must match
+in order to have a match and generate events for packets.
+
+Meta filtering has some known limitations, in particular only one
+field at the time can be matched.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ repo_url: https://github.com/retis-org/retis
 nav:
   - Overview: index.md
   - Profiles: profiles.md
+  - Filtering: filtering.md
   - Installation: install.md
   - Requirements: requirements.md
   - Contributing: CONTRIBUTING.md

--- a/retis/src/core/filters/meta/bpf/include/meta_filter.h
+++ b/retis/src/core/filters/meta/bpf/include/meta_filter.h
@@ -29,6 +29,7 @@ union retis_meta_op {
 		u8 nmemb;
 		u16 offt;
 		u8 bf_size;
+		u64 mask;
 	} l;
 	struct {
 		u8 md[META_TARGET_MAX];
@@ -61,6 +62,8 @@ struct retis_meta_ctx {
 	void *data;
 	/* size of data (optional). */
 	u8 sz;
+	/* mask for unsigned num comparison. */
+	u64 mask;
 	/* operation. */
 	u8 cmp;
 };
@@ -111,6 +114,7 @@ static __always_inline long meta_process_ops(struct retis_meta_ctx *ctx)
 		/* Non intermediate */
 		ctx->offset = val->l.offt;
 		ctx->type = val->l.type;
+		ctx->mask = val->l.mask;
 		ctx->nmemb = val->l.nmemb;
 		ctx->bfs = val->l.bf_size;
 	}
@@ -119,8 +123,11 @@ static __always_inline long meta_process_ops(struct retis_meta_ctx *ctx)
 }
 
 static __always_inline
-bool cmp_num(u64 operand1, u64 operand2, bool sign_bit, u8 cmp_type)
+bool cmp_num(u64 operand1, u64 mmask, u64 operand2, bool sign_bit, u8 cmp_type)
 {
+	if (!sign_bit && mmask)
+		operand1 &= mmask;
+
 	switch (cmp_type) {
 	case RETIS_EQ:
 		return (operand1 == operand2);
@@ -278,7 +285,7 @@ unsigned int filter_num(struct retis_meta_ctx *ctx)
 
 	tval = *((u64 *)ctx->data);
 
-	return cmp_num(mval, tval, sign_bit, ctx->cmp);
+	return cmp_num(mval, ctx->mask, tval, sign_bit, ctx->cmp);
 }
 
 static __always_inline

--- a/retis/src/core/filters/meta/bpf/include/meta_filter.h
+++ b/retis/src/core/filters/meta/bpf/include/meta_filter.h
@@ -107,7 +107,8 @@ static __always_inline long meta_process_ops(struct retis_meta_ctx *ctx)
 						  (char *)ctx->base + (val->l.offt)))
 				return -1;
 
-			ctx->base = (void *)ptr;
+			ctx->base = val->l.mask ? (void *)(ptr & val->l.mask)
+				                : (void *)ptr;
 			continue;
 		}
 

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -391,7 +391,10 @@ impl FilterMeta {
             | Type::Restrict(_)
             | Type::DeclTag(_)
             | Type::TypeTag(_) => (),
-            _ => bail!("unexpected type ({})", t.name()),
+            _ => bail!(
+                "unexpected type ({}) while walking struct members",
+                t.name()
+            ),
         };
 
         Ok(false)

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -496,7 +496,7 @@ impl FilterMeta {
                         stored_bf_size = bfs;
                     }
                 }
-                None => bail!("{field} not found or is a bitfield!"),
+                None => bail!("{field} not found!"),
             }
         }
 

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -545,7 +545,7 @@ mod tests {
     }
 
     #[test_case("==" ; "op is eq")]
-    #[test_case("!=" ; "op is neq")]
+    #[test_case("!=" ; "op is ne")]
     #[test_case("<" ; "op is lt")]
     #[test_case("<=" ; "op is le")]
     #[test_case(">" ; "op is gt")]
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[test_case("==", MetaCmp::Eq ; "op is eq")]
-    #[test_case("!=", MetaCmp::Ne ; "op is neq")]
+    #[test_case("!=", MetaCmp::Ne ; "op is ne")]
     fn meta_filter_string(op_str: &'static str, op: MetaCmp) {
         let filter =
             FilterMeta::from_string(format!("sk_buff.dev.name {op_str} 'dummy0'").to_string())
@@ -600,7 +600,7 @@ mod tests {
     }
 
     #[test_case("==", MetaCmp::Eq ; "op is eq")]
-    #[test_case("!=", MetaCmp::Ne ; "op is neq")]
+    #[test_case("!=", MetaCmp::Ne ; "op is ne")]
     #[test_case("<", MetaCmp::Lt ; "op is lt")]
     #[test_case("<=", MetaCmp::Le ; "op is le")]
     #[test_case(">", MetaCmp::Gt ; "op is gt")]
@@ -628,7 +628,7 @@ mod tests {
     }
 
     #[test_case("==", MetaCmp::Eq ; "op is eq")]
-    #[test_case("!=", MetaCmp::Ne ; "op is neq")]
+    #[test_case("!=", MetaCmp::Ne ; "op is ne")]
     #[test_case("<", MetaCmp::Lt ; "op is lt")]
     #[test_case("<=", MetaCmp::Le ; "op is le")]
     #[test_case(">", MetaCmp::Gt ; "op is gt")]

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -70,7 +70,7 @@ struct MetaTarget {
 }
 
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct MetaLoad {
     // Type of data we're going to load
     // bit 0-4: [char|short|int|long], bit5: reserved, bit6: is_ptr, bit7: sign
@@ -760,5 +760,22 @@ mod tests {
         assert!(meta_target.md.iter().all(|&x| x == 0));
 
         Ok(())
+    }
+
+    #[test_case("dev.name:~0x00" => matches Err(_); "string failure")]
+    #[test_case("dev:~0x00.mtu" => matches Ok(l) if l == MetaLoad { r#type: PTR_BIT, nmemb: 0, offt: 16, bf_size: 0, mask: !0x00 }; "pointer")]
+    #[test_case("mark:0xff" => matches Ok(l) if l == MetaLoad { r#type: MetaType::Int as u8, nmemb: 0, offt: 168, bf_size: 0, mask: 0xff }; "u32")]
+    #[test_case("mark:0x0" => matches Err(_); "zero hex mask failure")]
+    #[test_case("mark:~0xffffffffffffffff" => matches Err(_); "bitwise not u64 hex mask failure")]
+    #[test_case("mark:0b00" => matches Err(_); "zero bin mask failure")]
+    #[test_case("mark:0" => matches Err(_); "mask format failure")]
+    #[test_case("headers.skb_iif:0xbad" => matches Err(_); "signed int failure")]
+    #[test_case("pkt_type:0x2" => matches Ok(l) if l == MetaLoad { r#type: MetaType::Char as u8, nmemb: 0, offt: 1024, bf_size: 3, mask: 0x2 }; "unsigned bitfield")]
+    #[test_case("pkt_type:0b10" => matches Ok(l) if l == MetaLoad { r#type: MetaType::Char as u8, nmemb: 0, offt: 1024, bf_size: 3, mask: 0x2 }; "binary unsigned bitfield")]
+    #[test_case("pkt_type:~0b10" => matches Ok(l) if l == MetaLoad { r#type: MetaType::Char as u8, nmemb: 0, offt: 1024, bf_size: 3, mask: !0x2 }; "bitwise not binary unsigned bitfield")]
+    fn meta_filter_masks(expr: &'static str) -> Result<MetaLoad> {
+        let filter = FilterMeta::from_string(format!("sk_buff.{expr}").to_string())?;
+
+        Ok(filter.0[1].load_ref().clone())
     }
 }

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -739,4 +739,23 @@ mod tests {
         );
         assert_eq!(target, 1);
     }
+
+    // Only validates for what type of targets lhs-only expressions
+    // are allowed. The offset extraction is not required as it is
+    // already performed by previous tests.
+    #[test_case("dev" => matches Err(_); "pointer")]
+    #[test_case("dev.name" => matches Err(_); "string failure")]
+    #[test_case("headers" => matches Err(_); "named struct failure")]
+    #[test_case("mark" => matches Ok(_); "u32")]
+    #[test_case("headers.skb_iif" => matches Ok(_); "signed int")]
+    #[test_case("cloned" => matches Ok(_); "unsigned bitfield")]
+    fn meta_filter_lhs_only(field: &'static str) -> Result<()> {
+        let filter = FilterMeta::from_string(format!("sk_buff.{field}").to_string())?;
+        let meta_target = filter.0[0].target_ref();
+
+        assert_eq!(meta_target.cmp, MetaCmp::Ne as u8);
+        assert!(meta_target.md.iter().all(|&x| x == 0));
+
+        Ok(())
+    }
 }

--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -471,10 +471,14 @@ impl FilterMeta {
     // into rhs op and lhs.
     // Requires spaces as separator among elements.
     fn parse_filter(filter: &str) -> Result<(Vec<LhsNode>, MetaCmp, &str)> {
-        let Ok([lhs, op, rhs]): Result<[&str; 3], _> =
-            filter.split(' ').collect::<Vec<_>>().try_into()
-        else {
-            bail!("invalid filter format");
+        let expr = filter.split(' ').collect::<Vec<_>>();
+
+        let [lhs, op, rhs]: [&str; 3] = match expr.len() {
+            3 => expr
+                .try_into()
+                .map_err(|_| anyhow!("cannot split filter ({filter})"))?,
+            1 => [expr[0], "!=", "0"],
+            _ => bail!("invalid filter ({filter})"),
         };
 
         let lhs: Vec<_> = lhs


### PR DESCRIPTION
Implements  #317 plus lhs-only expressions.
- Needs unit tests.
- The doc needs some improvements
  - pseudo-EBNF requires some improvements (e.g. split numeric and string-only ops)
  - alternatively, pseudo-EBNF could be replaced by simple generic examples (which could be easier for the user to use as reference)
  
Turned into RFC.
Everything is open to discussion including:
- syntax for mask and cast (slight preference to keep it simple :)
- doc (see above)
- have a local version with some tests (I will update as soon as I find some time)