### PR TITLE
Untangle the section id, factories and modules

### DIFF
--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -27,36 +27,16 @@ pub fn event_section(
     let name: syn::LitStr = syn::parse(args).expect("Invalid event name");
 
     let output = quote! {
-        #[derive(Default, crate::EventSection)]
+        #[derive(Default)]
         #[crate::event_type]
         #input
 
         impl #ident {
             pub(crate) const SECTION_NAME: &'static str = #name;
         }
-    };
-    output.into()
-}
 
-#[proc_macro_attribute]
-pub fn event_type(
-    _: proc_macro::TokenStream,
-    item: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    let input: Item = parse_macro_input!(item);
-    let output = quote! {
-        #[serde_with::skip_serializing_none]
-        #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
-        #input
-    };
-    output.into()
-}
-
-#[proc_macro_derive(EventSection)]
-pub fn derive_event_section(input: TokenStream) -> TokenStream {
-    let DeriveInput { ident, .. } = parse_macro_input!(input);
-    let output = quote! {
         impl EventSectionInternal for #ident {
+
             fn as_any(&self) -> &dyn std::any::Any
                 where Self: Sized,
             {
@@ -77,6 +57,23 @@ pub fn derive_event_section(input: TokenStream) -> TokenStream {
         }
     };
     output.into()
+}
+
+#[proc_macro_attribute]
+pub fn event_type(
+    _: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let output = format!(
+        r#"
+        #[serde_with::skip_serializing_none]
+        #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+        {item}
+    "#
+    );
+    output
+        .parse()
+        .expect("Invalid tokens from event_section macro")
 }
 
 #[proc_macro_derive(EventSectionFactory)]

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -24,7 +24,7 @@ pub fn event_section(
     let input: ItemStruct = parse_macro_input!(item);
     let ident = &input.ident;
 
-    let name: syn::LitStr = syn::parse(args).expect("Invalid event name");
+    let id: syn::Expr = syn::parse(args).expect("Invalid event id");
 
     let output = quote! {
         #[derive(Default)]
@@ -32,10 +32,13 @@ pub fn event_section(
         #input
 
         impl #ident {
-            pub(crate) const SECTION_NAME: &'static str = #name;
+            pub(crate) const SECTION_ID: u8 = #id as u8;
         }
 
         impl EventSectionInternal for #ident {
+            fn id(&self) -> u8 {
+                Self::SECTION_ID
+            }
 
             fn as_any(&self) -> &dyn std::any::Any
                 where Self: Sized,

--- a/retis-events/src/common.rs
+++ b/retis-events/src/common.rs
@@ -6,7 +6,7 @@ use crate::*;
 
 /// Startup event section. Contains global information about a collection as a
 /// whole, with data gathered at collection startup time.
-#[event_section("startup")]
+#[event_section(SectionId::Startup)]
 pub struct StartupEvent {
     /// Retis version used while collecting events.
     pub retis_version: String,
@@ -33,7 +33,7 @@ pub struct TaskEvent {
 }
 
 /// Common event section.
-#[event_section("common")]
+#[event_section(SectionId::Common)]
 pub struct CommonEvent {
     /// Timestamp of when the event was generated.
     pub timestamp: u64,

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -100,7 +100,7 @@ pub enum CtState {
     Untracked,
 }
 /// Conntrack event
-#[event_section("ct")]
+#[event_section(SectionId::Ct)]
 pub struct CtEvent {
     /// Packet's conntrack state
     pub state: CtState,

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -166,7 +166,7 @@ impl EventFmt for Event {
         f.conf.inc_level(2);
 
         // Finally show all sections.
-        (SectionId::Skb.to_u8()..SectionId::_MAX.to_u8())
+        (SectionId::Skb as u8..SectionId::_MAX as u8)
             .collect::<Vec<u8>>()
             .iter()
             .filter_map(|id| self.0.get(&SectionId::from_u8(*id).unwrap()))
@@ -239,26 +239,6 @@ impl SectionId {
             11 => Startup,
             x => bail!("Can't construct a SectionId from {}", x),
         })
-    }
-
-    /// Converts an SectionId to a section unique identifier.
-    #[allow(dead_code)]
-    pub fn to_u8(self) -> u8 {
-        use SectionId::*;
-        match self {
-            Common => 1,
-            Kernel => 2,
-            Userspace => 3,
-            Tracking => 4,
-            SkbTracking => 5,
-            SkbDrop => 6,
-            Skb => 7,
-            Ovs => 8,
-            Nft => 9,
-            Ct => 10,
-            Startup => 11,
-            _MAX => 12,
-        }
     }
 
     /// Converts an SectionId to a section unique str identifier.

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -60,18 +60,15 @@ impl Event {
             .map_err(|e| anyhow!("Failed to parse json event at line {line}: {e}"))?;
 
         for (owner, value) in event_js.drain() {
-            let owner_mod = SectionId::from_str(&owner)?;
             let parser = event_sections()?
                 .get(&owner)
                 .ok_or_else(|| anyhow!("json contains an unsupported event {}", owner))?;
 
             debug!("Unmarshaling event section {owner}: {value}");
-            event.insert_section(
-                owner_mod,
-                parser(value).map_err(|e| {
-                    anyhow!("Failed to create EventSection for owner {owner} from json: {e}")
-                })?,
-            )?;
+            let section = parser(value).map_err(|e| {
+                anyhow!("Failed to create EventSection for owner {owner} from json: {e}")
+            })?;
+            event.insert_section(SectionId::from_u8(section.id())?, section)?;
         }
         Ok(event)
     }
@@ -205,17 +202,17 @@ impl FromStr for SectionId {
     fn from_str(val: &str) -> Result<Self> {
         use SectionId::*;
         Ok(match val {
-            CommonEvent::SECTION_NAME => Common,
-            KernelEvent::SECTION_NAME => Kernel,
-            UserEvent::SECTION_NAME => Userspace,
-            TrackingInfo::SECTION_NAME => Tracking,
-            SkbTrackingEvent::SECTION_NAME => SkbTracking,
-            SkbDropEvent::SECTION_NAME => SkbDrop,
-            SkbEvent::SECTION_NAME => Skb,
-            OvsEvent::SECTION_NAME => Ovs,
-            NftEvent::SECTION_NAME => Nft,
-            CtEvent::SECTION_NAME => Ct,
-            StartupEvent::SECTION_NAME => Startup,
+            "common" => Common,
+            "kernel" => Kernel,
+            "userspace" => Userspace,
+            "tracking" => Tracking,
+            "skb-tracking" => SkbTracking,
+            "skb-drop" => SkbDrop,
+            "skb" => Skb,
+            "ovs" => Ovs,
+            "nft" => Nft,
+            "ct" => Ct,
+            "startup" => Startup,
             x => bail!("Can't construct a SectionId from {}", x),
         })
     }
@@ -245,17 +242,17 @@ impl SectionId {
     pub fn to_str(self) -> &'static str {
         use SectionId::*;
         match self {
-            Common => CommonEvent::SECTION_NAME,
-            Kernel => KernelEvent::SECTION_NAME,
-            Userspace => UserEvent::SECTION_NAME,
-            Tracking => TrackingInfo::SECTION_NAME,
-            SkbTracking => SkbTrackingEvent::SECTION_NAME,
-            SkbDrop => SkbDropEvent::SECTION_NAME,
-            Skb => SkbEvent::SECTION_NAME,
-            Ovs => OvsEvent::SECTION_NAME,
-            Nft => NftEvent::SECTION_NAME,
-            Ct => CtEvent::SECTION_NAME,
-            Startup => StartupEvent::SECTION_NAME,
+            Common => "common",
+            Kernel => "kernel",
+            Userspace => "userspace",
+            Tracking => "tracking",
+            SkbTracking => "skb-tracking",
+            SkbDrop => "skb-drop",
+            Skb => "skb",
+            Ovs => "ovs",
+            Nft => "nft",
+            Ct => "ct",
+            Startup => "startup",
             _MAX => "_max",
         }
     }
@@ -271,39 +268,30 @@ impl fmt::Display for SectionId {
 type EventSectionMap = HashMap<String, fn(serde_json::Value) -> Result<Box<dyn EventSection>>>;
 static EVENT_SECTIONS: OnceCell<EventSectionMap> = OnceCell::new();
 
+macro_rules! insert_section {
+    ($events: expr, $ty: ty) => {
+        $events.insert(
+            SectionId::from_u8(<$ty>::SECTION_ID)?.to_str().to_string(),
+            |v| Ok(Box::new(serde_json::from_value::<$ty>(v)?)),
+        );
+    };
+}
+
 fn event_sections() -> Result<&'static EventSectionMap> {
     EVENT_SECTIONS.get_or_try_init(|| {
         let mut events = EventSectionMap::new();
-        events.insert(CommonEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<CommonEvent>(v)?))
-        });
-        events.insert(KernelEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<KernelEvent>(v)?))
-        });
-        events.insert(UserEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<UserEvent>(v)?))
-        });
-        events.insert(SkbTrackingEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<SkbTrackingEvent>(v)?))
-        });
-        events.insert(SkbDropEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<SkbDropEvent>(v)?))
-        });
-        events.insert(SkbEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<SkbEvent>(v)?))
-        });
-        events.insert(OvsEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<OvsEvent>(v)?))
-        });
-        events.insert(NftEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<NftEvent>(v)?))
-        });
-        events.insert(CtEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<CtEvent>(v)?))
-        });
-        events.insert(StartupEvent::SECTION_NAME.to_string(), |v| {
-            Ok(Box::new(serde_json::from_value::<StartupEvent>(v)?))
-        });
+
+        insert_section!(events, CommonEvent);
+        insert_section!(events, KernelEvent);
+        insert_section!(events, UserEvent);
+        insert_section!(events, SkbTrackingEvent);
+        insert_section!(events, SkbDropEvent);
+        insert_section!(events, SkbEvent);
+        insert_section!(events, OvsEvent);
+        insert_section!(events, NftEvent);
+        insert_section!(events, CtEvent);
+        insert_section!(events, StartupEvent);
+
         Ok(events)
     })
 }
