### PR TITLE
events: formatting: fix newline at end of buffer handling

### DIFF
--- a/retis-events/src/display.rs
+++ b/retis-events/src/display.rs
@@ -125,14 +125,18 @@ impl<'a, 'inner> Formatter<'a, 'inner> {
             prefix = " ".repeat(self.level);
         }
 
+        // If the buffer ends with a newline, the last split will be empty. In
+        // such case only print the newline.
         lines.try_for_each(|line| {
             self.inner.write_char('\n')?;
-            self.inner.write_str(&prefix)?;
-            self.inner.write_str(line)
+            if !line.is_empty() {
+                self.inner.write_str(&prefix)?;
+                self.inner.write_str(line)?;
+            }
+            Ok(())
         })?;
 
         if self.buf.ends_with('\n') {
-            self.inner.write_char('\n')?;
             self.start = true;
         }
 


### PR DESCRIPTION
When a newline is found at the end of the buffer it was printed twice. This is because splitting such string will result in having an empty last split. The logic was then printing a new line for the split and because one was at the end of the buffer.

This also prevents from printing the prefix and fixes cases where a double newline is found in the middle of the buffer.