### PR TITLE
codecov: update GH comment conf

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,8 @@
+comment:
+  layout: "reach, diff, flags"
+  behavior: default
+  require_changes: true
+
 coverage:
   status:
     project:


### PR DESCRIPTION
Let's avoid file-by-file summaries as those could always be consulted on the coverage site.

Also, let's set require_changes meaning:

"Only post comment if there are changes in coverage (positive or negative)"

The option `require_changes: true` was intentionally omitted in the first push to show how the new layout would look like.