@@ -338,6 +326,7 @@ impl<T> EventSection for T where T: EventSectionInternal + for<'a> EventDisplay<
 ///
 /// There should not be a need to have per-object implementations for this.
 pub trait EventSectionInternal {
+    fn id(&self) -> u8;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn to_json(&self) -> serde_json::Value;
@@ -346,6 +335,10 @@ pub trait EventSectionInternal {
 // We need this as the value given as the input when deserializing something
 // into an event could be mapped to (), e.g. serde_json::Value::Null.
 impl EventSectionInternal for () {
+    fn id(&self) -> u8 {
+        SectionId::_MAX as u8
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -34,7 +34,7 @@
 #![allow(dead_code)] // FIXME
 #![allow(clippy::wrong_self_convention)]
 
-use std::{any::Any, collections::HashMap, fmt, str::FromStr};
+use std::{any::Any, collections::HashMap, fmt};
 
 use anyhow::{anyhow, bail, Result};
 use log::debug;
@@ -193,29 +193,6 @@ pub enum SectionId {
     Startup = 11,
     // TODO: use std::mem::variant_count once in stable.
     _MAX = 12,
-}
-
-impl FromStr for SectionId {
-    type Err = anyhow::Error;
-
-    /// Constructs an SectionId from a section unique str identifier.
-    fn from_str(val: &str) -> Result<Self> {
-        use SectionId::*;
-        Ok(match val {
-            "common" => Common,
-            "kernel" => Kernel,
-            "userspace" => Userspace,
-            "tracking" => Tracking,
-            "skb-tracking" => SkbTracking,
-            "skb-drop" => SkbDrop,
-            "skb" => Skb,
-            "ovs" => Ovs,
-            "nft" => Nft,
-            "ct" => Ct,
-            "startup" => Startup,
-            x => bail!("Can't construct a SectionId from {}", x),
-        })
-    }
 }
 
 impl SectionId {

--- a/retis-events/src/kernel.rs
+++ b/retis-events/src/kernel.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::*;
 use crate::{event_section, event_type, Formatter};
 
-#[event_section("kernel")]
+#[event_section(SectionId::Kernel)]
 pub struct KernelEvent {
     /// Kernel symbol name associated with the event (i.e. which probe generated
     /// the event).

--- a/retis-events/src/nft.rs
+++ b/retis-events/src/nft.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Nft event section
-#[event_section("nft")]
+#[event_section(SectionId::Nft)]
 pub struct NftEvent {
     pub table_name: String,
     pub chain_name: String,

--- a/retis-events/src/ovs.rs
+++ b/retis-events/src/ovs.rs
@@ -8,7 +8,7 @@ use crate::{event_section, event_type, Formatter};
 
 ///The OVS Event
 #[derive(PartialEq)]
-#[event_section("ovs")]
+#[event_section(SectionId::Ovs)]
 pub struct OvsEvent {
     /// Event data
     #[serde(flatten)]

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{event_section, event_type, Formatter};
 
 /// Skb event section.
-#[event_section("skb")]
+#[event_section(SectionId::Skb)]
 pub struct SkbEvent {
     /// Ethernet fields, if any.
     pub eth: Option<SkbEthEvent>,

--- a/retis-events/src/skb_drop.rs
+++ b/retis-events/src/skb_drop.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Skb drop event section.
-#[event_section("skb-drop")]
+#[event_section(SectionId::SkbDrop)]
 pub struct SkbDropEvent {
     /// Sub-system who generated the below drop reason. None for core reasons.
     pub subsys: Option<String>,

--- a/retis-events/src/skb_tracking.rs
+++ b/retis-events/src/skb_tracking.rs
@@ -15,7 +15,7 @@ use crate::{event_section, Formatter};
 /// Tl;dr; the tracking unique id is `(timestamp, orig_head)` and `skb` can be
 /// used to distinguished between clones.
 #[derive(Copy, PartialEq)]
-#[event_section("skb-tracking")]
+#[event_section(SectionId::SkbTracking)]
 #[repr(C)]
 pub struct SkbTrackingEvent {
     /// Head of buffer (`skb->head`) when the packet was first seen by the
@@ -54,7 +54,7 @@ impl EventFmt for SkbTrackingEvent {
 
 /// Tracking event section. Generated at postprocessing with combined skb and ovs
 /// tracking information.
-#[event_section("tracking")]
+#[event_section(SectionId::Tracking)]
 pub struct TrackingInfo {
     /// Tracking information of the original packet.
     pub skb: SkbTrackingEvent,

--- a/retis-events/src/user.rs
+++ b/retis-events/src/user.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::*;
 use crate::{event_section, Formatter};
 
-#[event_section("userspace")]
+#[event_section(SectionId::Userspace)]
 pub struct UserEvent {
     /// Probe type: for now only "usdt" is supported.
     pub probe_type: String,

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -576,8 +576,8 @@ mod tests {
         fn collector(&mut self) -> &mut dyn Collector {
             self
         }
-        fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-            Ok(Box::new(TestEvent {}))
+        fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+            Ok(Some(Box::new(TestEvent {})))
         }
     }
 
@@ -608,8 +608,8 @@ mod tests {
         fn collector(&mut self) -> &mut dyn Collector {
             self
         }
-        fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-            Ok(Box::new(TestEvent {}))
+        fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+            Ok(Some(Box::new(TestEvent {})))
         }
     }
 

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -44,9 +44,9 @@ use crate::{
         probe::{kernel::probe_stack::ProbeStack, *},
         tracking::{gc::TrackingGC, skb_tracking::init_tracking},
     },
-    events::{EventResult, SectionId},
+    events::EventResult,
     helpers::{signals::Running, time::*},
-    module::Modules,
+    module::{ModuleId, Modules},
 };
 
 /// Generic trait representing a collector. All collectors are required to
@@ -110,7 +110,7 @@ pub(crate) struct Collectors {
     tracking_gc: Option<TrackingGC>,
     // Keep a reference on the tracking configuration map.
     tracking_config_map: Option<libbpf_rs::MapHandle>,
-    loaded: Vec<SectionId>,
+    loaded: Vec<ModuleId>,
     // Retis events factory.
     events_factory: Arc<RetisEventsFactory>,
 }
@@ -222,7 +222,7 @@ impl Collectors {
 
         // Try initializing all collectors.
         for name in &collect.args()?.collectors {
-            let id = SectionId::from_str(name)?;
+            let id = ModuleId::from_str(name)?;
             let c = self
                 .modules
                 .get_collector(&id)
@@ -642,10 +642,10 @@ mod tests {
     fn register_collectors() -> Result<()> {
         let mut group = Modules::new()?;
         assert!(group
-            .register(SectionId::Skb, Box::new(DummyCollectorA::new()?),)
+            .register(ModuleId::Skb, Box::new(DummyCollectorA::new()?),)
             .is_ok());
         assert!(group
-            .register(SectionId::Ovs, Box::new(DummyCollectorB::new()?),)
+            .register(ModuleId::Ovs, Box::new(DummyCollectorB::new()?),)
             .is_ok());
         Ok(())
     }
@@ -654,10 +654,10 @@ mod tests {
     fn register_uniqueness() -> Result<()> {
         let mut group = Modules::new()?;
         assert!(group
-            .register(SectionId::Skb, Box::new(DummyCollectorA::new()?),)
+            .register(ModuleId::Skb, Box::new(DummyCollectorA::new()?),)
             .is_ok());
         assert!(group
-            .register(SectionId::Skb, Box::new(DummyCollectorA::new()?),)
+            .register(ModuleId::Skb, Box::new(DummyCollectorA::new()?),)
             .is_err());
         Ok(())
     }
@@ -668,8 +668,8 @@ mod tests {
         let mut dummy_a = Box::new(DummyCollectorA::new()?);
         let mut dummy_b = Box::new(DummyCollectorB::new()?);
 
-        group.register(SectionId::Skb, Box::new(DummyCollectorA::new()?))?;
-        group.register(SectionId::Ovs, Box::new(DummyCollectorB::new()?))?;
+        group.register(ModuleId::Skb, Box::new(DummyCollectorA::new()?))?;
+        group.register(ModuleId::Ovs, Box::new(DummyCollectorB::new()?))?;
 
         let mut collectors = Collectors::new(group)?;
         let mut mgr = ProbeBuilderManager::new()?;
@@ -693,8 +693,8 @@ mod tests {
         let mut dummy_a = Box::new(DummyCollectorA::new()?);
         let mut dummy_b = Box::new(DummyCollectorB::new()?);
 
-        group.register(SectionId::Skb, Box::new(DummyCollectorA::new()?))?;
-        group.register(SectionId::Ovs, Box::new(DummyCollectorB::new()?))?;
+        group.register(ModuleId::Skb, Box::new(DummyCollectorA::new()?))?;
+        group.register(ModuleId::Ovs, Box::new(DummyCollectorB::new()?))?;
 
         let mut collectors = Collectors::new(group)?;
 

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -613,7 +613,7 @@ mod tests {
         }
     }
 
-    #[event_section("test")]
+    #[event_section(SectionId::Common)]
     #[derive(crate::EventSectionFactory)]
     struct TestEvent {}
 

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -16,14 +16,25 @@ use nix::unistd::Uid;
 
 use super::cli::Collect;
 use crate::{
-    cli::{CliDisplayFormat, SubCommandRunner},
+    cli::{dynamic::DynamicCommand, CliConfig, CliDisplayFormat, FullCli, SubCommandRunner},
     core::{
-        events::RetisEventsFactory,
-        filters::{meta::filter::FilterMeta, packets::filter::FilterPacketType},
+        events::{BpfEventsFactory, RetisEventsFactory},
+        filters::{
+            filters::{BpfFilter, Filter},
+            meta::filter::FilterMeta,
+            packets::filter::{FilterPacket, FilterPacketType},
+        },
+        inspect::check::collection_prerequisites,
         kernel::Symbol,
-        probe::kernel::utils::parse_probe,
+        probe::{
+            kernel::{probe_stack::ProbeStack, utils::parse_probe},
+            *,
+        },
+        tracking::{gc::TrackingGC, skb_tracking::init_tracking},
     },
     events::*,
+    helpers::{signals::Running, time::*},
+    module::{ModuleId, Modules},
     process::display::*,
 };
 
@@ -31,22 +42,6 @@ use crate::{
 use crate::core::{
     events::FactoryId,
     probe::kernel::{config::init_stack_map, kernel::KernelEventFactory},
-};
-use crate::{
-    cli::{dynamic::DynamicCommand, CliConfig, FullCli},
-    core::{
-        events::BpfEventsFactory,
-        filters::{
-            filters::{BpfFilter, Filter},
-            packets::filter::FilterPacket,
-        },
-        inspect::check::collection_prerequisites,
-        probe::{kernel::probe_stack::ProbeStack, *},
-        tracking::{gc::TrackingGC, skb_tracking::init_tracking},
-    },
-    events::EventResult,
-    helpers::{signals::Running, time::*},
-    module::{ModuleId, Modules},
 };
 
 /// Generic trait representing a collector. All collectors are required to

--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -542,8 +542,8 @@ unsafe impl Plain for BpfRawSectionHeader {}
 /// EventSection factory, providing helpers to create event sections from
 /// ebpf.
 ///
-/// Please use `#[retis_derive::event_section_factory(SectionType)]` to
-/// implement the common traits.
+/// Please use `#[retis_derive::event_section_factory]` to implement the common
+/// traits.
 pub(crate) trait EventSectionFactory: RawEventSectionFactory {
     fn as_any_mut(&mut self) -> &mut dyn any::Any;
 }

--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -364,12 +364,11 @@ pub(crate) fn parse_raw_event<'a>(
         let factory = factories
             .get_mut(&owner)
             .ok_or_else(|| anyhow!("Unknown factory for event section owner {}", &owner))?;
-        event.insert_section(
-            owner,
-            factory
-                .create(sections)
-                .map_err(|e| anyhow!("Failed to parse section {}: {e}", &owner))?,
-        )
+
+        let section = factory
+            .create(sections)
+            .map_err(|e| anyhow!("Failed to parse section {}: {e}", &owner))?;
+        event.insert_section(SectionId::from_u8(section.id())?, section)
     })?;
 
     Ok(event)
@@ -612,7 +611,7 @@ mod tests {
     const DATA_TYPE_U128: u8 = 2;
 
     #[derive(EventSectionFactory)]
-    #[event_section("test")]
+    #[event_section(SectionId::Common)]
     struct TestEvent {
         field0: Option<u64>,
         field1: Option<u64>,

--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -606,12 +606,13 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::{EventSection, EventSectionFactory};
+    use crate::{event_section, EventSectionFactory};
 
     const DATA_TYPE_U64: u8 = 1;
     const DATA_TYPE_U128: u8 = 2;
 
-    #[derive(Default, Deserialize, Serialize, EventSection, EventSectionFactory)]
+    #[derive(EventSectionFactory)]
+    #[event_section("test")]
     struct TestEvent {
         field0: Option<u64>,
         field1: Option<u64>,

--- a/retis/src/core/events/bpf/include/events.h
+++ b/retis/src/core/events/bpf/include/events.h
@@ -19,19 +19,18 @@ struct retis_log_event {
 	u8 msg[LOG_MAX];
 } __attribute__((packed));
 
-/* We're using the section identifiers defined in retis-events.
+/* We're using the factory identifiers defined in retis-events.
  * Please keep in sync. */
 enum retis_event_owners {
 	COMMON = 1,
 	KERNEL = 2,
 	USERSPACE = 3,
-	/* TRACKING = 4, */
-	COLLECTOR_SKB_TRACKING = 5,
-	COLLECTOR_SKB_DROP = 6,
-	COLLECTOR_SKB = 7,
-	COLLECTOR_OVS = 8,
-	COLLECTOR_NFT = 9,
-	COLLECTOR_CT = 10,
+	COLLECTOR_SKB_TRACKING = 4,
+	COLLECTOR_SKB_DROP = 5,
+	COLLECTOR_SKB = 6,
+	COLLECTOR_OVS = 7,
+	COLLECTOR_NFT = 8,
+	COLLECTOR_CT = 9,
 };
 
 struct retis_raw_event {

--- a/retis/src/core/probe/user/user.rs
+++ b/retis/src/core/probe/user/user.rs
@@ -4,13 +4,13 @@ use std::{any::Any, collections::HashMap, fmt, path::PathBuf};
 
 use anyhow::{anyhow, bail, Result};
 
-use crate::EventSectionFactory;
 use crate::{
     core::{
-        events::{BpfRawSection, EventSectionFactory, RawEventSectionFactory},
+        events::{BpfRawSection, EventSectionFactory, FactoryId, RawEventSectionFactory},
         probe::common::{Counters, CountersKey},
         user::proc::Process,
     },
+    event_section_factory,
     events::*,
 };
 
@@ -79,7 +79,8 @@ impl fmt::Display for UsdtProbe {
     }
 }
 
-#[derive(Default, EventSectionFactory)]
+#[event_section_factory(FactoryId::Userspace)]
+#[derive(Default)]
 pub(crate) struct UserEventFactory {
     cache: HashMap<String, Box<dyn Any>>,
 }

--- a/retis/src/module/ct/bpf.rs
+++ b/retis/src/module/ct/bpf.rs
@@ -9,9 +9,13 @@ use std::net::Ipv6Addr;
 
 use crate::{
     core::{
-        events::{parse_raw_section, BpfRawSection, EventSectionFactory, RawEventSectionFactory},
+        events::{
+            parse_raw_section, BpfRawSection, EventSectionFactory, FactoryId,
+            RawEventSectionFactory,
+        },
         inspect::inspector,
     },
+    event_section_factory,
     events::*,
     helpers, raw_event_section,
 };
@@ -73,7 +77,8 @@ pub(crate) struct RawCtEvent {
 
 unsafe impl Plain for RawCtEvent {}
 
-#[derive(Default, crate::EventSectionFactory)]
+#[event_section_factory(FactoryId::Ct)]
+#[derive(Default)]
 pub(crate) struct CtEventFactory {
     tcp_states: HashMap<i32, String>,
 }
@@ -275,14 +280,14 @@ pub(crate) mod benchmark {
     use anyhow::Result;
 
     use super::*;
-    use crate::{benchmark::helpers::*, events::SectionId};
+    use crate::{benchmark::helpers::*, core::events::FactoryId};
 
     impl RawSectionBuilder for RawCtMetaEvent {
         fn build_raw(out: &mut Vec<u8>) -> Result<()> {
             let data = RawCtMetaEvent::default();
             build_raw_section(
                 out,
-                SectionId::Ct.to_u8(),
+                FactoryId::Ct as u8,
                 SECTION_META as u8,
                 &mut as_u8_vec(&data),
             );
@@ -298,7 +303,7 @@ pub(crate) mod benchmark {
             };
             build_raw_section(
                 out,
-                SectionId::Ct.to_u8(),
+                FactoryId::Ct as u8,
                 SECTION_BASE_CONN as u8,
                 &mut as_u8_vec(&data),
             );

--- a/retis/src/module/ct/bpf.rs
+++ b/retis/src/module/ct/bpf.rs
@@ -124,11 +124,7 @@ impl RawEventSectionFactory for CtEventFactory {
 
 impl CtEventFactory {
     pub(super) fn new() -> Result<Self> {
-        Ok(Self::default())
-    }
-
-    pub(super) fn bpf() -> Result<Self> {
-        let mut me = Self::new()?;
+        let mut me = Self::default();
         me.parse_tcp_states()?;
         Ok(me)
     }

--- a/retis/src/module/ct/ct.rs
+++ b/retis/src/module/ct/ct.rs
@@ -15,16 +15,12 @@ use crate::{
     module::Module,
 };
 
-pub(crate) struct CtModule {
-    // Whether the event capturing module was initialized
-    init: bool,
-}
+#[derive(Default)]
+pub(crate) struct CtModule {}
 
 impl Collector for CtModule {
     fn new() -> Result<Self> {
-        Ok(CtModule {
-            init: cfg!(feature = "benchmark"),
-        })
+        Ok(Self::default())
     }
 
     fn known_kernel_types(&self) -> Option<Vec<&'static str>> {
@@ -60,9 +56,7 @@ impl Collector for CtModule {
         _: Arc<RetisEventsFactory>,
     ) -> Result<()> {
         // Register our generic conntrack hook.
-        probes.register_kernel_hook(Hook::from(ct_hook::DATA))?;
-        self.init = true;
-        Ok(())
+        probes.register_kernel_hook(Hook::from(ct_hook::DATA))
     }
 }
 
@@ -71,9 +65,6 @@ impl Module for CtModule {
         self
     }
     fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(match self.init {
-            true => CtEventFactory::bpf()?,
-            false => CtEventFactory::new()?,
-        }))
+        Ok(Box::new(CtEventFactory::new()?))
     }
 }

--- a/retis/src/module/ct/ct.rs
+++ b/retis/src/module/ct/ct.rs
@@ -64,7 +64,7 @@ impl Module for CtModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(CtEventFactory::new()?))
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(CtEventFactory::new()?)))
     }
 }

--- a/retis/src/module/module.rs
+++ b/retis/src/module/module.rs
@@ -9,11 +9,10 @@ use super::{
 use crate::{
     collect::Collector,
     core::{
-        events::{CommonEventFactory, EventSectionFactory, SectionFactories},
+        events::{CommonEventFactory, EventSectionFactory, FactoryId, SectionFactories},
         probe::{kernel::KernelEventFactory, user::UserEventFactory},
     },
     events::*,
-    process::tracking::TrackingInfoEventFactory,
 };
 
 /// Trait that must be implemented by Modules
@@ -81,17 +80,13 @@ impl Modules {
         let mut section_factories: SectionFactories = HashMap::new();
 
         // Register core event sections.
-        section_factories.insert(SectionId::Common, Box::<CommonEventFactory>::default());
-        section_factories.insert(SectionId::Kernel, Box::<KernelEventFactory>::default());
-        section_factories.insert(SectionId::Userspace, Box::<UserEventFactory>::default());
-        section_factories.insert(
-            SectionId::Tracking,
-            Box::<TrackingInfoEventFactory>::default(),
-        );
+        section_factories.insert(FactoryId::Common, Box::<CommonEventFactory>::default());
+        section_factories.insert(FactoryId::Kernel, Box::<KernelEventFactory>::default());
+        section_factories.insert(FactoryId::Userspace, Box::<UserEventFactory>::default());
 
-        for (id, module) in self.modules.iter() {
+        for (_, module) in self.modules.iter() {
             if let Some(factory) = module.section_factory()? {
-                section_factories.insert(*id, factory);
+                section_factories.insert(FactoryId::from_u8(factory.id())?, factory);
             }
         }
         Ok(section_factories)

--- a/retis/src/module/module.rs
+++ b/retis/src/module/module.rs
@@ -20,8 +20,10 @@ use crate::{
 pub(crate) trait Module {
     /// Return a Collector used for collect command
     fn collector(&mut self) -> &mut dyn Collector;
-    /// Return an EventSectionFactory
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>>;
+    /// Return an EventSectionFactory, if any
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(None)
+    }
 }
 
 /// All modules are registered there. The following is the main API and object
@@ -88,7 +90,9 @@ impl Modules {
         );
 
         for (id, module) in self.modules.iter() {
-            section_factories.insert(*id, module.section_factory()?);
+            if let Some(factory) = module.section_factory()? {
+                section_factories.insert(*id, factory);
+            }
         }
         Ok(section_factories)
     }

--- a/retis/src/module/module.rs
+++ b/retis/src/module/module.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt, str::FromStr};
 
 use anyhow::{bail, Result};
 
@@ -12,8 +12,58 @@ use crate::{
         events::{CommonEventFactory, EventSectionFactory, FactoryId, SectionFactories},
         probe::{kernel::KernelEventFactory, user::UserEventFactory},
     },
-    events::*,
 };
+
+/// Module identifiers.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum ModuleId {
+    SkbTracking,
+    Skb,
+    SkbDrop,
+    Ovs,
+    Nft,
+    Ct,
+}
+
+impl ModuleId {
+    /// Converts a ModuleId to a section unique str identifier.
+    pub fn to_str(self) -> &'static str {
+        use ModuleId::*;
+        match self {
+            SkbTracking => "skb-tracking",
+            SkbDrop => "skb-drop",
+            Skb => "skb",
+            Ovs => "ovs",
+            Nft => "nft",
+            Ct => "ct",
+        }
+    }
+}
+
+impl FromStr for ModuleId {
+    type Err = anyhow::Error;
+
+    /// Constructs a ModuleId from a section unique str identifier.
+    fn from_str(val: &str) -> Result<Self> {
+        use ModuleId::*;
+        Ok(match val {
+            "skb-tracking" => SkbTracking,
+            "skb-drop" => SkbDrop,
+            "skb" => Skb,
+            "ovs" => Ovs,
+            "nft" => Nft,
+            "ct" => Ct,
+            x => bail!("Can't construct a ModuleId from {}", x),
+        })
+    }
+}
+
+// Allow using ModuleId in log messages.
+impl fmt::Display for ModuleId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
 
 /// Trait that must be implemented by Modules
 pub(crate) trait Module {
@@ -29,7 +79,7 @@ pub(crate) trait Module {
 /// to manipulate them.
 pub(crate) struct Modules {
     /// Set of registered modules we can use.
-    modules: HashMap<SectionId, Box<dyn Module>>,
+    modules: HashMap<ModuleId, Box<dyn Module>>,
 }
 
 impl Modules {
@@ -50,7 +100,7 @@ impl Modules {
     ///         Box::new(SecondModule::new()?,
     ///     )?;
     /// ```
-    pub(crate) fn register(&mut self, id: SectionId, module: Box<dyn Module>) -> Result<&mut Self> {
+    pub(crate) fn register(&mut self, id: ModuleId, module: Box<dyn Module>) -> Result<&mut Self> {
         // Ensure uniqueness of the module name. This is important as their
         // name is used as a key.
         if self.modules.contains_key(&id) {
@@ -63,7 +113,7 @@ impl Modules {
 
     /// Get an hashmap of all the collectors available in the registered
     /// modules.
-    pub(crate) fn collectors(&mut self) -> HashMap<&SectionId, &mut dyn Collector> {
+    pub(crate) fn collectors(&mut self) -> HashMap<&ModuleId, &mut dyn Collector> {
         self.modules
             .iter_mut()
             .map(|(id, m)| (id, m.collector()))
@@ -71,7 +121,7 @@ impl Modules {
     }
 
     /// Get a specific collector, if found in the registered modules.
-    pub(crate) fn get_collector(&mut self, id: &SectionId) -> Option<&mut dyn Collector> {
+    pub(crate) fn get_collector(&mut self, id: &ModuleId) -> Option<&mut dyn Collector> {
         self.modules.get_mut(id).map(|m| m.collector())
     }
 
@@ -98,12 +148,12 @@ pub(crate) fn get_modules() -> Result<Modules> {
 
     // Register all collectors here.
     group
-        .register(SectionId::SkbTracking, Box::new(SkbTrackingModule::new()?))?
-        .register(SectionId::Skb, Box::new(SkbModule::new()?))?
-        .register(SectionId::SkbDrop, Box::new(SkbDropModule::new()?))?
-        .register(SectionId::Ovs, Box::new(OvsModule::new()?))?
-        .register(SectionId::Nft, Box::new(NftModule::new()?))?
-        .register(SectionId::Ct, Box::new(CtModule::new()?))?;
+        .register(ModuleId::SkbTracking, Box::new(SkbTrackingModule::new()?))?
+        .register(ModuleId::Skb, Box::new(SkbModule::new()?))?
+        .register(ModuleId::SkbDrop, Box::new(SkbDropModule::new()?))?
+        .register(ModuleId::Ovs, Box::new(OvsModule::new()?))?
+        .register(ModuleId::Nft, Box::new(NftModule::new()?))?
+        .register(ModuleId::Ct, Box::new(CtModule::new()?))?;
 
     Ok(group)
 }

--- a/retis/src/module/nft/bpf.rs
+++ b/retis/src/module/nft/bpf.rs
@@ -2,9 +2,10 @@ use anyhow::Result;
 
 use crate::{
     core::events::{
-        parse_single_raw_section, BpfRawSection, EventSectionFactory, RawEventSectionFactory,
+        parse_single_raw_section, BpfRawSection, EventSectionFactory, FactoryId,
+        RawEventSectionFactory,
     },
-    event_byte_array,
+    event_byte_array, event_section_factory,
     events::*,
     raw_event_section,
 };
@@ -85,13 +86,14 @@ struct NftBpfEvent {
     p: u8,
 }
 
-#[derive(Default, crate::EventSectionFactory)]
+#[event_section_factory(FactoryId::Nft)]
+#[derive(Default)]
 pub(crate) struct NftEventFactory {}
 
 impl RawEventSectionFactory for NftEventFactory {
     fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
         let mut event = NftEvent::default();
-        let raw = parse_single_raw_section::<NftBpfEvent>(SectionId::Nft, &raw_sections)?;
+        let raw = parse_single_raw_section::<NftBpfEvent>(&raw_sections)?;
 
         event.table_name = raw.tn.to_string()?;
         event.chain_name = raw.cn.to_string()?;

--- a/retis/src/module/nft/nft.rs
+++ b/retis/src/module/nft/nft.rs
@@ -53,8 +53,8 @@ impl Module for NftModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(NftEventFactory {}))
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(NftEventFactory {})))
     }
 }
 

--- a/retis/src/module/ovs/bpf.rs
+++ b/retis/src/module/ovs/bpf.rs
@@ -7,7 +7,10 @@ use std::net::Ipv6Addr;
 use anyhow::{bail, Result};
 
 use crate::{
-    core::events::{parse_raw_section, BpfRawSection, EventSectionFactory, RawEventSectionFactory},
+    core::events::{
+        parse_raw_section, BpfRawSection, EventSectionFactory, FactoryId, RawEventSectionFactory,
+    },
+    event_section_factory,
     events::*,
     helpers, raw_event_section,
 };
@@ -346,7 +349,8 @@ pub(super) fn unmarshall_upcall_return(
     Ok(())
 }
 
-#[derive(Default, crate::EventSectionFactory)]
+#[event_section_factory(FactoryId::Ovs)]
+#[derive(Default)]
 pub(crate) struct OvsEventFactory {}
 
 impl RawEventSectionFactory for OvsEventFactory {
@@ -377,7 +381,7 @@ pub(crate) mod benchmark {
     use anyhow::Result;
 
     use super::*;
-    use crate::{benchmark::helpers::*, events::SectionId};
+    use crate::{benchmark::helpers::*, core::events::FactoryId};
 
     impl RawSectionBuilder for BpfActionEvent {
         fn build_raw(out: &mut Vec<u8>) -> Result<()> {
@@ -387,7 +391,7 @@ pub(crate) mod benchmark {
             };
             build_raw_section(
                 out,
-                SectionId::Ovs.to_u8(),
+                FactoryId::Ovs as u8,
                 OvsDataType::ActionExec as u8,
                 &mut as_u8_vec(&data),
             );

--- a/retis/src/module/ovs/ovs.rs
+++ b/retis/src/module/ovs/ovs.rs
@@ -141,8 +141,8 @@ impl Module for OvsModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(OvsEventFactory {}))
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(OvsEventFactory {})))
     }
 }
 

--- a/retis/src/module/skb/bpf.rs
+++ b/retis/src/module/skb/bpf.rs
@@ -17,7 +17,7 @@ use crate::{
     core::events::{
         parse_raw_section, BpfRawSection, EventSectionFactory, FactoryId, RawEventSectionFactory,
     },
-    event_byte_array,
+    event_byte_array, event_section_factory,
     events::{
         net::{etype_str, RawPacket},
         *,

--- a/retis/src/module/skb/bpf.rs
+++ b/retis/src/module/skb/bpf.rs
@@ -14,7 +14,9 @@ use pnet_packet::{
 };
 
 use crate::{
-    core::events::{parse_raw_section, BpfRawSection, EventSectionFactory, RawEventSectionFactory},
+    core::events::{
+        parse_raw_section, BpfRawSection, EventSectionFactory, FactoryId, RawEventSectionFactory,
+    },
     event_byte_array,
     events::{
         net::{etype_str, RawPacket},
@@ -364,7 +366,8 @@ fn unmarshal_l4(
     Ok(())
 }
 
-#[derive(Default, crate::EventSectionFactory)]
+#[event_section_factory(FactoryId::Skb)]
+#[derive(Default)]
 pub(crate) struct SkbEventFactory {
     // Should we report the Ethernet header.
     pub(super) report_eth: bool,
@@ -395,7 +398,7 @@ pub(crate) mod benchmark {
     use anyhow::Result;
 
     use super::*;
-    use crate::{benchmark::helpers::*, events::SectionId};
+    use crate::{benchmark::helpers::*, core::events::FactoryId};
 
     impl RawSectionBuilder for RawDevEvent {
         fn build_raw(out: &mut Vec<u8>) -> Result<()> {
@@ -407,7 +410,7 @@ pub(crate) mod benchmark {
             };
             build_raw_section(
                 out,
-                SectionId::Skb.to_u8(),
+                FactoryId::Skb as u8,
                 SECTION_DEV as u8,
                 &mut as_u8_vec(&data),
             );
@@ -420,7 +423,7 @@ pub(crate) mod benchmark {
             let data = RawNsEvent::default();
             build_raw_section(
                 out,
-                SectionId::Skb.to_u8(),
+                FactoryId::Skb as u8,
                 SECTION_NS as u8,
                 &mut as_u8_vec(&data),
             );
@@ -450,7 +453,7 @@ pub(crate) mod benchmark {
             };
             build_raw_section(
                 out,
-                SectionId::Skb.to_u8(),
+                FactoryId::Skb as u8,
                 SECTION_PACKET as u8,
                 &mut as_u8_vec(&data),
             );

--- a/retis/src/module/skb/skb.rs
+++ b/retis/src/module/skb/skb.rs
@@ -131,10 +131,10 @@ impl Module for SkbModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(SkbEventFactory {
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(SkbEventFactory {
             report_eth: self.report_eth,
-        }))
+        })))
     }
 }
 

--- a/retis/src/module/skb_drop/bpf.rs
+++ b/retis/src/module/skb_drop/bpf.rs
@@ -13,10 +13,12 @@ const SKB_DROP_REASON_SUBSYS_SHIFT: u32 = 16;
 use crate::{
     core::{
         events::{
-            parse_single_raw_section, BpfRawSection, EventSectionFactory, RawEventSectionFactory,
+            parse_single_raw_section, BpfRawSection, EventSectionFactory, FactoryId,
+            RawEventSectionFactory,
         },
         inspect::inspector,
     },
+    event_section_factory,
     events::*,
 };
 
@@ -81,7 +83,7 @@ impl DropReasons {
     }
 }
 
-#[derive(crate::EventSectionFactory)]
+#[event_section_factory(FactoryId::SkbDrop)]
 pub(crate) struct SkbDropEventFactory {
     /// Map of sub-system reason ids to their custom drop reason definitions.
     reasons: HashMap<u16, DropReasons>,
@@ -89,7 +91,7 @@ pub(crate) struct SkbDropEventFactory {
 
 impl RawEventSectionFactory for SkbDropEventFactory {
     fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let raw = parse_single_raw_section::<BpfSkbDropEvent>(SectionId::SkbDrop, &raw_sections)?;
+        let raw = parse_single_raw_section::<BpfSkbDropEvent>(&raw_sections)?;
 
         let drop_reason = raw.drop_reason;
         let (subsys, drop_reason) = self.get_reason(drop_reason);

--- a/retis/src/module/skb_drop/skb_drop.rs
+++ b/retis/src/module/skb_drop/skb_drop.rs
@@ -104,7 +104,7 @@ impl Module for SkbDropModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(SkbDropEventFactory::new()?))
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(SkbDropEventFactory::new()?)))
     }
 }

--- a/retis/src/module/skb_drop/skb_drop.rs
+++ b/retis/src/module/skb_drop/skb_drop.rs
@@ -19,15 +19,12 @@ use crate::{
 
 pub(crate) struct SkbDropModule {
     reasons_available: bool,
-    // Was the module initialized, aka. installed BPF probes and hooks?
-    initialized: bool,
 }
 
 impl Collector for SkbDropModule {
     fn new() -> Result<Self> {
         Ok(Self {
             reasons_available: true,
-            initialized: cfg!(feature = "benchmark"),
         })
     }
 
@@ -99,7 +96,6 @@ impl Collector for SkbDropModule {
             bail!("Could not attach to skb:kfree_skb: {}", e);
         }
 
-        self.initialized = true;
         Ok(())
     }
 }
@@ -109,9 +105,6 @@ impl Module for SkbDropModule {
         self
     }
     fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(match self.initialized {
-            true => SkbDropEventFactory::bpf()?,
-            false => SkbDropEventFactory::new()?,
-        }))
+        Ok(Box::new(SkbDropEventFactory::new()?))
     }
 }

--- a/retis/src/module/skb_tracking/skb_tracking.rs
+++ b/retis/src/module/skb_tracking/skb_tracking.rs
@@ -10,9 +10,9 @@ use crate::{
         events::*,
         probe::{manager::ProbeBuilderManager, Hook},
     },
+    event_section_factory,
     events::*,
     module::Module,
-    EventSectionFactory,
 };
 
 #[derive(Default)]
@@ -50,13 +50,13 @@ impl Module for SkbTrackingModule {
     }
 }
 
-#[derive(Default, EventSectionFactory)]
+#[event_section_factory(FactoryId::SkbTracking)]
+#[derive(Default)]
 pub(crate) struct SkbTrackingEventFactory {}
 
 impl RawEventSectionFactory for SkbTrackingEventFactory {
     fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let event =
-            parse_single_raw_section::<SkbTrackingEvent>(SectionId::SkbTracking, &raw_sections)?;
+        let event = parse_single_raw_section::<SkbTrackingEvent>(&raw_sections)?;
 
         Ok(Box::new(*event))
     }
@@ -66,20 +66,12 @@ impl RawEventSectionFactory for SkbTrackingEventFactory {
 pub(crate) mod benchmark {
     use anyhow::Result;
 
-    use crate::{
-        benchmark::helpers::*,
-        events::{SectionId, SkbTrackingEvent},
-    };
+    use crate::{benchmark::helpers::*, core::events::FactoryId, events::SkbTrackingEvent};
 
     impl RawSectionBuilder for SkbTrackingEvent {
         fn build_raw(out: &mut Vec<u8>) -> Result<()> {
             let data = SkbTrackingEvent::default();
-            build_raw_section(
-                out,
-                SectionId::SkbTracking.to_u8(),
-                0,
-                &mut as_u8_vec(&data),
-            );
+            build_raw_section(out, FactoryId::SkbTracking as u8, 0, &mut as_u8_vec(&data));
             Ok(())
         }
     }

--- a/retis/src/module/skb_tracking/skb_tracking.rs
+++ b/retis/src/module/skb_tracking/skb_tracking.rs
@@ -45,8 +45,8 @@ impl Module for SkbTrackingModule {
     fn collector(&mut self) -> &mut dyn Collector {
         self
     }
-    fn section_factory(&self) -> Result<Box<dyn EventSectionFactory>> {
-        Ok(Box::new(SkbTrackingEventFactory {}))
+    fn section_factory(&self) -> Result<Option<Box<dyn EventSectionFactory>>> {
+        Ok(Some(Box::new(SkbTrackingEventFactory {})))
     }
 }
 

--- a/retis/src/process/tracking.rs
+++ b/retis/src/process/tracking.rs
@@ -14,19 +14,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Result};
 
-use crate::{
-    core::events::{BpfRawSection, EventSectionFactory, RawEventSectionFactory},
-    events::*,
-};
-
-#[derive(Default, crate::EventSectionFactory)]
-pub(crate) struct TrackingInfoEventFactory {}
-
-impl RawEventSectionFactory for TrackingInfoEventFactory {
-    fn create(&mut self, _: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        bail!("TrackingInfoEvents cannot be created from bpf")
-    }
-}
+use crate::events::*;
 
 // Data identifying an OvsUpcall Event
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Semi-RFC material; since code is ready let's not flag it but feel free to discuss the approach :)

The main goal of this series is $title, and some preliminary work for a possible future removal of the module concept. In any way this solve issues linked to how the section ids were used which did not map to the reality:

- Factories are tied to a BPF counterpart, not to an event section. Eg. the tracking section is generated at post-processing time and does not have any link to the BPF side.
- Modules are not strictly tied to event sections. Eg. all core sections do not have a corresponding module.
- Factories and modules are not in a 1:1 relationship. Eg. core factories are not in a module.

This also now allows to have a factory producing more than a single type of event section; this is no side effect and is intended.

Overall this was something I wanted to tackle for some time now, but I was keeping it for later. But adding support for `enum sk_rst_reason` showed w/o this preliminary rework things would have gotten even worse between event sections, factories and modules. This is why I chose to keep those patches in that PR; but I can split into two PRs if needed.

One question I have is with the last commit: should be put all those "common types" into the same event section or add one for each. Having a dedicated section helps for possible future improvement (more fields when applicable), but makes event section count to potentially grow quite a lot. Also I should find a better name instead of "common types".