### PR TITLE
Added RETIS_IMAGE environment variable for alternate image location

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -50,6 +50,13 @@ fully functional.
 $ RETIS_TAG=next ./retis_in_container.sh --help
 ```
 
+For those operating in a disconnected environment, an environment variable `RETIS_IMAGE` can be
+used to point to an alternate image location.
+
+```none
+$ RETIS_IMAGE=my-registry.example.com/retis ./retis_in_container.sh --help
+```
+
 ### From sources
 
 Retis depends on the following (in addition to Git and Cargo):

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 set -e
+RETIS_IMAGE=${RETIS_IMAGE:-quay.io/retis/retis}
 RETIS_TAG=${RETIS_TAG:-latest}
+
 
 # Auto-detect the available runtime.
 if command -v podman >/dev/null; then
@@ -60,4 +62,4 @@ exec $runtime run $extra_args $term_opts --privileged --rm --pid=host \
       -v $(pwd):/data:rw \
       $local_conf \
       $ovs_binary_mount \
-      quay.io/retis/retis:$RETIS_TAG "$@"
+      $RETIS_IMAGE:$RETIS_TAG "$@"


### PR DESCRIPTION
Added an environment variable in tools/retis_in_container.sh to point to an alternate location for the retis container image for use by those in disconnected environments.