### PR TITLE
CI: temporarily workaround vagrant dependency failure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,7 +125,7 @@ functional_task:
       # Installing it from Hashicorp directly
     - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-    - DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractiven apt-get -y install vagrant ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make ruby-nokogiri
+    - DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractiven apt-get -y install vagrant=2.4.1-1 ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make ruby-nokogiri
     - vagrant plugin install vagrant-libvirt
     - systemctl enable --now libvirtd
 


### PR DESCRIPTION
Temporarily fix the failure in the CI by using 2.4.1-1 until the fixed version is available