### PR TITLE
Clean cli internal structures

### DIFF
--- a/retis/src/cli/cli.rs
+++ b/retis/src/cli/cli.rs
@@ -2,8 +2,7 @@
 //!
 //! Cli module, providing tools for registering and accessing command line interface arguments
 //! as well as defining the subcommands that the tool supports.
-#![allow(dead_code)] // FIXME
-use std::{any::Any, convert::From, env, ffi::OsString, fmt::Debug, str::FromStr, sync::Arc};
+use std::{any::Any, convert::From, env, ffi::OsString, fmt::Debug, str::FromStr};
 
 use anyhow::{anyhow, bail, Result};
 use clap::{
@@ -72,12 +71,6 @@ pub(crate) trait SubCommand {
     /// Returns the unique name of the subcommand.
     fn name(&self) -> String;
 
-    /// Returns self as a std::any::Any trait.
-    ///
-    /// This is useful for dynamically downcast the SubCommand into it's specific type to access
-    /// subcommand-specific functionality.
-    fn as_any(&self) -> &dyn Any;
-
     /// Returns self as a mutable std::any::Any trait.
     ///
     /// This is useful for dynamically downcast the SubCommand into it's specific type to access
@@ -122,10 +115,6 @@ where
         <Self as clap::CommandFactory>::command()
             .get_name()
             .to_string()
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
@@ -347,7 +336,6 @@ impl RetisCli {
             command,
             main_config,
             subcommand,
-            logger,
         })
     }
 }
@@ -361,8 +349,6 @@ pub(crate) struct CliConfig {
     pub(crate) main_config: MainConfig,
     /// Subcommand that was run
     pub(crate) subcommand: Box<dyn SubCommand>,
-    /// The global logger already initialized with the right level
-    pub(crate) logger: Arc<Logger>,
 }
 
 /// Type of the "format" argument.

--- a/retis/src/cli/cli.rs
+++ b/retis/src/cli/cli.rs
@@ -3,7 +3,9 @@
 //! Cli module, providing tools for registering and accessing command line interface arguments
 //! as well as defining the subcommands that the tool supports.
 #![allow(dead_code)] // FIXME
