### PR TITLE
docs: Fix "Edit on GitHub" links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://retis.readthedocs.io/
 docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/retis-org/retis
+edit_uri: edit/main/docs/
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
Currently, "Edit on GitHub" links points to the wrong "master" branch so use "main" branch instead.

See https://github.com/mkdocs/mkdocs/issues/1578#issuecomment-410836503