### PR TITLE
Improve event formatting

### DIFF
--- a/retis-events/src/common.rs
+++ b/retis-events/src/common.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use chrono::{DateTime, Utc};
 
-use crate::{event_section, event_type, *};
+use crate::*;
 
 /// Startup event section. Contains global information about a collection as a
 /// whole, with data gathered at collection startup time.
@@ -15,7 +15,7 @@ pub struct StartupEvent {
 }
 
 impl EventFmt for StartupEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(f, "Retis version {}", self.retis_version)
     }
 }
@@ -44,7 +44,7 @@ pub struct CommonEvent {
 }
 
 impl EventFmt for CommonEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result {
         match format.time_format {
             TimeFormat::MonotonicTimestamp => write!(f, "{}", self.timestamp)?,
             TimeFormat::UtcDate => match format.monotonic_offset {

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::*;
-use crate::{event_section, event_type};
+use crate::{event_section, event_type, Formatter};
 
 #[event_type]
 #[derive(Default)]
@@ -128,7 +128,7 @@ pub struct CtConnEvent {
 }
 
 impl EventFmt for CtEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         use CtState::*;
         match self.state {
             Established => write!(f, "ct_state ESTABLISHED ")?,
@@ -152,7 +152,7 @@ impl EventFmt for CtEvent {
 }
 
 impl CtEvent {
-    fn format_conn(conn: &CtConnEvent, f: &mut fmt::Formatter) -> fmt::Result {
+    fn format_conn(conn: &CtConnEvent, f: &mut Formatter) -> fmt::Result {
         match (&conn.orig.proto, &conn.reply.proto) {
             (CtProto::Tcp(tcp_orig), CtProto::Tcp(tcp_reply)) => {
                 write!(

--- a/retis-events/src/display.rs
+++ b/retis-events/src/display.rs
@@ -1,4 +1,9 @@
-use std::fmt;
+use std::{
+    fmt::{self, Write},
+    result, str,
+};
+
+use log::warn;
 
 use super::TimeSpec;
 
@@ -45,6 +50,165 @@ impl DisplayFormat {
     }
 }
 
+/// `Formatter` implements `std::fmt::Write` and controls how events are being
+/// displayed.  This is similar to `std::fmt::Formatter` but with our own
+/// constraints.
+///
+/// It supports the following capabilities: indentation and itemization. Each of
+/// those are always context-based: the capabilities and their configuration can
+/// change over time and might end based on input (eg. itemization).
+pub struct Formatter<'a, 'inner> {
+    inner: &'a mut fmt::Formatter<'inner>,
+    pub conf: FormatterConf,
+    /// Indentation level (in spaces).
+    level: usize,
+    /// True if the next input is the start of a block (aka. first call to
+    /// `flush_buf`).
+    first: bool,
+    /// True if the next input is the start of a line.
+    start: bool,
+    /// Buffer holding the output before being flushed.
+    buf: String,
+}
+
+impl<'a, 'inner> Formatter<'a, 'inner> {
+    pub fn new(
+        inner: &'a mut fmt::Formatter<'inner>,
+        conf: FormatterConf,
+    ) -> Formatter<'a, 'inner> {
+        let level = conf.level;
+
+        Self {
+            inner,
+            conf,
+            level,
+            first: true,
+            start: true,
+            buf: String::with_capacity(4096usize),
+        }
+    }
+
+    /// Directly implement write_fmt to avoid the need of an explicit
+    /// `use fmt::Write` by every user. See the `std::write` documentation.
+    #[inline]
+    pub fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> result::Result<(), fmt::Error> {
+        <Self as fmt::Write>::write_fmt(self, args)
+    }
+
+    pub fn flush_buf(&mut self) -> result::Result<(), fmt::Error> {
+        let first = self.first;
+        match self.buf.is_empty() {
+            true => return Ok(()),
+            false => self.first = false,
+        }
+
+        let mut lines = self.buf.split('\n');
+
+        // Compute the prefix including the itemization char, if any.
+        let mut prefix = " ".repeat(self.level);
+        if first && self.level >= 2 {
+            if let Some(item) = self.conf.item {
+                prefix.replace_range(self.level - 2..self.level - 1, &item.to_string());
+            }
+        }
+
+        if let Some(line) = lines.next() {
+            if self.start {
+                self.start = false;
+                self.inner.write_str(&prefix)?;
+            }
+            self.inner.write_str(line)?;
+        }
+
+        // Reset the itemization char, if any.
+        if first && self.level >= 2 && self.conf.item.is_some() {
+            prefix = " ".repeat(self.level);
+        }
+
+        lines.try_for_each(|line| {
+            self.inner.write_char('\n')?;
+            self.inner.write_str(&prefix)?;
+            self.inner.write_str(line)
+        })?;
+
+        if self.buf.ends_with('\n') {
+            self.inner.write_char('\n')?;
+            self.start = true;
+        }
+
+        self.buf.clear();
+        Ok(())
+    }
+}
+
+impl fmt::Write for Formatter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> result::Result<(), fmt::Error> {
+        if self.conf.level != self.level {
+            if !self.buf.is_empty() {
+                self.flush_buf()?;
+            }
+            self.level = self.conf.level;
+        }
+
+        self.buf.push_str(s);
+        Ok(())
+    }
+}
+
+impl Drop for Formatter<'_, '_> {
+    fn drop(&mut self) {
+        if !self.buf.is_empty() {
+            self.flush_buf().expect("Could not flush Formatter buffer");
+        }
+    }
+}
+
+/// Configuration for the `Formatter`. It can be shared between multiple
+/// `EventDisplay::display` calls but its scope is restricted to a single call.
+/// This means a base configuration can be shared for multiple
+/// `EventDisplay::display` call but any modification made within an
+/// `EventDisplay::display` call won't be visibile outside.
+#[derive(Clone, Default)]
+pub struct FormatterConf {
+    level: usize,
+    saved_levels: Vec<usize>,
+    item: Option<char>,
+}
+
+impl FormatterConf {
+    pub fn new() -> Self {
+        Self::with_level(0)
+    }
+
+    pub fn with_level(level: usize) -> Self {
+        Self {
+            level,
+            ..Default::default()
+        }
+    }
+
+    /// Increase the indentation level by `diff`.
+    pub fn inc_level(&mut self, diff: usize) {
+        self.saved_levels.push(self.level);
+        self.level += diff;
+    }
+
+    /// Reset the indentation level to its previous value.
+    pub fn reset_level(&mut self) {
+        match self.saved_levels.pop() {
+            Some(level) => {
+                self.level = level;
+            }
+            None => warn!("Cannot reset the indentation level"),
+        }
+    }
+
+    /// Set an itemization char to be printed at the start of output, or None.
+    pub fn set_item(&mut self, item: Option<char>) {
+        self.item = item;
+    }
+}
+
 /// Trait controlling how an event or an event section (or any custom type
 /// inside it) is displayed. It works by providing an helper returning an
 /// implementation of the std::fmt::Display trait, which can be used later to
@@ -52,7 +216,11 @@ impl DisplayFormat {
 /// arguments, unlike a plain std::fmt::Display implementation.
 pub trait EventDisplay<'a>: EventFmt {
     /// Display the event using the default event format.
-    fn display(&'a self, format: &'a DisplayFormat) -> Box<dyn fmt::Display + 'a>;
+    fn display(
+        &'a self,
+        format: &'a DisplayFormat,
+        conf: &'a FormatterConf,
+    ) -> Box<dyn fmt::Display + 'a>;
 }
 
 /// Trait controlling how an event or an event section (or any custom type
@@ -64,26 +232,33 @@ pub trait EventDisplay<'a>: EventFmt {
 /// members if any.
 pub trait EventFmt {
     /// Default formatting of an event.
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result;
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result;
 }
 
 impl<'a, T> EventDisplay<'a> for T
 where
     T: EventFmt,
 {
-    fn display(&'a self, format: &'a DisplayFormat) -> Box<dyn fmt::Display + 'a> {
+    fn display(
+        &'a self,
+        format: &'a DisplayFormat,
+        conf: &'a FormatterConf,
+    ) -> Box<dyn fmt::Display + 'a> {
         struct DefaultDisplay<'a, U> {
             myself: &'a U,
             format: &'a DisplayFormat,
+            conf: &'a FormatterConf,
         }
         impl<U: EventFmt> fmt::Display for DefaultDisplay<'_, U> {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                self.myself.event_fmt(f, self.format)
+                self.myself
+                    .event_fmt(&mut Formatter::new(f, self.conf.clone()), self.format)
             }
         }
         Box::new(DefaultDisplay {
             myself: self,
             format,
+            conf,
         })
     }
 }
@@ -95,7 +270,7 @@ where
 ///
 /// ```
 /// use std::fmt;
-/// use retis_events::DelimWriter;
+/// use retis_events::{Formatter, FormatterConf, DelimWriter};
 ///
 /// struct Flags {
 ///     opt1: bool,
@@ -103,15 +278,17 @@ where
 /// }
 /// impl fmt::Display for Flags {
 ///     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-///         write!(f, "flags")?;
+///         let mut f = Formatter::new(f, FormatterConf::new());
+///
+///         write!(&mut f, "flags")?;
 ///         let mut space = DelimWriter::new(' ');
 ///         if self.opt1 {
-///             space.write(f)?;
-///             write!(f, "opt1");
+///             space.write(&mut f)?;
+///             write!(&mut f, "opt1");
 ///          }
 ///         if self.opt2 {
-///             space.write(f)?;
-///             write!(f, "opt2")?;
+///             space.write(&mut f)?;
+///             write!(&mut f, "opt2")?;
 ///          }
 ///          Ok(())
 ///     }
@@ -129,7 +306,7 @@ impl DelimWriter {
     }
 
     /// If it's not the first time it's called, write the delimiter.
-    pub fn write(&mut self, f: &mut fmt::Formatter) -> fmt::Result {
+    pub fn write(&mut self, f: &mut Formatter) -> fmt::Result {
         match self.first {
             true => self.first = false,
             false => write!(f, "{}", self.delim)?,

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -121,7 +121,7 @@ impl Event {
 }
 
 impl EventFmt for Event {
-    fn event_fmt(&self, f: &mut std::fmt::Formatter, format: &DisplayFormat) -> std::fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> std::fmt::Result {
         // First format the first event line starting with the always-there
         // {common} section, followed by the {kernel} or {user} one.
         self.0
@@ -151,15 +151,19 @@ impl EventFmt for Event {
         }
 
         // Separator between each following sections.
-        let sep = if format.multiline { "\n  " } else { " " };
+        let sep = if format.multiline { '\n' } else { ' ' };
 
         // If we have a stack trace, show it.
         if let Some(kernel) = self.get_section::<KernelEvent>(SectionId::Kernel) {
             if let Some(stack) = &kernel.stack_trace {
+                f.conf.inc_level(4);
                 write!(f, "{sep}")?;
                 stack.event_fmt(f, format)?;
+                f.conf.reset_level();
             }
         }
+
+        f.conf.inc_level(2);
 
         // Finally show all sections.
         (SectionId::Skb.to_u8()..SectionId::_MAX.to_u8())
@@ -171,6 +175,7 @@ impl EventFmt for Event {
                 section.event_fmt(f, format)
             })?;
 
+        f.conf.reset_level();
         Ok(())
     }
 }

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -124,48 +124,52 @@ impl EventFmt for Event {
     fn event_fmt(&self, f: &mut std::fmt::Formatter, format: &DisplayFormat) -> std::fmt::Result {
         // First format the first event line starting with the always-there
         // {common} section, followed by the {kernel} or {user} one.
-        write!(
-            f,
-            "{}",
-            self.0.get(&SectionId::Common).unwrap().display(format)
-        )?;
+        self.0
+            .get(&SectionId::Common)
+            .unwrap()
+            .event_fmt(f, format)?;
         if let Some(kernel) = self.0.get(&SectionId::Kernel) {
-            write!(f, " {}", kernel.display(format))?;
+            write!(f, " ")?;
+            kernel.event_fmt(f, format)?;
         } else if let Some(user) = self.0.get(&SectionId::Userspace) {
-            write!(f, " {}", user.display(format))?;
+            write!(f, " ")?;
+            user.event_fmt(f, format)?;
         }
 
         // If we do have tracking and/or drop sections, put them there too.
         // Special case the global tracking information from here for now.
         if let Some(tracking) = self.0.get(&SectionId::Tracking) {
-            write!(f, " {}", tracking.display(format))?;
+            write!(f, " ")?;
+            tracking.event_fmt(f, format)?;
         } else if let Some(skb_tracking) = self.0.get(&SectionId::SkbTracking) {
-            write!(f, " {}", skb_tracking.display(format))?;
+            write!(f, " ")?;
+            skb_tracking.event_fmt(f, format)?;
         }
         if let Some(skb_drop) = self.0.get(&SectionId::SkbDrop) {
-            write!(f, " {}", skb_drop.display(format))?;
+            write!(f, " ")?;
+            skb_drop.event_fmt(f, format)?;
         }
+
+        // Separator between each following sections.
+        let sep = if format.multiline { "\n  " } else { " " };
 
         // If we have a stack trace, show it.
         if let Some(kernel) = self.get_section::<KernelEvent>(SectionId::Kernel) {
             if let Some(stack) = &kernel.stack_trace {
-                write!(
-                    f,
-                    "{}{}",
-                    if format.multiline { '\n' } else { ' ' },
-                    stack.display(format)
-                )?;
+                write!(f, "{sep}")?;
+                stack.event_fmt(f, format)?;
             }
         }
-
-        let sep = if format.multiline { "\n  " } else { " " };
 
         // Finally show all sections.
         (SectionId::Skb.to_u8()..SectionId::_MAX.to_u8())
             .collect::<Vec<u8>>()
             .iter()
             .filter_map(|id| self.0.get(&SectionId::from_u8(*id).unwrap()))
-            .try_for_each(|section| write!(f, "{sep}{}", section.display(format)))?;
+            .try_for_each(|section| {
+                write!(f, "{sep}")?;
+                section.event_fmt(f, format)
+            })?;
 
         Ok(())
     }

--- a/retis-events/src/kernel.rs
+++ b/retis-events/src/kernel.rs
@@ -46,7 +46,7 @@ impl EventFmt for StackTrace {
         let last = self.0.len() - 1;
         if format.multiline {
             self.0.iter().enumerate().try_for_each(|(i, sym)| {
-                write!(f, "    {sym}")?;
+                write!(f, "{sym}")?;
                 if i != last {
                     writeln!(f)?;
                 }

--- a/retis-events/src/kernel.rs
+++ b/retis-events/src/kernel.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::*;
-use crate::{event_section, event_type};
+use crate::{event_section, event_type, Formatter};
 
 #[event_section("kernel")]
 pub struct KernelEvent {
@@ -14,7 +14,7 @@ pub struct KernelEvent {
 }
 
 impl EventFmt for KernelEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "[{}] {}",
@@ -42,7 +42,7 @@ impl StackTrace {
 }
 
 impl EventFmt for StackTrace {
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result {
         let last = self.0.len() - 1;
         if format.multiline {
             self.0.iter().enumerate().try_for_each(|(i, sym)| {

--- a/retis-events/src/nft.rs
+++ b/retis-events/src/nft.rs
@@ -1,7 +1,7 @@
 use std::{fmt, str};
 
 use super::*;
-use crate::event_section;
+use crate::{event_section, Formatter};
 
 /// Nft event section
 #[event_section("nft")]
@@ -17,7 +17,7 @@ pub struct NftEvent {
 }
 
 impl EventFmt for NftEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "table {} ({}) chain {} ({})",

--- a/retis-events/src/ovs.rs
+++ b/retis-events/src/ovs.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use serde::{de::Error as Derror, ser::Error as Serror, Deserialize, Deserializer, Serializer};
 
 use super::*;
-use crate::{event_section, event_type};
+use crate::{event_section, event_type, Formatter};
 
 ///The OVS Event
 #[derive(PartialEq)]
@@ -16,7 +16,7 @@ pub struct OvsEvent {
 }
 
 impl EventFmt for OvsEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result {
         self.event.event_fmt(f, format)
     }
 }
@@ -58,7 +58,7 @@ pub enum OvsEventType {
 }
 
 impl EventFmt for OvsEventType {
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result {
         use OvsEventType::*;
         let disp: &dyn EventFmt = match self {
             Upcall(e) => e,
@@ -102,7 +102,7 @@ pub struct UpcallEvent {
 }
 
 impl EventFmt for UpcallEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "upcall{} port {} cpu {}",
@@ -134,7 +134,7 @@ pub struct UpcallEnqueueEvent {
 }
 
 impl EventFmt for UpcallEnqueueEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "upcall_enqueue{} ({}/{}) q {} ret {}",
@@ -158,7 +158,7 @@ pub struct UpcallReturnEvent {
 }
 
 impl EventFmt for UpcallReturnEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "upcall_ret ({}/{}) ret {}",
@@ -218,7 +218,7 @@ impl OperationEvent {
 }
 
 impl EventFmt for OperationEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(
             f,
             "flow_{} q {} ts {} ({})",
@@ -250,7 +250,7 @@ pub struct RecvUpcallEvent {
 }
 
 impl EventFmt for RecvUpcallEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         // FIXME: there are more fields.
         write!(
             f,
@@ -276,7 +276,7 @@ pub struct ActionEvent {
 }
 
 impl EventFmt for ActionEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         if self.recirc_id != 0 {
             write!(f, "[recirc_id {:#x}] ", self.recirc_id)?;
         }

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -65,16 +65,11 @@ impl EventFmt for SkbEvent {
         if let Some(eth) = &self.eth {
             space.write(f)?;
 
-            let ethertype = match etype_str(eth.etype) {
-                Some(s) => format!(" {}", s),
-                None => String::new(),
-            };
-
-            write!(
-                f,
-                "{} > {} ethertype{} ({:#06x})",
-                eth.src, eth.dst, ethertype, eth.etype
-            )?;
+            write!(f, "{} > {} ethertype", eth.src, eth.dst)?;
+            if let Some(etype) = etype_str(eth.etype) {
+                write!(f, " {etype}")?;
+            }
+            write!(f, " ({:#06x})", eth.etype)?;
         }
 
         if let Some(arp) = &self.arp {
@@ -153,18 +148,17 @@ impl EventFmt for SkbEvent {
                 }
             }
 
-            let protocol = match protocol_str(ip.protocol) {
-                Some(s) => format!(" {}", s),
-                None => String::new(),
-            };
-
             // In some rare cases the IP header might not be fully filled yet,
             // length might be unset.
             if ip.len != 0 {
                 write!(f, " len {}", ip.len)?;
             }
 
-            write!(f, " proto{} ({})", protocol, ip.protocol)?;
+            if let Some(proto) = protocol_str(ip.protocol) {
+                write!(f, " proto {}", proto)?;
+            }
+
+            write!(f, " ({})", ip.protocol)?;
         }
 
         if let Some(tcp) = &self.tcp {

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -4,7 +4,7 @@ use super::{
     net::{etype_str, protocol_str, RawPacket},
     *,
 };
-use crate::{event_section, event_type};
+use crate::{event_section, event_type, Formatter};
 
 /// Skb event section.
 #[event_section("skb")]
@@ -38,7 +38,7 @@ pub struct SkbEvent {
 }
 
 impl EventFmt for SkbEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         let mut len = 0;
 
         let mut space = DelimWriter::new(' ');

--- a/retis-events/src/skb_drop.rs
+++ b/retis-events/src/skb_drop.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::*;
-use crate::event_section;
+use crate::{event_section, Formatter};
 
 /// Skb drop event section.
 #[event_section("skb-drop")]
@@ -14,7 +14,7 @@ pub struct SkbDropEvent {
 }
 
 impl EventFmt for SkbDropEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         match &self.subsys {
             None => write!(f, "drop (reason {})", self.drop_reason),
             Some(name) => write!(f, "drop (reason {name}/{})", self.drop_reason),

--- a/retis-events/src/skb_tracking.rs
+++ b/retis-events/src/skb_tracking.rs
@@ -86,7 +86,8 @@ impl Ord for TrackingInfo {
 
 impl EventFmt for TrackingInfo {
     fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
-        write!(f, "{} n {}", self.skb.display(format), self.idx)
+        self.skb.event_fmt(f, format)?;
+        write!(f, " n {}", self.idx)
     }
 }
 

--- a/retis-events/src/skb_tracking.rs
+++ b/retis-events/src/skb_tracking.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use super::*;
-use crate::event_section;
+use crate::{event_section, Formatter};
 
 /// Tracking event section.
 /// For more information of how the tracking logic is designed and how it can be
@@ -47,7 +47,7 @@ impl SkbTrackingEvent {
 }
 
 impl EventFmt for SkbTrackingEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(f, "#{:x} (skb {:x})", self.tracking_id(), self.skb)
     }
 }
@@ -85,7 +85,7 @@ impl Ord for TrackingInfo {
 }
 
 impl EventFmt for TrackingInfo {
-    fn event_fmt(&self, f: &mut fmt::Formatter, format: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> fmt::Result {
         self.skb.event_fmt(f, format)?;
         write!(f, " n {}", self.idx)
     }

--- a/retis-events/src/user.rs
+++ b/retis-events/src/user.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::*;
-use crate::event_section;
+use crate::{event_section, Formatter};
 
 #[event_section("userspace")]
 pub struct UserEvent {
@@ -21,7 +21,7 @@ pub struct UserEvent {
 }
 
 impl EventFmt for UserEvent {
-    fn event_fmt(&self, f: &mut fmt::Formatter, _: &DisplayFormat) -> fmt::Result {
+    fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> fmt::Result {
         write!(f, "[u] {}", self.symbol)?;
         if let Some((_, bin)) = self.path.rsplit_once('/') {
             write!(f, " ({})", bin)?;

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -618,7 +618,7 @@ mod tests {
     struct TestEvent {}
 
     impl EventFmt for TestEvent {
-        fn event_fmt(&self, f: &mut std::fmt::Formatter, _: &DisplayFormat) -> std::fmt::Result {
+        fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> std::fmt::Result {
             write!(f, "test event section")
         }
     }

--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -17,11 +17,7 @@ use anyhow::{anyhow, bail, Result};
 use log::{error, log, Level};
 use plain::Plain;
 
-use crate::{
-    events::{CommonEvent, TaskEvent, *},
-    helpers::signals::Running,
-    raw_event_section,
-};
+use crate::{events::*, helpers::signals::Running, raw_event_section};
 
 /// Raw event sections for common.
 pub(super) const COMMON_SECTION_CORE: u64 = 0;
@@ -623,7 +619,7 @@ mod tests {
     }
 
     impl EventFmt for TestEvent {
-        fn event_fmt(&self, f: &mut std::fmt::Formatter, _: &DisplayFormat) -> std::fmt::Result {
+        fn event_fmt(&self, f: &mut Formatter, _: &DisplayFormat) -> std::fmt::Result {
             write!(
                 f,
                 "field0: {:?} field1: {:?} field2: {:?}",

--- a/tools/benchmark_event_output.sh
+++ b/tools/benchmark_event_output.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-make bench V=1
+make bench -j$(nproc)
 
 time_single_single=0
 time_single_multi=0

--- a/tools/benchmark_event_parsing.sh
+++ b/tools/benchmark_event_parsing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-make bench V=1
+make bench -j$(nproc)
 
 time_first=0
 time_1m=0


### PR DESCRIPTION
Based on #385.

This introduces our own `Formatter` instead of directly using `fmt::Formatter` when constructing the event display result. The main advantage is an improved flexibility where formatting is not done at post-processing but directly while constructing the output. Event sub-sections and types can now decide to output multi-line data.