### PR TITLE
Container kconfig fixes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,4 +35,4 @@ COPY --from=builder /retis/target/release/retis /usr/bin/retis
 COPY --from=builder /retis/retis/profiles /etc/retis/profiles
 
 WORKDIR /data
-ENTRYPOINT ["/usr/bin/retis", "--kconf", "/kconfig"]
+ENTRYPOINT ["/usr/bin/retis"]

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -37,7 +37,7 @@ for kconfig in /proc/config.gz \
         kconfig_map="$kconfig_map -v ${kconfig}:${kconfig}:ro"
     fi
 done
-if [ $kconfig_map == "" ]; then
+if [[ -z $kconfig_map ]]; then
 	echo "WARN: Could not auto-detect kernel configuration location. "
 	echo "You can place your configuration file in the current directory and use the '--kconf' option"
 fi

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -35,6 +35,9 @@ for kconfig in /proc/config.gz \
                /lib/modules/$(uname -r)/config; do
     if [ -f $kconfig ]; then
         kconfig_map="$kconfig_map -v ${kconfig}:${kconfig}:ro"
+	# Map the first item to /kconfig to support older versions of the container
+	# image.
+	[[ -z $kconfig_legacy_map ]] && kconfig_legacy_map="-v ${kconfig}:/kconfig"
     fi
 done
 if [[ -z $kconfig_map ]]; then
@@ -58,7 +61,7 @@ exec $runtime run $extra_args $term_opts --privileged --rm --pid=host \
       -v /sys/kernel/btf:/sys/kernel/btf:ro \
       -v /sys/kernel/debug:/sys/kernel/debug:ro \
       -v $(pwd):/data:rw \
-      $kconfig_map \
+      $kconfig_legacy_map $kconfig_map \
       $local_conf \
       $ovs_binary_mount \
       $RETIS_IMAGE:$RETIS_TAG "$@"


### PR DESCRIPTION
The removal of the `--kconf` root level option in #500  lead to some issues, namely:
- The `Containerfile` was not updated and this lead to generating incompatible images.
- The container script is linked from our documentation but does not work anymore for older images, including the current stable one.
- A syntax error could be seen while running the script.

Another potential issue would be running newer images while using the old container script. IMO that's not ideal but probably OK. If we want, we could add a hidden top level `--kconf` option and match it to display an error message, e.g. "option was removed, please update your script". I have not done that here as I'm not 100% convinced.