### PR TITLE
Support context extensions

### DIFF
--- a/retis/src/collect/collector/ovs/bpf/kernel_enqueue.bpf.c
+++ b/retis/src/collect/collector/ovs/bpf/kernel_enqueue.bpf.c
@@ -42,7 +42,7 @@ DEFINE_HOOK_RAW(
 	if (!uctx)
 		return 0;
 
-	skb = __retis_get_sk_buff(ctx);
+	skb = retis_get_sk_buff(ctx);
 	if (!skb)
 		return 0;
 

--- a/retis/src/core/probe/manager.rs
+++ b/retis/src/core/probe/manager.rs
@@ -490,6 +490,7 @@ impl ProbeRuntimeManager {
                     Vec::new()
                 },
                 self.filters.clone(),
+                None,
             )?;
 
             builders.insert(p.type_key(), builder);
@@ -514,7 +515,12 @@ impl ProbeRuntimeManager {
             hooks.extend(self.hooks.clone());
         }
 
-        builder.init(self.map_fds.clone(), hooks, self.filters.clone())?;
+        builder.init(
+            self.map_fds.clone(),
+            hooks,
+            self.filters.clone(),
+            probe.ctx_hook.clone(),
+        )?;
 
         Self::attach_probe(
             &mut builder,

--- a/retis/src/core/probe/user/usdt.rs
+++ b/retis/src/core/probe/user/usdt.rs
@@ -32,6 +32,7 @@ impl<'a> ProbeBuilder for UsdtBuilder<'a> {
         map_fds: Vec<(String, RawFd)>,
         hooks: Vec<Hook>,
         _filters: Vec<Filter>,
+        _ctx_hook: Option<Hook>,
     ) -> Result<()> {
         self.map_fds = map_fds;
         if hooks.len() > 1 {
@@ -92,7 +93,9 @@ mod tests {
         let p = Process::from_pid(std::process::id() as i32).unwrap();
 
         // It's for now, the probes below won't do much.
-        assert!(builder.init(Vec::new(), Vec::new(), Vec::new()).is_ok());
+        assert!(builder
+            .init(Vec::new(), Vec::new(), Vec::new(), None)
+            .is_ok());
         assert!(builder
             .attach(&Probe::usdt(UsdtProbe::new(&p, "test_builder::usdt").unwrap()).unwrap())
             .is_ok());


### PR DESCRIPTION
The retis context contains enough information to access common types such as the `sk_buff` pointer.

Sometimes this information cannot be easily available through the probe's arguments. In such cases, the context needs to be dynamically extended.

Well known types to `sk_buff` indirection can be implemented in the core so that it can be used in generic probes. However, this might be insufficient for some specific probes, for which a freplaced hook is available.

Note the hook is currently unused, the first user will be #493 