### PR TITLE
core: events: bpf: do not exit polling thread on EINTR

### DIFF
--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -153,11 +153,10 @@ impl BpfEventsFactory {
                         // ringbuffer. This could normally be
                         // triggered by an actual interruption
                         // (signal) or artificially from the
-                        // callback. Exit without printing any error.
+                        // callback. Do not print any error.
                         libbpf_rs::ErrorKind::Interrupted => (),
                         _ => error!("Unexpected error while polling ({e})"),
                     }
-                    break;
                 }
             }
         }))


### PR DESCRIPTION
While polling the ringbuffer -EINTR can be returned on various occasions. Some are valid reasons to exit the polling thread (^C, running state info from rb handler, etc) but some are not (^Z). We can safely omit explicitly breaking the polling loop as it already depends on Running.

Fixes #397.

Fixes: 95a690e99fdd ("allow to gracefully interrupt the tool.")