### PR TITLE
ct: add support for mark and labels

### DIFF
--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::*;
+use super::{helpers::U128, *};
 use crate::{event_section, event_type, Formatter};
 
 #[event_type]
@@ -127,6 +127,8 @@ pub struct CtConnEvent {
     pub tcp_state: Option<String>,
     /// Connection mark tracking label
     pub mark: Option<u32>,
+    /// Connection tracking labels.
+    pub labels: Option<U128>,
 }
 
 impl EventFmt for CtEvent {
@@ -210,6 +212,10 @@ impl CtEvent {
 
         if let Some(mark) = conn.mark {
             write!(f, " mark {}", mark)?;
+        }
+
+        if let Some(labels) = &conn.labels {
+            write!(f, " labels {:#x}", labels.bits())?;
         }
 
         Ok(())

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -125,6 +125,8 @@ pub struct CtConnEvent {
     pub reply: CtTuple,
     /// TCP state; if any
     pub tcp_state: Option<String>,
+    /// Connection mark tracking label
+    pub mark: Option<u32>,
 }
 
 impl EventFmt for CtEvent {
@@ -204,6 +206,10 @@ impl CtEvent {
             ZoneDir::Reply => write!(f, "reply-zone {}", conn.zone_id)?,
             ZoneDir::Default => write!(f, "zone {}", conn.zone_id)?,
             ZoneDir::None => (),
+        }
+
+        if let Some(mark) = conn.mark {
+            write!(f, " mark {}", mark)?;
         }
 
         Ok(())

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -142,7 +142,7 @@ impl EventFmt for CtEvent {
         Self::format_conn(&self.base, f)?;
 
         if let Some(parent) = &self.parent {
-            write!(f, " parent [")?;
+            write!(f, "\n\\ parent [")?;
             Self::format_conn(parent, f)?;
             write!(f, "]")?;
         }

--- a/retis-events/src/helpers.rs
+++ b/retis-events/src/helpers.rs
@@ -54,6 +54,27 @@ pub(crate) fn protocol_str(protocol: u8) -> Option<&'static str> {
     })
 }
 
+/// u128 representation in the events. We can't use the Rust primitive as serde
+/// does not handle the type well.
+#[event_type]
+pub struct U128 {
+    hi: u64,
+    lo: u64,
+}
+
+impl U128 {
+    pub fn from_u128(from: u128) -> Self {
+        Self {
+            hi: (from >> 64) as u64,
+            lo: from as u64,
+        }
+    }
+
+    pub fn bits(&self) -> u128 {
+        (self.hi as u128) << 64 | self.lo as u128
+    }
+}
+
 /// Represents a raw packet. Stored internally as a `Vec<u8>`.
 /// We don't use #[event_type] as we're implementing serde::Serialize and
 /// serde::Deserialize manually.

--- a/retis-events/src/helpers.rs
+++ b/retis-events/src/helpers.rs
@@ -5,6 +5,8 @@ use base64::{
     display::Base64Display, engine::general_purpose::STANDARD, prelude::BASE64_STANDARD, Engine,
 };
 
+use crate::event_type;
+
 /// Returns a translation of some ethertypes into a readable format.
 pub fn etype_str(etype: u16) -> Option<&'static str> {
     Some(match etype {

--- a/retis-events/src/lib.rs
+++ b/retis-events/src/lib.rs
@@ -13,7 +13,7 @@ pub mod display;
 pub use display::*;
 
 pub mod file;
-pub mod net;
+pub mod helpers;
 #[cfg(feature = "python")]
 pub mod python;
 #[cfg(feature = "python-embed")]

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use super::{
-    net::{etype_str, protocol_str, RawPacket},
+    helpers::{etype_str, protocol_str, RawPacket},
     *,
 };
 use crate::{event_section, event_type, Formatter};

--- a/retis/src/bindings/ct_uapi.rs
+++ b/retis/src/bindings/ct_uapi.rs
@@ -74,6 +74,7 @@ pub struct ct_event {
     pub orig: nf_conn_tuple,
     pub reply: nf_conn_tuple,
     pub flags: u32_,
+    pub mark: u32_,
     pub zone_id: u16_,
     pub tcp_state: u8_,
 }

--- a/retis/src/bindings/ct_uapi.rs
+++ b/retis/src/bindings/ct_uapi.rs
@@ -75,6 +75,7 @@ pub struct ct_event {
     pub reply: nf_conn_tuple,
     pub flags: u32_,
     pub mark: u32_,
+    pub labels: [u8_; 16usize],
     pub zone_id: u16_,
     pub tcp_state: u8_,
 }

--- a/retis/src/core/probe/kernel/bpf/include/helpers.h
+++ b/retis/src/core/probe/kernel/bpf/include/helpers.h
@@ -5,6 +5,12 @@
 
 #define MIN(a, b)	(((a) < (b)) ? (a) : (b))
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define BUILD_BUG_ON(cond)	_Static_assert(!(cond), "BUILD_BUG_ON failed " #cond)
+#else
+#define BUILD_BUG_ON(cond)
+#endif
+
 enum bpf_func_id___x { BPF_FUNC_get_func_ip___5_15_0 = 42 };
 
 /* The following helper retrieves the function IP in kprobes.

--- a/retis/src/module/skb/bpf.rs
+++ b/retis/src/module/skb/bpf.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     event_section_factory,
     events::{
-        net::{etype_str, RawPacket},
+        helpers::{etype_str, RawPacket},
         *,
     },
     helpers,


### PR DESCRIPTION
RFC as I don't want this to be merged before the bindgen PR (#419); this will need to be rebased.

A test image is available and can be used as follow:

```
$ RETIS_TAG=ct-mark-label ./retis_in_container.sh collect -c ct ...
```

Labels can be set for testing, eg:

```
$ iptables -A INPUT -m connlabel --label 42 --set
```

A few questions / remarks:
- I took the opportunity to make the parent ct information to be printed on a newline. Is that understandable?
- Both the mark and labels are retrieved for the base *and* the parent `nf_conn`.
- Labels are a bitmask; I chose to print them as an hex value to save some space. Is that fine?

@igsilya can you help testing to make sure this looks good? Thanks!

Close #407.