### PR TITLE
Makefile: augment RUSTFLAGS globally in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endef
 debug: ebpf
 	$(call build, build, building retis (debug))
 
-release: RUSTFLAGS += -D warnings
+release: $(eval RUSTFLAGS += -D warnings)
 release: ebpf
 	$(call build, build --release, building retis (release))
 


### PR DESCRIPTION
Add the warnings flag to RUSTFLAGS globally in the release target to prevent targets depending on this one to build Retis again when executed.

For example `make install` was unconditionally rebuilding Retis even if a release build was done before, this was because the RUSTFLAGS differed between the targets. We now set it for all future targets, so the build states are consistent.