### PR TITLE
docs: install: fix copr link

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Retis can be installed from [COPR](https://copr.fedorainfracloud.org/coprs/atenart/retis/)
+Retis can be installed from [COPR](https://copr.fedorainfracloud.org/coprs/g/retis/retis/)
 for rpm-compatible distributions, from a container image or from sources.
 
 ### COPR


### PR DESCRIPTION
The doc then used the right instructions, pointing to the right copr; that's probably why we didn't caught it before.