### PR TITLE
[RFC] Introduce checkpatch action

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,6 @@
+--no-tree
+
+--ignore EMAIL_SUBJECT
+--ignore FILE_PATH_CHANGES
+--ignore SPDX_LICENSE_TAG
+--ignore VOLATILE

--- a/.github/workflows/checkpatch.yaml
+++ b/.github/workflows/checkpatch.yaml
@@ -1,0 +1,14 @@
+name: eBPF coding style check
+on: [pull_request]
+jobs:
+  review:
+    name: checkpatch run
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: $((${{ github.event.pull_request.commits }} + 1))
+    - name: Run checkpatch
+      uses: webispy/checkpatch-action@v9

--- a/retis/src/core/filters/packets/bpf/include/packet_filter.h
+++ b/retis/src/core/filters/packets/bpf/include/packet_filter.h
@@ -75,7 +75,7 @@ unsigned int packet_filter(struct retis_packet_filter_ctx *ctx, u32 placeholder)
 		  "r4", "r5", "r6", "r7",
 		  "r8", "r9");
 
-	return ctx->ret;
-}
+ return ctx->ret;
+ } 
 
 #endif

--- a/retis/src/core/filters/packets/bpf/include/packet_filter.h
+++ b/retis/src/core/filters/packets/bpf/include/packet_filter.h
@@ -56,10 +56,11 @@ unsigned int packet_filter(struct retis_packet_filter_ctx *ctx, u32 placeholder)
 	u8 stack[STACK_SIZE] __attribute__ ((aligned (8)));
 	register u64 *fp asm("r9");
 
-	if (!ctx)
+	if (!ctx) {
 		return 0;
+	}
 
-	ctx_reg = ctx;
+   ctx_reg = ctx;
 	fp = (u64 *)((void *)stack + sizeof(stack));
 
 	asm volatile (

--- a/retis/src/core/probe/kernel/bpf/raw_tracepoint.bpf.c
+++ b/retis/src/core/probe/kernel/bpf/raw_tracepoint.bpf.c
@@ -6,7 +6,7 @@
 /* It is safe to have these values per-object as the loaded object won't be
  * shared between attached programs for raw tracepoints.
  */
-const volatile u64 ksym = 0;
+ const volatile u64 ksym = 0;
 const volatile u32 nargs = 0;
 
 /* We unroll the loop bellow as the verifier disallow arithmetic operations on


### PR DESCRIPTION
Reusing an existing GH action doesn't seem bad, but Cirrus would be fairly simple.

If Cirrus or in general we reach a consensus around not reusing the action used here, we have to decide whether we have to redistribute `checkpatch.pl` (and `spelling.txt`)

Included a couple of patches that intentionally introduce some coding style issues to show the pros and cons of the action.

Configs have been left intentionally loose, feel free to propose what you think could make sense.