### PR TITLE
Extend ct and ovs events 

### DIFF
--- a/docs/collectors/ct.md
+++ b/docs/collectors/ct.md
@@ -22,6 +22,17 @@ ct_state {state}
 `state` is one of `ESTABLISHED`, `RELATED`, `NEW`, `REPLY`, `RELATED_REPLY` and
 `UNTRACKED.`
 
+Status information,
+
+```none
+status {status}
+```
+
+with `status` representing the bits set in `ct->status` in hex format.
+See `enum ip_conntrack_status` in the kernel
+[uapi headers](https://github.com/torvalds/linux/blob/master/include/uapi/linux/netfilter/nf_conntrack_common.h)
+for the bitset representing the corresponding values.
+
 ### Connection information
 
 This starts by a protocol specific part. For TCP and UDP,

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -140,6 +140,8 @@ pub struct CtConnEvent {
     pub mark: Option<u32>,
     /// Connection tracking labels.
     pub labels: Option<U128>,
+    /// nf_conn status (ct->status).
+    pub ct_status: u64,
 }
 
 impl EventFmt for CtEvent {
@@ -168,6 +170,8 @@ impl EventFmt for CtEvent {
 
 impl CtEvent {
     fn format_conn(conn: &CtConnEvent, f: &mut Formatter) -> fmt::Result {
+        write!(f, "status {:#x} ", conn.ct_status)?;
+
         match (&conn.orig.proto, &conn.reply.proto) {
             (CtProto::Tcp { tcp: tcp_orig }, CtProto::Tcp { tcp: tcp_reply }) => {
                 write!(

--- a/retis/src/bindings/ct_uapi.rs
+++ b/retis/src/bindings/ct_uapi.rs
@@ -3,9 +3,11 @@
 pub type __u8 = ::std::os::raw::c_uchar;
 pub type __u16 = ::std::os::raw::c_ushort;
 pub type __u32 = ::std::os::raw::c_uint;
+pub type __u64 = ::std::os::raw::c_ulonglong;
 pub type u8_ = __u8;
 pub type u16_ = __u16;
 pub type u32_ = __u32;
+pub type u64_ = __u64;
 pub const SECTION_META: ct_sections = 0;
 pub const SECTION_BASE_CONN: ct_sections = 1;
 pub const SECTION_PARENT_CONN: ct_sections = 2;
@@ -73,6 +75,7 @@ impl Default for nf_conn_tuple {
 pub struct ct_event {
     pub orig: nf_conn_tuple,
     pub reply: nf_conn_tuple,
+    pub status: u64_,
     pub flags: u32_,
     pub mark: u32_,
     pub labels: [u8_; 16usize],

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -236,6 +236,7 @@ impl CtEventFactory {
         let labels = U128::from_u128(u128::from_ne_bytes(raw.labels));
 
         Ok(CtConnEvent {
+            ct_status: raw.status,
             zone_id: raw.zone_id,
             zone_dir,
             orig: CtTuple {

--- a/retis/src/collect/collector/ct/bpf/ct.bpf.c
+++ b/retis/src/collect/collector/ct/bpf/ct.bpf.c
@@ -58,6 +58,7 @@ struct nf_conn_tuple {
 struct ct_event {
 	struct nf_conn_tuple orig;
 	struct nf_conn_tuple reply;
+	u64 status;
 	u32 flags;
 	u32 mark;
 	u8 labels[16];
@@ -134,6 +135,7 @@ static __always_inline int process_nf_conn(struct ct_event *e,
 	if (bpf_core_field_exists(ct->mark))
 		e->mark = BPF_CORE_READ(ct, mark);
 
+	e->status = BPF_CORE_READ(ct, status);
 	switch (l3num) {
 	case NFPROTO_IPV4:
 		e->flags |= RETIS_CT_IPV4;


### PR DESCRIPTION
Extend ct and ovs events respectively with `ct->status`, and action address while executing.

Edit: I decided to drop the ovs patch for the time being as we have other work pending in that area.
Can be easily resurrected in a later moment. 