-use std::{any::Any, convert::From, env, ffi::OsString, fmt::Debug, path::PathBuf};
+use std::{
+    any::Any, convert::From, env, ffi::OsString, fmt::Debug, path::PathBuf, str::FromStr, sync::Arc,
+};
 
 use anyhow::{anyhow, bail, Result};
 use clap::{
@@ -12,13 +14,14 @@ use clap::{
     error::ErrorKind,
     {ArgMatches, Args, Command, FromArgMatches, ValueEnum},
 };
-use log::debug;
+use log::{debug, LevelFilter};
 
 #[cfg(feature = "benchmark")]
 use crate::benchmark::cli::Benchmark;
 use crate::{
     collect::cli::Collect,
     generate::Complete,
+    helpers::logger::{set_libbpf_rs_print_callback, Logger},
     inspect::Inspect,
     process::cli::*,
     profiles::{cli::ProfileCmd, Profile},
@@ -27,20 +30,20 @@ use crate::{
 /// SubCommandRunner defines the common interface to run SubCommands.
 pub(crate) trait SubCommandRunner {
     /// Run the subcommand using a cli configuration
-    fn run(&mut self, cli: FullCli) -> Result<()>;
+    fn run(&mut self, cli: CliConfig) -> Result<()>;
 }
 
 /// SubCommandRunnerFunc is a wrapper for functions that implements SubCommandRunner
 pub(crate) struct SubCommandRunnerFunc<F>
 where
-    F: Fn(FullCli) -> Result<()>,
+    F: Fn(CliConfig) -> Result<()>,
 {
     func: F,
 }
 
 impl<F> SubCommandRunnerFunc<F>
 where
-    F: Fn(FullCli) -> Result<()>,
+    F: Fn(CliConfig) -> Result<()>,
 {
     pub(crate) fn new(func: F) -> Self {
         Self { func }
@@ -49,18 +52,16 @@ where
 
 impl<F> SubCommandRunner for SubCommandRunnerFunc<F>
 where
-    F: Fn(FullCli) -> Result<()>,
+    F: Fn(CliConfig) -> Result<()>,
 {
-    fn run(&mut self, cli: FullCli) -> Result<()> {
+    fn run(&mut self, cli: CliConfig) -> Result<()> {
         (self.func)(cli)
     }
 }
 
-/// SubCommand defines the way to handle SubCommands.
-/// SubCommands arguments are parsed in two rounds, the "thin" and the "full" round.
-///
-/// In the "thin" round a SubCommand should only define a simple clap Command with a short help
-/// string (about in clap's parlace). This will be used to show the main program's help.
+/// SubCommand defines the way to handle cli subcommands by providing a convenient way
+/// of encapsulating both its arguments (i.e: clap::Command) and a way to run it
+/// (provided by SubCommandRunner).
 pub(crate) trait SubCommand {
     /// Allocate and return a new instance of a SubCommand.
     fn new() -> Result<Self>
@@ -82,10 +83,8 @@ pub(crate) trait SubCommand {
     /// subcommand-specific functionality.
     fn as_any_mut(&mut self) -> &mut dyn Any;
 
-    /// Generate the clap Command to be used for "full" parsing.
-    ///
-    /// This method should be called after all dynamic options have been registered.
-    fn full(&mut self) -> Result<Command>;
+    /// Generate the clap Command.
+    fn command(&mut self) -> Result<Command>;
 
     /// Updates internal structures with clap's ArgMatches.
     fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), ClapError>;
@@ -132,7 +131,7 @@ where
         self
     }
 
-    fn full(&mut self) -> Result<Command> {
+    fn command(&mut self) -> Result<Command> {
         Ok(<Self as clap::CommandFactory>::command())
     }
 
@@ -142,8 +141,7 @@ where
 
     fn runner(&self) -> Result<Box<dyn SubCommandRunner>> {
         Ok(Box::new(SubCommandRunnerFunc::new(
-            |cli: FullCli| -> Result<()> {
-                let mut cli = cli.run()?;
+            |mut cli: CliConfig| -> Result<()> {
                 let cmd: &mut Self = cli
                     .subcommand
                     .as_any_mut()
@@ -181,26 +179,35 @@ pub(crate) struct MainConfig {
     pub(crate) kconf: Option<PathBuf>,
 }
 
-/// ThinCli handles the first (a.k.a "thin") round of Command Line Interface parsing.
-///
-/// During this phase, SubCommands can be added. After all SubCommands have been added, the build()
-/// method will run the thin CLI parsing that does not perform dynamic subcommand argument
-/// validation and yield a FullCli object to represent the results.
-#[derive(Debug)]
-pub(crate) struct ThinCli {
+#[derive(Debug, Default)]
+pub(crate) struct RetisCli {
     subcommands: Vec<Box<dyn SubCommand>>,
 }
 
-impl ThinCli {
-    /// Allocate and return a new ThinCli object that will parse the command arguments.
+impl RetisCli {
+    /// Allocate and return a new RetisCli object that will parse the command arguments.
     pub(crate) fn new() -> Result<Self> {
-        Ok(ThinCli {
-            subcommands: Vec::new(),
-        })
+        let mut cli = RetisCli::default();
+        // Note the logger has not been initialized yet. Subcommand creation should
+        // be as simple as possible and all logging should be delayed to
+        // update_from_arg_matches.
+        cli.add_subcommand(Box::new(Collect::new()?))?;
+        cli.add_subcommand(Box::new(Print::new()?))?;
+        cli.add_subcommand(Box::new(Sort::new()?))?;
+        #[cfg(feature = "python")]
+        cli.add_subcommand(Box::new(PythonCli::new()?))?;
+        cli.add_subcommand(Box::new(Pcap::new()?))?;
+        cli.add_subcommand(Box::new(Inspect::new()?))?;
+        cli.add_subcommand(Box::new(ProfileCmd::new()?))?;
+        cli.add_subcommand(Box::new(Complete::new()?))?;
+
+        #[cfg(feature = "benchmark")]
+        cli.add_subcommand(Box::new(Benchmark::new()?))?;
+
+        Ok(cli)
     }
 
-    /// Add a subcommand to the ThinCli object.
-    pub(crate) fn add_subcommand(&mut self, sub: Box<dyn SubCommand>) -> Result<&mut Self> {
+    fn add_subcommand(&mut self, sub: Box<dyn SubCommand>) -> Result<&mut Self> {
         let name = sub.name();
 
         if self.subcommands.iter().any(|s| s.name() == name) {
@@ -211,49 +218,85 @@ impl ThinCli {
         Ok(self)
     }
 
-    /// Build a FullCli by running a first round of CLI parsing without subcommand argument
-    /// validation.
-    /// If clap reports an error (including "--help" and "--version"), print the message and
-    /// exit the program.
-    pub(crate) fn build(self) -> FullCli {
-        self.build_from(env::args_os()).unwrap_or_else(|e| e.exit())
+    /// Build a CliConfig by parsing the arguments
+    pub(crate) fn parse(self) -> CliConfig {
+        self.parse_from(env::args_os()).unwrap_or_else(|e| e.exit())
     }
 
-    /// Build a FullCli by running a first round of CLI parsing with the given list of arguments.
+    /// Enhance arguments with provided profile.
+    fn enhance_profile(
+        main_config: &MainConfig,
+        subcommand: &str,
+        args: &mut Vec<OsString>,
+    ) -> Result<()> {
+        if main_config.profile.is_empty() {
+            return Ok(());
+        }
+
+        for name in main_config.profile.iter() {
+            let profile = Profile::find(name.as_str())?;
+            let mut extra_args = profile.cli_args(subcommand)?;
+            args.append(&mut extra_args);
+        }
+        Ok(())
+    }
+
+    fn get_version() -> String {
+        let pkg_version = option_env!("RELEASE_VERSION").unwrap_or("unspec");
+        let pkg_name = option_env!("RELEASE_NAME").unwrap_or("unreleased");
+
+        if cfg!(debug_assertions) {
+            format!("{} [dbg] (\"{}\")", pkg_version, pkg_name)
+        } else {
+            format!("{} (\"{}\")", pkg_version, pkg_name)
+        }
+    }
+
+    /// Build a CliConfig by parsing the given list of arguments.
     /// This function should be only used directly by unit tests.
-    pub(crate) fn build_from<I, T>(mut self, args: I) -> Result<FullCli, ClapError>
+    pub(crate) fn parse_from<I, T>(mut self, args: I) -> Result<CliConfig, ClapError>
     where
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
     {
-        let pkg_version = option_env!("RELEASE_VERSION").unwrap_or("unspec");
-        let pkg_name = option_env!("RELEASE_NAME").unwrap_or("unreleased");
+        let mut args: Vec<OsString> = args.into_iter().map(|x| x.into()).collect();
 
-        let version = if cfg!(debug_assertions) {
-            format!("{} [dbg] (\"{}\")", pkg_version, pkg_name)
-        } else {
-            format!("{} (\"{}\")", pkg_version, pkg_name)
-        };
-
-        let args: Vec<OsString> = args.into_iter().map(|x| x.into()).collect();
+        // Build the main command.
         let mut command = MainConfig::augment_args(Command::new("retis"))
-            .version(version)
+            .version(Self::get_version())
             .disable_help_subcommand(true)
             .infer_subcommands(true)
             .subcommand_required(true);
+
         // Add full subcommands so that the main help shows them.
         for sub in self.subcommands.iter_mut() {
-            command = command.subcommand(sub.full().expect("full command failed"));
+            command = command.subcommand(sub.command().expect("command failed"));
         }
 
-        // Determine the subcommand that was run while ignoring errors from yet-to-be-defined
-        // arguments.
-        let matches = command
-            .clone()
-            .ignore_errors(true)
-            .try_get_matches_from(args.iter())?;
+        // Run command parsing once before profile expansion to extract the logging level and the
+        // subcommand name (needed to know what part of the profile we need to expand).
+        let matches = command.clone().try_get_matches_from(args.iter())?;
 
-        let ran_subcommand = matches
+        let mut main_config = MainConfig::default();
+        main_config.update_from_arg_matches(&matches)?;
+
+        let log_level = main_config.log_level.as_str();
+        let log_level = LevelFilter::from_str(log_level).map_err(|e| {
+            command.error(
+                ErrorKind::InvalidValue,
+                format!("Invalid log_level: {log_level} ({e})"),
+            )
+        })?;
+        let logger = Logger::init(log_level).map_err(|e| {
+            command.error(
+                ErrorKind::InvalidValue,
+                format!("Invalid log_level: {log_level} ({e})"),
+            )
+        })?;
+        set_libbpf_rs_print_callback(log_level);
+
+        // Retrieve the subcommand that was run.
+        let mut subcommand = matches
             .subcommand_name()
             .and_then(|name| self.subcommands.drain(..).find(|s| s.name() == name))
             .ok_or_else(||
@@ -263,113 +306,57 @@ impl ThinCli {
                     .try_get_matches_from_mut(args.iter())
                     .expect_err("clap should fail with no arguments"))?;
 
-        // Get main config.
-        let mut main_config = MainConfig::default();
-        main_config.update_from_arg_matches(&matches)?;
-
-        // A command was run, build the FullCli so we can parse it.
-        Ok(FullCli {
-            args,
-            main_config,
-            command,
-            subcommand: ran_subcommand,
-        })
-    }
-}
-
-/// FullCli handles the second (a.k.a "full") round of Command Line Interface parsing.
-///
-/// When a FullCli is created it can be used to dynamically add command line arguments to the
-/// SubCommand that was ran. After this phase, a call to run() will perform the full argument
-/// validation.
-#[derive(Debug)]
-pub(crate) struct FullCli {
-    pub(crate) main_config: MainConfig,
-    args: Vec<OsString>,
-    command: Command,
-    subcommand: Box<dyn SubCommand>,
-}
-
-impl FullCli {
-    /// Enhance arguments with provided profile.
-    fn enhance_profile(&mut self) -> Result<()> {
-        if self.main_config.profile.is_empty() {
-            return Ok(());
-        }
-
-        for name in self.main_config.profile.iter() {
-            let profile = Profile::find(name.as_str())?;
-            let mut extra_args = profile.cli_args(self.subcommand.name().as_str())?;
-            self.args.append(&mut extra_args);
-        }
-        Ok(())
-    }
-    /// Perform full CLI parsing and validation
-    pub(crate) fn run(mut self) -> Result<CliConfig, ClapError> {
-        self.enhance_profile().map_err(|err| {
-            self.command
-                .error(ErrorKind::InvalidValue, format!("{err}"))
-        })?;
+        // Expand profile arguments.
+        RetisCli::enhance_profile(&main_config, subcommand.name().as_str(), &mut args)
+            .map_err(|err| command.error(ErrorKind::InvalidValue, format!("{err}")))?;
 
         debug!(
             "Resulting CLI arguments: {}",
-            self.args
-                .iter()
+            args.iter()
                 .map(|o| o.as_os_str().to_str().unwrap_or("<encoding error>"))
                 .collect::<Vec<&str>>()
                 .join(" ")
         );
 
-        // Get the matches.
+        // Final round of parsing.
         let matches = match cfg!(test) {
-            true => self.command.try_get_matches_from_mut(self.args.iter())?,
-            false => self
-                .command
-                .try_get_matches_from_mut(self.args.iter())
+            true => command.try_get_matches_from_mut(args.iter())?,
+            false => command
+                .try_get_matches_from_mut(args.iter())
                 .unwrap_or_else(|e| e.exit()),
         };
-
-        let (subcommand, matches) = matches
+        let (_, matches) = matches
             .subcommand()
             .expect("full parsing did not find subcommand");
-        if !subcommand.to_string().eq(&self.subcommand.as_ref().name()) {
-            // thin and full cli parsing should yield the same subcommand. There is no way to
-            // recover from this error, so let's just panic.
-            panic!("Thin and full parsing did not yield the same subcommand");
-        }
 
         // Update subcommand options.
         match cfg!(test) {
-            true => self.subcommand.update_from_arg_matches(matches)?,
-            false => self
-                .subcommand
+            true => subcommand.update_from_arg_matches(matches)?,
+            false => subcommand
                 .update_from_arg_matches(matches)
                 .unwrap_or_else(|e| e.exit()),
         }
+
         Ok(CliConfig {
-            main_config: self.main_config,
-            subcommand: self.subcommand,
+            command,
+            main_config,
+            subcommand,
+            logger,
         })
-    }
-
-    pub(crate) fn get_subcommand(&self) -> Result<&dyn SubCommand> {
-        Ok(self.subcommand.as_ref())
-    }
-
-    pub(crate) fn get_subcommand_mut(&mut self) -> Result<&mut dyn SubCommand> {
-        Ok(self.subcommand.as_mut())
-    }
-
-    pub(crate) fn get_command(&self) -> Command {
-        self.command.clone()
     }
 }
 
-/// CliConfig represents the result of the Full CLI parsing
+/// CliConfig represents the result of the RetisCli
 #[derive(Debug)]
 pub(crate) struct CliConfig {
+    /// The underlying clap.Command object
+    pub(crate) command: Command,
+    /// Main configuration options
     pub(crate) main_config: MainConfig,
+    /// Subcommand that was run
     pub(crate) subcommand: Box<dyn SubCommand>,
+    /// The global logger already initialized with the right level
+    pub(crate) logger: Arc<Logger>,
 }
 
 /// Type of the "format" argument.
@@ -379,151 +366,4 @@ pub(crate) enum CliDisplayFormat {
     SingleLine,
     #[default]
     MultiLine,
-}
-
-/// Create and register a ThinCli
-pub(crate) fn get_cli() -> Result<ThinCli> {
-    let mut cli = ThinCli::new()?;
-    cli.add_subcommand(Box::new(Collect::new()?))?;
-    cli.add_subcommand(Box::new(Print::new()?))?;
-    cli.add_subcommand(Box::new(Sort::new()?))?;
-    #[cfg(feature = "python")]
-    cli.add_subcommand(Box::new(PythonCli::new()?))?;
-    cli.add_subcommand(Box::new(Pcap::new()?))?;
-    cli.add_subcommand(Box::new(Inspect::new()?))?;
-    cli.add_subcommand(Box::new(ProfileCmd::new()?))?;
-    cli.add_subcommand(Box::new(Complete::new()?))?;
-
-    #[cfg(feature = "benchmark")]
-    cli.add_subcommand(Box::new(Benchmark::new()?))?;
-
-    Ok(cli)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use clap::error::ErrorKind;
-
-    #[derive(Debug, Default, Args)]
-    struct Sub1 {
-        #[arg(id = "sub1-arg", long)]
-        someopt: Option<String>,
-    }
-
-    impl SubCommand for Sub1 {
-        fn new() -> Result<Self> {
-            Ok(Sub1 { someopt: None })
-        }
-        fn name(&self) -> String {
-            "sub1".to_string()
-        }
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn as_any_mut(&mut self) -> &mut dyn Any {
-            self
-        }
-        fn full(&mut self) -> Result<Command> {
-            Ok(Sub1::augment_args(
-                Command::new("sub1")
-                    .about("does some things")
-                    .long_about("this is a longer description"),
-            ))
-        }
-        fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), ClapError> {
-            <Self as FromArgMatches>::update_from_arg_matches(self, matches)
-        }
-        fn runner(&self) -> Result<Box<dyn SubCommandRunner>> {
-            Ok(Box::new(SubCommandRunnerFunc::new(|_: FullCli| Ok(()))))
-        }
-    }
-
-    #[derive(Debug, Default, clap::Parser)]
-    #[command(name = "sub2", about = "sub2 help")]
-    struct Sub2 {
-        #[arg(id = "sub2-flag", long)]
-        flag: Option<bool>,
-    }
-
-    impl SubCommandParserRunner for Sub2 {
-        fn run(&mut self, main_config: &MainConfig) -> Result<()> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn cli_register_subcommands() -> Result<()> {
-        let mut cli = ThinCli::new()?;
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_ok());
-        assert!(cli.add_subcommand(Box::<Sub2>::default()).is_ok());
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_err());
-        Ok(())
-    }
-
-    #[test]
-    fn cli_build() -> Result<()> {
-        let mut cli = ThinCli::new()?;
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_ok());
-        assert!(cli.add_subcommand(Box::<Sub2>::default()).is_ok());
-
-        let err = cli.build_from(vec!["retis", "--help"]);
-        assert!(err.is_err() && err.unwrap_err().kind() == ErrorKind::DisplayHelp);
-
-        Ok(())
-    }
-
-    #[test]
-    fn cli_full_help() -> Result<()> {
-        let mut cli = ThinCli::new()?;
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_ok());
-        assert!(cli.add_subcommand(Box::<Sub2>::default()).is_ok());
-
-        let cli = cli.build_from(vec!["retis", "sub1", "--help"]);
-        assert!(cli.is_ok());
-
-        let err = cli?.run();
-        assert!(err.is_err() && err.unwrap_err().kind() == ErrorKind::DisplayHelp);
-
-        Ok(())
-    }
-
-    #[test]
-    fn cli_sub_args() -> Result<()> {
-        let mut cli = ThinCli::new()?;
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_ok());
-        assert!(cli.add_subcommand(Box::<Sub2>::default()).is_ok());
-
-        let cli = cli.build_from(vec!["retis", "sub1", "--sub1-arg", "foo"]);
-        assert!(cli.is_ok());
-        let cli = cli.unwrap();
-        assert!(cli.get_subcommand().is_ok() && cli.get_subcommand().unwrap().name().eq("sub1"));
-
-        let res = cli.run();
-        assert!(res.is_ok());
-        let res = res.unwrap();
-        assert!(res.subcommand.name().eq("sub1"));
-        let sub1 = res.subcommand.as_any().downcast_ref::<Sub1>();
-        assert!(sub1.is_some());
-        assert!(sub1.unwrap().someopt.as_ref().unwrap().eq("foo"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn cli_sub_args_err() -> Result<()> {
-        let mut cli = ThinCli::new()?;
-        assert!(cli.add_subcommand(Box::new(Sub1::new()?)).is_ok());
-        assert!(cli.add_subcommand(Box::<Sub2>::default()).is_ok());
-
-        let cli = cli.build_from(vec!["retis", "sub1", "--noexists", "foo"]);
-        assert!(cli.is_ok());
-        let cli = cli.unwrap();
-        assert!(cli.get_subcommand().is_ok() && cli.get_subcommand().unwrap().name().eq("sub1"));
-
-        let res = cli.run();
-        assert!(res.is_err() && res.unwrap_err().kind() == ErrorKind::UnknownArgument);
-
-        Ok(())
-    }
 }

--- a/retis/src/cli/cli.rs
+++ b/retis/src/cli/cli.rs
@@ -3,9 +3,7 @@
 //! Cli module, providing tools for registering and accessing command line interface arguments
 //! as well as defining the subcommands that the tool supports.
 #![allow(dead_code)] // FIXME
-use std::{
-    any::Any, convert::From, env, ffi::OsString, fmt::Debug, path::PathBuf, str::FromStr, sync::Arc,
-};
+use std::{any::Any, convert::From, env, ffi::OsString, fmt::Debug, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, bail, Result};
 use clap::{
@@ -172,11 +170,6 @@ pub(crate) struct MainConfig {
         help = "Comma separated list of profile names to apply"
     )]
     pub(crate) profile: Vec<String>,
-    #[arg(
-        long,
-        help = "Path to kernel configuration (e.g. /boot/config-6.3.8-200.fc38.x86_64; default: auto-detect)"
-    )]
-    pub(crate) kconf: Option<PathBuf>,
 }
 
 #[derive(Debug, Default)]

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use clap::{builder::PossibleValuesParser, Parser};
 
 use super::Collectors;
-use crate::{cli::*, collect::collector::*};
+use crate::{cli::*, collect::collector::*, core::inspect::init_inspector};
 
 /// Collect events.
 ///
@@ -154,6 +154,12 @@ fully operational:
 "#
     )]
     pub(crate) allow_system_changes: bool,
+    pub(crate) profile: Vec<String>,
+    #[arg(
+        long,
+        help = "Path to kernel configuration (e.g. /boot/config-6.3.8-200.fc38.x86_64; default: auto-detect)"
+    )]
+    pub(crate) kconf: Option<PathBuf>,
     #[arg(long, help = "Print the time as UTC")]
     pub(super) utc: bool,
     #[arg(long, help = "Format used when printing an event.")]
@@ -179,6 +185,9 @@ pub(crate) struct CollectorsArgs {
 
 impl SubCommandParserRunner for Collect {
     fn run(&mut self, main_config: &MainConfig) -> Result<()> {
+        if let Some(kconf) = &self.kconf {
+            init_inspector(kconf)?;
+        }
         let mut collectors = Collectors::new()?;
 
         collectors.check(self)?;

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -428,9 +428,6 @@ impl Collectors {
             gc.start(self.run.clone())?;
         }
 
-        // Start factory
-        self.factory.start(section_factories)?;
-
         // Attach probes and start collectors. We're using an open coded take &
         // replace combination. We could use a Cell<> instead but that would
         // complicate the use of self.probes (additional .get() calls) while
@@ -444,6 +441,9 @@ impl Collectors {
                 warn!("Could not start collector {name}");
             }
         }
+
+        // Start factory
+        self.factory.start(section_factories)?;
 
         Ok(())
     }

--- a/retis/src/generate/completion.rs
+++ b/retis/src/generate/completion.rs
@@ -50,7 +50,7 @@ impl SubCommand for Complete {
         self
     }
 
-    fn full(&mut self) -> Result<Command> {
+    fn command(&mut self) -> Result<Command> {
         Ok(<Self as clap::CommandFactory>::command())
     }
 
@@ -67,9 +67,9 @@ impl SubCommand for Complete {
 pub(crate) struct CompleteRunner {}
 
 impl SubCommandRunner for CompleteRunner {
-    fn run(&mut self, cli: FullCli) -> Result<()> {
-        let mut cmd = cli.get_command();
-        let matches = cli.get_command().get_matches();
+    fn run(&mut self, cli: CliConfig) -> Result<()> {
+        let mut cmd = cli.command.clone();
+        let matches = cli.command.get_matches();
 
         if let Some(sub_m) = matches.subcommand_matches("sh-complete") {
             if let Some(generator) = sub_m.get_one::<Shell>("shell") {

--- a/retis/src/generate/completion.rs
+++ b/retis/src/generate/completion.rs
@@ -42,10 +42,6 @@ impl SubCommand for Complete {
             .to_string()
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/retis/src/inspect/inspect.rs
+++ b/retis/src/inspect/inspect.rs
@@ -1,10 +1,12 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{arg, Parser};
 
 use crate::{
     cli::*,
     collect::collector::get_known_types,
-    core::{kernel::Symbol, probe::kernel::utils::probe_from_cli},
+    core::{inspect::init_inspector, kernel::Symbol, probe::kernel::utils::probe_from_cli},
 };
 
 /// Inspect the current machine.
@@ -23,10 +25,18 @@ a compatibility check is performed for each one.
 Eg. '-p tp:*'. See `retis collect --help` for more details on the probe format."
     )]
     pub(crate) probe: Option<String>,
+    #[arg(
+        long,
+        help = "Path to kernel configuration (e.g. /boot/config-6.3.8-200.fc38.x86_64; default: auto-detect)"
+    )]
+    pub(crate) kconf: Option<PathBuf>,
 }
 
 impl SubCommandParserRunner for Inspect {
     fn run(&mut self, _: &MainConfig) -> Result<()> {
+        if let Some(kconf) = &self.kconf {
+            init_inspector(kconf)?;
+        }
         if let Some(probe) = &self.probe {
             let known_types = get_known_types()?;
 

--- a/retis/src/main.rs
+++ b/retis/src/main.rs
@@ -13,7 +13,7 @@ mod profiles;
 #[cfg(feature = "benchmark")]
 mod benchmark;
 
-use crate::{cli::RetisCli, helpers::pager::try_enable_pager};
+use crate::cli::RetisCli;
 
 // Re-export events crate. It's not really an import but a re-export so events appear as module
 // inside the crate rather than an external crate. However, clippy doesn't like it.
@@ -24,17 +24,6 @@ use retis_derive::*;
 
 fn main() -> Result<()> {
     let cli = RetisCli::new()?.parse();
-
-    // Per-command early fixups.
-    match cli.subcommand.name().as_str() {
-        // Try setting up the pager for a selected subset of commands.
-        // This needs to be done before the final round of cli parsing because logs can be emitted
-        // and we need to redirect them to stdout if pager is active.
-        "print" | "sort" => {
-            try_enable_pager(&cli.logger.clone());
-        }
-        _ => (),
-    }
 
     let mut runner = cli.subcommand.runner()?;
     runner.run(cli)?;

--- a/retis/src/main.rs
+++ b/retis/src/main.rs
@@ -28,6 +28,8 @@ fn main() -> Result<()> {
     // Per-command early fixups.
     match cli.subcommand.name().as_str() {
         // Try setting up the pager for a selected subset of commands.
+        // This needs to be done before the final round of cli parsing because logs can be emitted
+        // and we need to redirect them to stdout if pager is active.
         "print" | "sort" => {
             try_enable_pager(&cli.logger.clone());
         }

--- a/retis/src/main.rs
+++ b/retis/src/main.rs
@@ -13,7 +13,7 @@ mod profiles;
 #[cfg(feature = "benchmark")]
 mod benchmark;
 
-use crate::{cli::RetisCli, core::inspect::init_inspector, helpers::pager::try_enable_pager};
+use crate::{cli::RetisCli, helpers::pager::try_enable_pager};
 
 // Re-export events crate. It's not really an import but a re-export so events appear as module
 // inside the crate rather than an external crate. However, clippy doesn't like it.
@@ -25,20 +25,8 @@ use retis_derive::*;
 fn main() -> Result<()> {
     let cli = RetisCli::new()?.parse();
 
-    // Save the --kconf option value before using the cli object to dispatch the
-    // command.
-    let kconf_opt = cli.main_config.kconf.clone();
-
     // Per-command early fixups.
     match cli.subcommand.name().as_str() {
-        // If the user provided a custom kernel config location, use it early to
-        // initialize the inspector. As the inspector is only used by the
-        // collect command, only initialize it there for now.
-        "collect" => {
-            if let Some(kconf) = &kconf_opt {
-                init_inspector(kconf)?;
-            }
-        }
         // Try setting up the pager for a selected subset of commands.
         "print" | "sort" => {
             try_enable_pager(&cli.logger.clone());


### PR DESCRIPTION
This is the natural follow up of #464 , and as discussed in https://github.com/retis-org/retis/pull/493#discussion_r1954898672

This PR merges the two-struct model into a single `RetisCli` struct and moves some top-level options down the relevant sub-commands.