### PR TITLE
events: ct: make CtConnEvent an event_type

### DIFF
--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -111,8 +111,9 @@ pub struct CtEvent {
     pub parent: Option<CtConnEvent>,
 }
 
-/// Conntrack event
-#[event_section("ct")]
+/// Conntrack connection information
+#[event_type]
+#[derive(Default)]
 pub struct CtConnEvent {
     /// Zone ID
     pub zone_id: u16,


### PR DESCRIPTION
CtConnEvent is not an event section, it's an event type embedded into the "ct" event section.