### PR TITLE
Stack trace filter

### DIFF
--- a/retis/profiles/drop.yaml
+++ b/retis/profiles/drop.yaml
@@ -4,7 +4,7 @@ about: Drop monitor-like
 collect:
   - args:
       collectors: skb-drop,skb
-      stack: ~
+      probe: tp:skb:kfree_skb/stack
 pcap:
   - args:
       probe: tp:skb:kfree_skb
@@ -16,7 +16,7 @@ collect:
   - args:
       collectors: nft,skb
       nft_verdicts: drop
-      stack: ~
+      probe: kprobe:__nft_trace_packet/stack
 pcap:
   - args:
       probe: kprobe:__nft_trace_packet

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -221,10 +221,15 @@ impl Collectors {
         self.run.register_term_signals()?;
 
         // Check if we need to report stack traces in the events.
-        if collect.stack || collect.probe_stack {
+        if collect.stack {
             self.probes
                 .builder_mut()?
-                .set_probe_opt(probe::ProbeOption::StackTrace)?;
+                .set_probe_opt(probe::ProbeOption::ReportStack)?;
+        }
+        if collect.probe_stack {
+            self.probes
+                .builder_mut()?
+                .set_probe_opt(probe::ProbeOption::ProbeStack)?;
         }
 
         // Generate an initial event with the startup section.
@@ -542,7 +547,6 @@ impl Collectors {
 
         let (mut iccount, mut eccount) = (0, 0);
         let mut probe_stack = ProbeStack::new(
-            collect.stack,
             self.probes.runtime_mut()?.attached_probes(),
             self.known_kernel_types.clone(),
         );

--- a/retis/src/core/probe/kernel/kernel.rs
+++ b/retis/src/core/probe/kernel/kernel.rs
@@ -45,7 +45,7 @@ impl KernelProbe {
 
         #[allow(clippy::single_match)]
         options.iter().for_each(|o| match o {
-            ProbeOption::StackTrace => {
+            ProbeOption::ProbeStack | ProbeOption::ReportStack => {
                 config.stack_trace = 1;
             }
             _ => (),

--- a/retis/src/core/probe/kernel/utils.rs
+++ b/retis/src/core/probe/kernel/utils.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
+
 use anyhow::{bail, Result};
 
 use crate::core::{
     kernel::symbol::{matching_events_to_symbols, matching_functions_to_symbols, Symbol},
-    probe::Probe,
+    probe::{Probe, ProbeOption},
 };
 
 /// Probe type for probes given through cli arguments.
@@ -23,23 +25,47 @@ impl CliProbeType {
     }
 }
 
+/// Parses the probe options given as a cli argument and returns their
+/// ProbeOption representation.
+fn parse_cli_probe_opts(options: &str) -> Result<HashSet<ProbeOption>> {
+    let opts = options.split('/');
+
+    if opts.clone().next_back() == Some("") {
+        bail!("Empty options are not allowed. Check your option list doesn't terminate with '/'.");
+    }
+
+    opts.map(ProbeOption::try_from)
+        .try_fold(HashSet::new(), |mut hset, option| {
+            if !hset.insert(option?.clone()) {
+                bail!("duplicate options detected in {options}.");
+            }
+
+            Ok(hset)
+        })
+}
+
 /// Parses a probe given as a cli argument and returns its type and the probe
 /// with the type identifier (if any).
-pub(crate) fn parse_cli_probe(input: &str) -> Result<(CliProbeType, &str)> {
+pub(crate) fn parse_cli_probe(input: &str) -> Result<(CliProbeType, &str, HashSet<ProbeOption>)> {
     use CliProbeType::*;
+
+    let (input, opts) = match input.split_once('/') {
+        Some((probe, options)) => (probe, parse_cli_probe_opts(options)?),
+        None => (input, HashSet::new()),
+    };
 
     Ok(match input.split_once(':') {
         Some((type_str, target)) => match type_str {
-            "kprobe" | "k" => (Kprobe, target),
-            "kretprobe" | "kr" => (Kretprobe, target),
-            "raw_tracepoint" | "tp" => (RawTracepoint, target),
+            "kprobe" | "k" => (Kprobe, target, opts),
+            "kretprobe" | "kr" => (Kretprobe, target, opts),
+            "raw_tracepoint" | "tp" => (RawTracepoint, target, opts),
             // If a single ':' was found in the probe name but we didn't match
             // any known type, defaults to trying using it as a raw tracepoint.
-            _ if input.chars().filter(|c| *c == ':').count() == 1 => (RawTracepoint, input),
+            _ if input.chars().filter(|c| *c == ':').count() == 1 => (RawTracepoint, input, opts),
             x => bail!("Invalid TYPE {}. See the help.", x),
         },
         // If no ':' was found, defaults to kprobe.
-        None => (Kprobe, input),
+        None => (Kprobe, input, opts),
     })
 }
 
@@ -51,7 +77,7 @@ where
 {
     use CliProbeType::*;
 
-    let (r#type, target) = parse_cli_probe(probe)?;
+    let (r#type, target, options) = parse_cli_probe(probe)?;
 
     // Convert the target to a list of matching ones for probe types
     // supporting it.
@@ -67,11 +93,17 @@ where
             continue;
         }
 
-        probes.push(match r#type {
+        let mut probe = match r#type {
             Kprobe => Probe::kprobe(symbol)?,
             Kretprobe => Probe::kretprobe(symbol)?,
             RawTracepoint => Probe::raw_tracepoint(symbol)?,
-        })
+        };
+
+        options
+            .iter()
+            .try_for_each(|o| probe.set_option(o.clone()))?;
+
+        probes.push(probe)
     }
 
     Ok(probes)

--- a/retis/src/core/probe/manager.rs
+++ b/retis/src/core/probe/manager.rs
@@ -101,23 +101,11 @@ impl ProbeManager {
             _ => bail!("Probe manager is already at runtime state"),
         };
 
-        // Prepare all hooks:
-        // - Reuse global maps.
-        // - Set global options.
+        // Prepare hooks.
         builder
             .generic_hooks
             .iter_mut()
             .for_each(|h| h.maps.extend(builder.maps.clone()));
-        builder.probes.values_mut().try_for_each(|p| {
-            builder
-                .maps
-                .iter()
-                .try_for_each(|(name, fd)| p.reuse_map(name, *fd))?;
-            builder
-                .global_probes_options
-                .iter()
-                .try_for_each(|o| p.set_option(o.clone()))
-        })?;
 
         // Set up filters and their handlers.
         for filter in builder.filters.iter() {
@@ -169,6 +157,7 @@ impl ProbeManager {
             generic_builders: HashMap::new(),
             targeted_builders: Vec::new(),
             probes: HashSet::new(),
+            global_probes_options: builder.global_probes_options.into_iter().collect(),
             filters: builder.filters,
         };
 
@@ -412,6 +401,7 @@ pub(crate) struct ProbeRuntimeManager {
     map_fds: Vec<(String, RawFd)>,
     hooks: Vec<Hook>,
     probes: HashSet<String>,
+    global_probes_options: Vec<ProbeOption>,
     filters: Vec<Filter>,
 }
 
@@ -501,9 +491,20 @@ impl ProbeRuntimeManager {
         Ok(())
     }
 
+    /// Make the probe inherit the global options.
+    fn prepare_probe(&mut self, probe: &mut Probe) -> Result<()> {
+        self.map_fds
+            .iter()
+            .try_for_each(|(name, fd)| probe.reuse_map(name, *fd))?;
+        self.global_probes_options
+            .iter()
+            .try_for_each(|o| probe.set_option(o.clone()))
+    }
+
     /// Attach a new targeted probe.
     #[cfg(not(test))]
     fn attach_targeted_probe(&mut self, probe: &mut Probe) -> Result<()> {
+        self.prepare_probe(probe)?;
         if !self.probes.insert(probe.key()) {
             bail!("A probe on {probe} is already attached");
         }
@@ -535,6 +536,7 @@ impl ProbeRuntimeManager {
     /// Attach a new generic probe.
     #[cfg(not(test))]
     pub(crate) fn attach_generic_probe(&mut self, probe: &mut Probe) -> Result<()> {
+        self.prepare_probe(probe)?;
         if !self.probes.insert(probe.key()) {
             bail!("A probe on {probe} is already attached");
         }

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -242,7 +242,7 @@ impl SubCommandParserRunner for Pcap {
         // The following unwrap() will never fail as Clap makes sure that either
         // list_probes is true, or probe is Some().
         let probe = self.cmd.probe.as_ref().unwrap();
-        let (probe_type, target) = parse_cli_probe(probe)?;
+        let (probe_type, target, _) = parse_cli_probe(probe)?;
         let symbol = Symbol::from_name_no_inspect(target);
 
         // Filtering logic.


### PR DESCRIPTION
Had this old patch hanging locally.
RFC as I'm mostly sending it as it was (just rebased).

- it's in addition to the stack option but can be as an alternative to those (e.g. --stack-list ... conflicting with the others)
- It's a global option remapped per-probe (we have to take into account automatic probes)

Some remarks:
- it doesn't formally check whether the symbol exists (we can extend it to do it, but I'm not sure what the advantage is), but just the syntax (consistency with the `-p`)
- even with the former bullet, it would be possible to specify an unprobed but existing symbol. 

The last bullet would implicitly cover the probe existence check but would require a bit of special casing.
I don't have a strong preference for the previous remarks (e.g. whether special casing while checking through the set option is worth it), but feel free to propose a preferred approach.