### PR TITLE
Containerfile and workflow improvements

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,10 @@
+**
+!Makefile
+!ebpf.mk
+!**/Cargo.*
+!retis-derive
+!retis-events
+!retis/profiles
+!retis/build.rs
+!retis/src
+!tools

--- a/.github/workflows/build_push_image.yaml
+++ b/.github/workflows/build_push_image.yaml
@@ -1,0 +1,66 @@
+name: Build and push container image
+
+on:
+  # Manual trigger for the workflow.
+  workflow_dispatch:
+    inputs:
+      release_tags:
+        required: false
+        default: 'next'
+
+  # Every day at 01:32 AM UTC.
+  schedule:
+    - cron: "32 01 * * *"
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # This is kept intentionally separate from "Set environment".
+      - name: Check scheduled run
+        if: github.event_name == 'schedule'
+        run: |
+          last_commit=$(git log -n1 --since=yesterday --oneline)
+          if [ -z "${last_commit}" ]; then
+              echo "No new commits found, cancelling ..."
+              exit 1
+          else
+              echo "Proceeding with the current tip:"
+              echo "  ${last_commit}"
+          fi
+
+      - name: Set environment
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "RELEASE_TAGS=${{ github.event.inputs.release_tags }}" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+              echo "RELEASE_TAGS=next" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "release" ]; then
+              :
+          fi
+
+      - name: Build container image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: ./Containerfile
+          image: retis
+          tags: ${{ env.RELEASE_TAGS }}
+
+      - name: Push container image
+        id: push_image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          tags: ${{ steps.build_image.outputs.tags }}
+          registry: quay.io/retis
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "${{ toJSON(steps.push_image.outputs) }}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,10 +18,9 @@
          not that can be set in the project settings.
       1. `Packages > Rebuild`.
    1. Build and push the container image.
-      1. `$ buildah build -t quay.io/retis/retis:x.y.z`
-      1. `$ buildah push quay.io/retis/retis:x.y.z`
-      1. Manually tag on the web UI the image pushed with `latest`, if
-         applicable.
+      1. Manually run the workflow [Build and push container image](https://github.com/retis-org/retis/actions/workflows/build_push_image.yaml)
+         (in the Actions tab on the Retis Github page) selecting the branch and setting the
+         `release_tags` with the space separated list of tags (i.e. release_tags="x.y.z latest").
 1. Release on [crates.io](https://crates.io): `cargo publish`.
 1. Write and publish a release notes in the GitHub interface. This must be done
    once the rpm and the image successfully built to allow pushing last minute


### PR DESCRIPTION
- Modifies `Containerfile` keeping in mind the workspace structure
  - while at it, included some clean-ups
- Introduces the creation of a new image based on the current main
  - scheduled every 1st of the month
  - can be triggered manually
- Simplifies the release process
  - RELEASE.md was updated accordingly
- Tokens have been added to the repo settings

Workflow complete run:
- [manual](https://github.com/vlrpl/retis/actions/runs/11386275978/job/31678089186)
  - nexttest latest-nexttest
- [scheduled](https://github.com/vlrpl/retis/actions/runs/11384264586/job/31671597581) 
  - next

New images generated with the workflow (will be deleted):
https://quay.io/repository/retis/retis?tab=tags

Fixes #291 