### PR TITLE
Try mounting debugfs if not there + a bonus patch

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,7 +9,7 @@ the `collect` sub-command.
 - Access to `/sys/kernel/btf` and `/proc/kallsyms` to parse kernel functions and
   types.
 - `debugfs` should be mounted to `/sys/kernel/debug` to allow filtering
-  functions and events.
+  functions and events (or `--allow-system-changes` must be set).
 
 ## Kernel Kconfig options
 

--- a/retis/Cargo.toml
+++ b/retis/Cargo.toml
@@ -42,7 +42,7 @@ libbpf-sys = "=1.2"
 libc = "0.2"
 log = { version = "0.4", features = ["std"] }
 memoffset = "0.9"
-nix = { version = "0.28", features = ["feature", "time", "user"] }
+nix = { version = "0.28", features = ["feature", "mount", "time", "user"] }
 once_cell = "1.15"
 pager = "0.16"
 pcap = "1.3"

--- a/retis/src/cli/cli.rs
+++ b/retis/src/cli/cli.rs
@@ -29,8 +29,6 @@ use crate::{
 
 /// SubCommandRunner defines the common interface to run SubCommands.
 pub(crate) trait SubCommandRunner {
-    /// Checks global prerequisites for the command to run successfully.
-    fn check_prerequisites(&self) -> Result<()>;
     /// Run the subcommand with a given set of modules and cli configuration
     fn run(&mut self, cli: FullCli, modules: Modules) -> Result<()>;
 }
@@ -56,9 +54,6 @@ impl<F> SubCommandRunner for SubCommandRunnerFunc<F>
 where
     F: Fn(FullCli, Modules) -> Result<()>,
 {
-    fn check_prerequisites(&self) -> Result<()> {
-        Ok(())
-    }
     fn run(&mut self, cli: FullCli, modules: Modules) -> Result<()> {
         (self.func)(cli, modules)
     }

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -116,19 +116,22 @@ Notes:
         long,
         default_value = "false",
         help = r#"Allow the tool to setup all the system changes needed to make the tracing
-fully operational.
+fully operational:
 
-Specifically, in the case the nft module is used, it creates a dummy table called "Retis_Table"
-as the following:
+- Mounting debugfs to /sys/kernel/debug if not already mounted. If Retis mounted debugfs it
+  will unmount it when stopped.
 
-table inet Retis_Table {
-    chain Retis_Chain {
-        meta nftrace set 1
+- In the case the nft module is used, creating a dummy table called "Retis_Table"
+  as the following:
+
+    table inet Retis_Table {
+        chain Retis_Chain {
+            meta nftrace set 1
+        }
     }
-}
 
-The table will be removed once the program gets stopped.
-Note that the tool tries to remove "Retis_Table" before creating it.
+  The table will be removed once the program gets stopped. Note that the tool tries to remove
+  "Retis_Table" before creating it.
 "#
     )]
     pub(crate) allow_system_changes: bool,

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -191,15 +191,16 @@ impl Collectors {
             bail!("Probe-stack mode requires filtering (--filter-packet and/or --filter-meta)");
         }
 
+        // --allow-system-changes requires root.
+        if collect.args()?.allow_system_changes && !Uid::effective().is_root() {
+            bail!("Retis needs to be run as root when --allow-system-changes is used");
+        }
+
+        // Check if we need to report stack traces in the events.
         if collect.args()?.stack || collect.args()?.probe_stack {
             self.probes
                 .builder_mut()?
                 .set_probe_opt(probe::ProbeOption::StackTrace)?;
-        }
-
-        // --allow-system-changes requires root.
-        if collect.args()?.allow_system_changes && !Uid::effective().is_root() {
-            bail!("Retis needs to be run as root when --allow-system-changes is used");
         }
 
         // Generate an initial event with the startup section.

--- a/retis/src/collect/collector.rs
+++ b/retis/src/collect/collector.rs
@@ -562,13 +562,15 @@ pub(crate) struct CollectRunner {}
 
 impl SubCommandRunner for CollectRunner {
     fn run(&mut self, cli: FullCli, modules: Modules) -> Result<()> {
-        // Initialize collectors.
-        let mut collectors = Collectors::new(modules)?;
         // Collector arguments are arealdy registered when build FullCli
         let cli = cli.run()?;
+
+        // Initialize & start collectors.
+        let mut collectors = Collectors::new(modules)?;
         collectors.check(&cli)?;
         collectors.init(&cli)?;
         collectors.start()?;
+
         // Starts a loop.
         collectors.process(&cli)?;
         Ok(())

--- a/retis/src/generate/completion.rs
+++ b/retis/src/generate/completion.rs
@@ -67,10 +67,6 @@ impl SubCommand for Complete {
 pub(crate) struct CompleteRunner {}
 
 impl SubCommandRunner for CompleteRunner {
-    fn check_prerequisites(&self) -> Result<()> {
-        Ok(())
-    }
-
     fn run(&mut self, cli: FullCli, _modules: Modules) -> Result<()> {
         let mut cmd = cli.get_command();
         let matches = cli.get_command().get_matches();

--- a/retis/src/main.rs
+++ b/retis/src/main.rs
@@ -66,7 +66,6 @@ fn main() -> Result<()> {
     }
 
     let mut runner = command.runner()?;
-    runner.check_prerequisites()?;
     runner.run(cli, modules)?;
     Ok(())
 }


### PR DESCRIPTION
If `debugfs` is not mounted (eg. in containers, namespaces) try mounting it if `--allow-system-changes` is set. The bonus patch is making `retis collect --help` not requiring root privileges.

Closes #402, closes #278.