### PR TITLE
ovs_operation: fix load issue in Rawhide

### DIFF
--- a/retis/src/collect/collector/ovs/bpf/include/ovs_operation.h
+++ b/retis/src/collect/collector/ovs/bpf/include/ovs_operation.h
@@ -120,10 +120,6 @@ static __always_inline bool batch_is_processing(const struct upcall_batch *batch
 
 /* Retrieve the current upcall being processed. */
 static __always_inline struct user_upcall_info *batch_current(struct upcall_batch *batch) {
-	/* In some cases the branch get optimized. The barrier below
-	 * appear to prevent that making the verifier happy.
-	 */
-	barrier_var(batch->current_upcall);
 	if (!batch ||
 	    batch->current_upcall >= (UPCALL_MAX_BATCH -1))
 		return NULL;


### PR DESCRIPTION
Remove the barrier_var() as this seems to alleviate the issue on Rawhide.

There's still the potential to break the verification on the previous versions of clang as this was introduced exactly for that.
Let's check this giving it a spin of functional tests.
