### PR TITLE
events: skb: add RARP support

### DIFF
--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -87,6 +87,12 @@ impl EventFmt for SkbEvent {
                 ArpOperation::Reply => {
                     write!(f, "reply {} is-at {}", arp.spa, arp.sha)?;
                 }
+                ArpOperation::ReverseRequest => {
+                    write!(f, "reverse request who-is {} tell {}", arp.tha, arp.sha)?;
+                }
+                ArpOperation::ReverseReply => {
+                    write!(f, "reverse reply {} at {}", arp.tha, arp.tpa)?;
+                }
             }
         }
 
@@ -328,6 +334,8 @@ pub struct SkbArpEvent {
 pub enum ArpOperation {
     Request,
     Reply,
+    ReverseRequest,
+    ReverseReply,
 }
 
 /// IPv4/IPv6 fields.

--- a/retis/src/module/skb/bpf.rs
+++ b/retis/src/module/skb/bpf.rs
@@ -38,6 +38,8 @@ pub(super) fn unmarshal_arp(arp: &ArpPacket) -> Result<Option<SkbArpEvent>> {
     let operation = match arp.get_operation().0 {
         1 => ArpOperation::Request,
         2 => ArpOperation::Reply,
+        3 => ArpOperation::ReverseRequest,
+        4 => ArpOperation::ReverseReply,
         // We only support ARP for IPv4 over Ethernet; request & reply */
         _ => return Ok(None),
     };


### PR DESCRIPTION
While reverse ARP is quite old and note widely used, there are setups where it can still be seen; e.g. live migration of VMs. Let's not silence those ARP packets.