### PR TITLE
tools: retis_in_container: use PAGER and NOPAGER

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,8 @@ used to point to an alternate image location.
 $ RETIS_IMAGE=my-registry.example.com/retis ./retis_in_container.sh --help
 ```
 
+`PAGER` and `NOPAGER` environment variables work the same way as with the Retis binary.
+
 ### From sources
 
 Retis depends on the following (in addition to Git and Cargo):

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -54,7 +54,7 @@ fi
 
 # Run the Retis container.
 exec $runtime run $extra_args $term_opts --privileged --rm --pid=host \
-      -e TERM -e LC_ALL="C.UTF-8" \
+      -e PAGER -e NOPAGER -e TERM -e LC_ALL="C.UTF-8" \
       --cap-add SYS_ADMIN --cap-add BPF --cap-add SYSLOG \
       -v /sys/kernel/btf:/sys/kernel/btf:ro \
       -v /sys/kernel/debug:/sys/kernel/debug:ro \


### PR DESCRIPTION
PAGER and NOPAGER can be used to control how retis pages stdout. Make them available inside the container.