### PR TITLE
Cargo.toml: use pnet_packet directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,15 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnetwork"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,39 +1108,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
-name = "pnet"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130c5b738eeda2dc5796fe2671e49027e6935e817ab51b930a36ec9e6a206a64"
-dependencies = [
- "ipnetwork",
- "pnet_base",
- "pnet_datalink",
- "pnet_packet",
- "pnet_sys",
- "pnet_transport",
-]
-
-[[package]]
 name = "pnet_base"
 version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cf6fb3ab38b68d01ab2aea03ed3d1132b4868fa4e06285f29f16da01c5f4c"
 dependencies = [
  "no-std-net",
-]
-
-[[package]]
-name = "pnet_datalink"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5854abf0067ebbd3967f7d45ebc8976ff577ff0c7bd101c4973ae3c70f98fe"
-dependencies = [
- "ipnetwork",
- "libc",
- "pnet_base",
- "pnet_sys",
- "winapi",
 ]
 
 [[package]]
@@ -1183,28 +1147,6 @@ dependencies = [
  "pnet_base",
  "pnet_macros",
  "pnet_macros_support",
-]
-
-[[package]]
-name = "pnet_sys"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417c0becd1b573f6d544f73671070b039051e5ad819cc64aa96377b536128d00"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "pnet_transport"
-version = "0.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2637e14d7de974ee2f74393afccbc8704f3e54e6eb31488715e72481d1662cc3"
-dependencies = [
- "libc",
- "pnet_base",
- "pnet_packet",
- "pnet_sys",
 ]
 
 [[package]]
@@ -1351,7 +1293,7 @@ dependencies = [
  "pcap",
  "pcap-file",
  "plain",
- "pnet",
+ "pnet_packet",
  "probe",
  "rbpf",
  "regex",

--- a/retis/Cargo.toml
+++ b/retis/Cargo.toml
@@ -47,7 +47,7 @@ pager = "0.16"
 pcap = "1.3"
 pcap-file = "2.0"
 plain = "0.2"
-pnet = "0.34"
+pnet_packet = "0.34"
 rbpf = {version = "0.2", optional = true}
 regex = "1.7"
 retis-derive = {version = "1.4", path = "../retis-derive"}

--- a/retis/src/module/skb/bpf.rs
+++ b/retis/src/module/skb/bpf.rs
@@ -8,7 +8,7 @@ use anyhow::bail;
 use std::str;
 
 use anyhow::{anyhow, Result};
-use pnet::packet::{
+use pnet_packet::{
     arp::ArpPacket, ethernet::*, icmp::IcmpPacket, icmpv6::Icmpv6Packet, ip::*, ipv4::*, ipv6::*,
     tcp::TcpPacket, udp::UdpPacket, Packet,
 };


### PR DESCRIPTION
pnet is a thin re-export of pnet_base, pnet_sys, pnet_datalink, pnet_transport and pnet_packet.

We only use the last package so pointing directly to it makes our dependency smaller and packaging easier.