### PR TITLE
Add basic tests for VLAN

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,8 @@ dnf install -y \
     socat \
     nftables \
     make \
-    jq
+    jq \
+    ethtool
 
     python3 -m pip install pytest pyroute2
 SCRIPT

--- a/retis/src/module/skb/bpf/include/if_vlan.h
+++ b/retis/src/module/skb/bpf/include/if_vlan.h
@@ -1,7 +1,8 @@
 #ifndef __MODULE_SKB_BPF_IF_VLAN__
 #define __MODULE_SKB_BPF_IF_VLAN__
 
-/* Code to handle VLAN tags ported from source/include/linux/if_vlan.h and modified to handle BPF */
+/* Code to handle VLAN tags ported from source/include/linux/if_vlan.h and
+   modified to handle BPF */
 
 #include <vmlinux.h>
 #include <bpf/bpf_core_read.h>
@@ -13,6 +14,10 @@
 #define	ENODATA		61
 #define ETH_P_8021Q	0x8100
 #define ETH_P_8021AD	0x88A8
+
+// Used for kernels prior to 0c4b2d370514cb4f3454dd3b18f031d2651fab73.
+#define VLAN_CFI_MASK		0x1000 /* Canonical Format Indicator */
+#define VLAN_TAG_PRESENT	VLAN_CFI_MASK
 
 #define set_skb_vlan_event(e, vlan_tci, vlan_accel)	{ \
 	e->pcp = (vlan_tci & 0xe000) >> 13; \
@@ -28,21 +33,56 @@ struct skb_vlan_event {
 	u8 acceleration;
 } __binding;
 
+/**
+ * vlan_tag_present tries to determine if a VLAN tag is present. There have been
+ * various changes over the years in the kernel: The kernel uses
+ * skb_vlan_tag_present which in more recent versions either relies on
+ * vlan_present or on vlan_all.
+ * We use CO-RE functionality to probe if either field is present and return
+ * false otherwise.
+ * See kernel commit 354259fa73e2
+ *
+ * @param skb
+ *
+ * Returns true if a VLAN tag is present in vlan_present or vlan_all
+ */
 static __always_inline bool vlan_tag_present(const struct sk_buff *skb)
 {
-       struct sk_buff___6_1_0 *skb_61 = (struct sk_buff___6_1_0 *)skb;
+	struct sk_buff___6_1_0 *skb_61 = (struct sk_buff___6_1_0 *)skb;
 
-       if (bpf_core_field_exists(skb_61->vlan_present))
-               return BPF_CORE_READ_BITFIELD_PROBED(skb_61, vlan_present);
+	// Older kernerls, e.g. RHEL 9.
+	if (bpf_core_field_exists(skb_61->vlan_present))
+		return BPF_CORE_READ_BITFIELD_PROBED(skb_61, vlan_present);
 
-       return BPF_CORE_READ(skb, vlan_all);
+	// New kernels, e.g. Fedora 40 and later.
+	if (bpf_core_field_exists(skb->vlan_all))
+		return BPF_CORE_READ(skb, vlan_all);
+
+	return false;
 }
 
 /**
- * __vlan_hwaccel_get_tag - get the VLAN ID that is in @skb->cb[]
- * The kernel uses skb_vlan_tag_present which either relies on vlan_present or
- * on vlan_all depending on the kernel version (see commit 354259fa73e2aac92ae5e19522adb69a92c15b49).
- * We use CO-RE functionality to probe either field in vlan_tag_present.
+ * vlan_tag_present_old implements logic from before kernel commit 0c4b2d370514
+ * to determine if a VLAN tag is present. In old kernel versions,
+ * __vlan_hwaccel_put_tag set skb->vlan_tci = VLAN_TAG_PRESENT | vlan_tci.
+ * Therefore, old versions of the kernel use the DEI / CFI bit indicate / detect
+ * presence of the VLAN tag.
+ *
+ * @param skb
+ *
+ * Returns true if a VLAN tag is present
+ */
+static __always_inline bool vlan_tag_present_old(const struct sk_buff *skb) {
+	return (BPF_CORE_READ(skb, vlan_tci) & VLAN_TAG_PRESENT);
+}
+
+/**
+ * __vlan_hwaccel_get_tag - get the VLAN TCI that is in @skb->cb[]. In newer
+ * versions of the kernel, report the vlan_tci as is. Versions of the kernel
+ * before commit 0c4b2d370514 always set the DEI / CFI bit to on. As it is more
+ * common to have this bit off, and in order to not report a false positive, set
+ * the bit to 0 for these old kernels.
+ *
  * @skb: skbuff to query
  * @vlan_tci: buffer to store value
  *
@@ -53,6 +93,9 @@ static inline int __vlan_hwaccel_get_tag(const struct sk_buff *skb,
 {
 	if (vlan_tag_present(skb)) {
 		*vlan_tci = BPF_CORE_READ(skb, vlan_tci);
+		return 0;
+	} else if (vlan_tag_present_old(skb)) {
+		*vlan_tci = BPF_CORE_READ(skb, vlan_tci) & 0xefff;
 		return 0;
 	} else {
 		*vlan_tci = 0;


### PR DESCRIPTION
Fixes https://github.com/retis-org/retis/issues/479

How to test:
```
cd tests
python3 -m flake8 && python3 -m pytest test_skb.py
```

Also fixed the issue that can be seen in:
https://cirrus-ci.com/task/6381925075517440?logs=up#L717

![image](https://github.com/user-attachments/assets/d1675293-5ea4-4cad-a05a-d5e0b350c2ab)

that issue didn't block the CI lane but nevertheless caused an error when bringing up the centos8 vagrant box