### PR TITLE
Make Event a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,11 +1075,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "indoc",
  "inventory",
  "libc",
@@ -1094,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1104,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1114,9 +1113,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1126,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/docs/python.md
+++ b/docs/python.md
@@ -46,9 +46,9 @@ available. It is of type `EventFile`.
 ```python
 $ cat myscript.py
 for event in reader.events():
-    if "skb" in event and getattr(event["skb"], "tcp", None):
+    if event.skb and event.skb.tcp:
         print("TCP event with dport: {}".format(
-            event["skb"].tcp.dport))
+            event.skb.tcp.dport))
 
 $ retis python myscript.py
 ```

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -3,7 +3,7 @@ use syn::{parse_macro_input, Fields, Ident, Item, ItemStruct};
 
 #[proc_macro_attribute]
 pub fn event_section(
-    args: proc_macro::TokenStream,
+    _args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let input: Item = parse_macro_input!(item);
@@ -13,21 +13,11 @@ pub fn event_section(
         _ => panic!("event types must be enums or structs"),
     };
 
-    let id: syn::Expr = syn::parse(args).expect("Invalid event id");
-
     let output = quote! {
         #[crate::event_type]
         #input
 
-        impl #ident {
-            pub(crate) const SECTION_ID: u8 = #id as u8;
-        }
-
         impl EventSectionInternal for #ident {
-            fn id(&self) -> u8 {
-                Self::SECTION_ID
-            }
-
             fn as_any(&self) -> &dyn std::any::Any
                 where Self: Sized,
             {

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -17,37 +17,11 @@ pub fn event_section(
         #[crate::event_type]
         #input
 
-        impl EventSectionInternal for #ident {
-            fn as_any(&self) -> &dyn std::any::Any
-                where Self: Sized,
-            {
-                self
-            }
-
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any
-                where Self: Sized,
-            {
-                self
-            }
-
-            fn to_json(&self) -> serde_json::Value
-                where Self: serde::Serialize,
-            {
-                serde_json::json!(self)
-            }
-
-            #[cfg(feature = "python")]
-            fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
-                use pyo3::IntoPyObject;
-                self.clone().into_pyobject(py).unwrap().into_any().unbind()
-            }
-        }
-
         #[cfg_attr(feature = "python", pyo3::pymethods)]
         #[cfg(feature = "python")]
         impl #ident {
             fn raw(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
-                crate::python::to_pyobject(&self.to_json(), py)
+                crate::python::to_pyobject(&serde_json::json!(self), py)
             }
 
             fn show(&self) -> String {

--- a/retis-events/Cargo.toml
+++ b/retis-events/Cargo.toml
@@ -19,7 +19,7 @@ chrono = "0.4"
 log = { version = "0.4", features = ["std"] }
 once_cell = "1.15"
 retis-derive = {version = "1.4", path = "../retis-derive"}
-pyo3 = {version = "0.24", features = ["multiple-pymethods"], optional = true}
+pyo3 = {version = "0.25", features = ["multiple-pymethods"], optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_with = "3.0"

--- a/retis-events/pytests/test_event.py
+++ b/retis-events/pytests/test_event.py
@@ -1,0 +1,31 @@
+from retis import Event, EventFile
+
+import pytest
+
+
+def test_event_inspection():
+    """Test Event sections can be accessed"""
+    f = EventFile("test_data/test_events.json")
+    events = f.events()
+
+    e = next(events)
+
+    # Access via getitem and contains
+    assert "kernel" in e
+    assert "userspace" not in e
+    assert "foo" not in e
+    assert e["kernel"]
+
+    with pytest.raises(KeyError):
+        assert e["userspace"]
+
+    # Direct access
+    assert e.kernel
+    assert e.userspace is None
+
+    # Sections
+    sections = e.sections()
+    assert isinstance(e.sections(), list)
+    assert "kernel" in e.sections()
+    assert "userspace" not in e.sections()
+    assert "foo" not in e.sections()

--- a/retis-events/src/common.rs
+++ b/retis-events/src/common.rs
@@ -6,7 +6,7 @@ use crate::*;
 
 /// Startup event section. Contains global information about a collection as a
 /// whole, with data gathered at collection startup time.
-#[event_section(SectionId::Startup)]
+#[event_section]
 pub struct StartupEvent {
     /// Retis version used while collecting events.
     pub retis_version: String,
@@ -33,7 +33,7 @@ pub struct TaskEvent {
 }
 
 /// Common event section.
-#[event_section(SectionId::Common)]
+#[event_section]
 #[derive(Default)]
 pub struct CommonEvent {
     /// Timestamp of when the event was generated.

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -111,7 +111,7 @@ pub enum CtState {
     Untracked,
 }
 /// Conntrack event
-#[event_section(SectionId::Ct)]
+#[event_section]
 pub struct CtEvent {
     /// Packet's conntrack state
     pub state: CtState,

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -31,105 +31,62 @@
 //!     ]
 //! }
 
-#![allow(dead_code)] // FIXME
 #![allow(clippy::wrong_self_convention)]
 
-use std::{any::Any, collections::HashMap, fmt, str::FromStr};
+use std::any::Any;
 
-use anyhow::{anyhow, bail, Result};
-use log::debug;
-use once_cell::sync::OnceCell;
+use anyhow::{anyhow, Result};
 
 use crate::{display::*, *};
 
-/// Full event. Internal representation. The first key is the collector from
-/// which the event sections originate. The second one is the field name of a
-/// given (collector) event field.
-#[derive(Default)]
-pub struct Event(HashMap<SectionId, Box<dyn EventSection>>);
+/// Full event. Internal representation
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, serde::Deserialize, serde::Serialize)]
+// For backwards compatiblity reasons, we keep section names in kebab-case.
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+pub struct Event {
+    /// Common section.
+    pub common: Option<CommonEvent>,
+    /// Kernel section.
+    pub kernel: Option<KernelEvent>,
+    /// Userpace section.
+    pub userspace: Option<UserEvent>,
+    /// Tracking section.
+    pub tracking: Option<TrackingInfo>,
+    /// Skb tracking section.
+    pub skb_tracking: Option<SkbTrackingEvent>,
+    /// Skb drop section.
+    pub skb_drop: Option<SkbDropEvent>,
+    /// Skb section.
+    pub skb: Option<SkbEvent>,
+    /// OVS section.
+    pub ovs: Option<OvsEvent>,
+    /// OVS-detrace section.
+    pub ovs_detrace: Option<OvsFlowInfoEvent>,
+    /// Nft section
+    pub nft: Option<NftEvent>,
+    /// Ct section
+    pub ct: Option<CtEvent>,
+    /// Startup event
+    pub startup: Option<StartupEvent>,
+
+    #[cfg(feature = "test-events")]
+    pub test: Option<TestEvent>,
+}
 
 impl Event {
     pub fn new() -> Event {
         Event::default()
     }
 
-    /// Create an Event from a json object.
-    pub(crate) fn from_json_obj(mut obj: HashMap<String, serde_json::Value>) -> Result<Event> {
-        let mut event = Event::new();
-
-        for (owner, value) in obj.drain() {
-            let parser = event_sections()?
-                .get(&owner)
-                .ok_or_else(|| anyhow!("json contains an unsupported event {}", owner))?;
-
-            debug!("Unmarshaling event section {owner}: {value}");
-            let section = parser(value).map_err(|e| {
-                anyhow!("Failed to create EventSection for owner {owner} from json: {e}")
-            })?;
-            event.insert_section(SectionId::from_u8(section.id())?, section)?;
-        }
-        Ok(event)
-    }
-
     /// Create an Event from a json string.
     pub(crate) fn from_json(line: String) -> Result<Event> {
-        let event_js: HashMap<String, serde_json::Value> = serde_json::from_str(line.as_str())
-            .map_err(|e| anyhow!("Failed to parse json event at line {line}: {e}"))?;
-
-        Self::from_json_obj(event_js)
+        Ok(serde_json::from_str(line.as_str())?)
     }
 
-    /// Insert a new event field into an event.
-    pub fn insert_section(
-        &mut self,
-        owner: SectionId,
-        section: Box<dyn EventSection>,
-    ) -> Result<()> {
-        if self.0.contains_key(&owner) {
-            bail!("Section for {} already found in the event", owner);
-        }
-
-        self.0.insert(owner, section);
-        Ok(())
-    }
-
-    /// Get a reference to an event field by its owner and key.
-    pub fn get_section<T: EventSection + 'static>(&self, owner: SectionId) -> Option<&T> {
-        match self.0.get(&owner) {
-            Some(section) => section.as_any().downcast_ref::<T>(),
-            None => None,
-        }
-    }
-
-    /// Get a reference to an event field by its owner and key.
-    pub fn get_section_mut<T: EventSection + 'static>(
-        &mut self,
-        owner: SectionId,
-    ) -> Option<&mut T> {
-        match self.0.get_mut(&owner) {
-            Some(section) => section.as_any_mut().downcast_mut::<T>(),
-            None => None,
-        }
-    }
-
-    #[allow(clippy::borrowed_box)]
-    pub(super) fn get(&self, owner: SectionId) -> Option<&Box<dyn EventSection>> {
-        self.0.get(&owner)
-    }
-
-    pub fn to_json(&self) -> serde_json::Value {
-        let mut event = serde_json::Map::new();
-
-        for (owner, section) in self.0.iter() {
-            event.insert(owner.to_str().to_string(), section.to_json());
-        }
-
-        serde_json::Value::Object(event)
-    }
-
-    /// Iterator over the existing sections
-    pub fn sections(&self) -> impl Iterator<Item = SectionId> + '_ {
-        self.0.keys().map(|s| s.to_owned())
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(self)?)
     }
 }
 
@@ -137,28 +94,25 @@ impl EventFmt for Event {
     fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> std::fmt::Result {
         // First format the first event line starting with the always-there
         // {common} section, followed by the {kernel} or {user} one.
-        self.0
-            .get(&SectionId::Common)
-            .unwrap()
-            .event_fmt(f, format)?;
-        if let Some(kernel) = self.0.get(&SectionId::Kernel) {
+        self.common.as_ref().unwrap().event_fmt(f, format)?;
+        if let Some(kernel) = &self.kernel {
             write!(f, " ")?;
             kernel.event_fmt(f, format)?;
-        } else if let Some(user) = self.0.get(&SectionId::Userspace) {
+        } else if let Some(user) = &self.userspace {
             write!(f, " ")?;
             user.event_fmt(f, format)?;
         }
 
         // If we do have tracking and/or drop sections, put them there too.
         // Special case the global tracking information from here for now.
-        if let Some(tracking) = self.0.get(&SectionId::Tracking) {
+        if let Some(tracking) = &self.tracking {
             write!(f, " ")?;
             tracking.event_fmt(f, format)?;
-        } else if let Some(skb_tracking) = self.0.get(&SectionId::SkbTracking) {
+        } else if let Some(skb_tracking) = &self.skb_tracking {
             write!(f, " ")?;
             skb_tracking.event_fmt(f, format)?;
         }
-        if let Some(skb_drop) = self.0.get(&SectionId::SkbDrop) {
+        if let Some(skb_drop) = &self.skb_drop {
             write!(f, " ")?;
             skb_drop.event_fmt(f, format)?;
         }
@@ -167,7 +121,7 @@ impl EventFmt for Event {
         let sep = if format.multiline { '\n' } else { ' ' };
 
         // If we have a stack trace, show it.
-        if let Some(kernel) = self.get_section::<KernelEvent>(SectionId::Kernel) {
+        if let Some(kernel) = &self.kernel {
             if let Some(stack) = &kernel.stack_trace {
                 f.conf.inc_level(4);
                 write!(f, "{sep}")?;
@@ -178,144 +132,27 @@ impl EventFmt for Event {
 
         f.conf.inc_level(2);
 
-        // Finally show all sections.
-        (SectionId::Skb as u8..SectionId::_MAX as u8)
-            .collect::<Vec<u8>>()
-            .iter()
-            .filter_map(|id| self.0.get(&SectionId::from_u8(*id).unwrap()))
-            .try_for_each(|section| {
+        /* Format the rest of the optional fields. */
+        [
+            self.skb.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ovs.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ovs_detrace.as_ref().map(|f| f as &dyn EventDisplay),
+            self.nft.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ct.as_ref().map(|f| f as &dyn EventDisplay),
+            self.startup.as_ref().map(|f| f as &dyn EventDisplay),
+        ]
+        .iter()
+        .try_for_each(|field| {
+            if let Some(field) = field {
                 write!(f, "{sep}")?;
-                section.event_fmt(f, format)
-            })?;
+                return field.event_fmt(f, format);
+            }
+            Ok(())
+        })?;
 
         f.conf.reset_level();
         Ok(())
     }
-}
-
-/// List of unique event sections owners.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SectionId {
-    Common = 1,
-    Kernel = 2,
-    Userspace = 3,
-    Tracking = 4,
-    SkbTracking = 5,
-    SkbDrop = 6,
-    Skb = 7,
-    Ovs = 8,
-    Nft = 9,
-    Ct = 10,
-    Startup = 11,
-    OvsFlowInfo = 12,
-    // TODO: use std::mem::variant_count once in stable.
-    _MAX = 13,
-}
-
-impl SectionId {
-    /// Constructs an SectionId from a section unique identifier
-    pub fn from_u8(val: u8) -> Result<SectionId> {
-        use SectionId::*;
-        Ok(match val {
-            1 => Common,
-            2 => Kernel,
-            3 => Userspace,
-            4 => Tracking,
-            5 => SkbTracking,
-            6 => SkbDrop,
-            7 => Skb,
-            8 => Ovs,
-            9 => Nft,
-            10 => Ct,
-            11 => Startup,
-            12 => OvsFlowInfo,
-            x => bail!("Can't construct a SectionId from {}", x),
-        })
-    }
-
-    /// Converts an SectionId to a section unique str identifier.
-    pub fn to_str(self) -> &'static str {
-        use SectionId::*;
-        match self {
-            Common => "common",
-            Kernel => "kernel",
-            Userspace => "userspace",
-            Tracking => "tracking",
-            SkbTracking => "skb-tracking",
-            SkbDrop => "skb-drop",
-            Skb => "skb",
-            Ovs => "ovs",
-            Nft => "nft",
-            Ct => "ct",
-            Startup => "startup",
-            OvsFlowInfo => "ovs-detrace",
-            _MAX => "_max",
-        }
-    }
-}
-
-// Allow using SectionId in log messages.
-impl fmt::Display for SectionId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl FromStr for SectionId {
-    type Err = anyhow::Error;
-
-    /// Constructs an SectionId from a section unique str identifier.
-    fn from_str(val: &str) -> Result<Self> {
-        use SectionId::*;
-        Ok(match val {
-            "common" => Common,
-            "kernel" => Kernel,
-            "userspace" => Userspace,
-            "tracking" => Tracking,
-            "skb-tracking" => SkbTracking,
-            "skb-drop" => SkbDrop,
-            "skb" => Skb,
-            "ovs" => Ovs,
-            "nft" => Nft,
-            "ct" => Ct,
-            "startup" => Startup,
-            "ovs-detrace" => OvsFlowInfo,
-            x => bail!("Can't construct a SectionId from {}", x),
-        })
-    }
-}
-
-type EventSectionMap = HashMap<String, fn(serde_json::Value) -> Result<Box<dyn EventSection>>>;
-static EVENT_SECTIONS: OnceCell<EventSectionMap> = OnceCell::new();
-
-macro_rules! insert_section {
-    ($events: expr, $ty: ty) => {
-        $events.insert(
-            SectionId::from_u8(<$ty>::SECTION_ID)?.to_str().to_string(),
-            |v| Ok(Box::new(serde_json::from_value::<$ty>(v)?)),
-        );
-    };
-}
-
-fn event_sections() -> Result<&'static EventSectionMap> {
-    EVENT_SECTIONS.get_or_try_init(|| {
-        let mut events = EventSectionMap::new();
-
-        insert_section!(events, CommonEvent);
-        insert_section!(events, KernelEvent);
-        insert_section!(events, UserEvent);
-        insert_section!(events, SkbTrackingEvent);
-        insert_section!(events, SkbDropEvent);
-        insert_section!(events, SkbEvent);
-        insert_section!(events, OvsEvent);
-        insert_section!(events, NftEvent);
-        insert_section!(events, CtEvent);
-        insert_section!(events, StartupEvent);
-        insert_section!(events, TrackingInfo);
-        insert_section!(events, OvsFlowInfoEvent);
-
-        Ok(events)
-    })
 }
 
 /// Event section, should map 1:1 with a SectionId. Requiring specific traits to
@@ -338,7 +175,6 @@ impl<T> EventSection for T where T: EventSectionInternal + for<'a> EventDisplay<
 ///
 /// There should not be a need to have per-object implementations for this.
 pub trait EventSectionInternal {
-    fn id(&self) -> u8;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn to_json(&self) -> serde_json::Value;
@@ -349,10 +185,6 @@ pub trait EventSectionInternal {
 // We need this as the value given as the input when deserializing something
 // into an event could be mapped to (), e.g. serde_json::Value::Null.
 impl EventSectionInternal for () {
-    fn id(&self) -> u8 {
-        SectionId::_MAX as u8
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -380,20 +212,24 @@ pub struct EventSeries {
 
 impl EventSeries {
     /// Encode the EventSeries into a json object.
-    pub fn to_json(&self) -> serde_json::Value {
-        serde_json::Value::Array(self.events.iter().map(|e| e.to_json()).collect())
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        let mut events = Vec::<serde_json::Value>::new();
+        self.events.iter().try_for_each(|e| -> Result<()> {
+            events.push(e.to_json()?);
+            Ok(())
+        })?;
+        Ok(serde_json::Value::Array(events))
     }
 
     /// Create an EventSeries from a json string.
     pub(crate) fn from_json(line: String) -> Result<EventSeries> {
         let mut series = EventSeries::default();
 
-        let mut series_js: Vec<HashMap<String, serde_json::Value>> =
-            serde_json::from_str(line.as_str())
-                .map_err(|e| anyhow!("Failed to parse json series at line {line}: {e}"))?;
+        let mut series_js: Vec<serde_json::Value> = serde_json::from_str(line.as_str())
+            .map_err(|e| anyhow!("Failed to parse json series at line {line}: {e}"))?;
 
         for obj in series_js.drain(..) {
-            let event = Event::from_json_obj(obj)?;
+            let event = serde_json::from_value(obj)?;
             series.events.push(event);
         }
         Ok(series)

--- a/retis-events/src/file.rs
+++ b/retis-events/src/file.rs
@@ -54,7 +54,7 @@ impl FileEventsFactory {
         match self.reader.read_line(&mut line) {
             Err(e) => Err(e.into()),
             Ok(0) => Ok(None),
-            Ok(_) => Ok(Some(Event::from_json(line)?)),
+            Ok(_) => Ok(Some(serde_json::from_str(line.as_str())?)),
         }
     }
 
@@ -70,7 +70,7 @@ impl FileEventsFactory {
         match self.reader.read_line(&mut line) {
             Err(e) => Err(e.into()),
             Ok(0) => Ok(None),
-            Ok(_) => Ok(Some(EventSeries::from_json(line)?)),
+            Ok(_) => Ok(Some(serde_json::from_str(line.as_str())?)),
         }
     }
 
@@ -111,7 +111,7 @@ mod tests {
 
         let mut events = Vec::new();
         while let Some(event) = fact.next_event().unwrap() {
-            println!("event: {:#?}", event.to_json());
+            println!("event: {:#?}", serde_json::json!(event));
             events.push(event)
         }
         assert!(events.len() == 4);

--- a/retis-events/src/lib.rs
+++ b/retis-events/src/lib.rs
@@ -4,8 +4,6 @@
 //! well as some ancillary structs and helpers to facilitate parsing, displaying and
 //! inspecting events.
 
-//#![allow(dead_code)]
-
 pub mod events;
 pub use events::*;
 

--- a/retis-events/src/lib.rs
+++ b/retis-events/src/lib.rs
@@ -4,7 +4,7 @@
 //! well as some ancillary structs and helpers to facilitate parsing, displaying and
 //! inspecting events.
 
-#![allow(dead_code)]
+//#![allow(dead_code)]
 
 pub mod events;
 pub use events::*;

--- a/retis-events/src/nft.rs
+++ b/retis-events/src/nft.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Nft event section
-#[event_section(SectionId::Nft)]
+#[event_section]
 #[derive(Default)]
 pub struct NftEvent {
     pub table_name: String,

--- a/retis-events/src/ovs.rs
+++ b/retis-events/src/ovs.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::{event_section, event_type, Formatter};
 
 ///The OVS Event
-#[event_section(SectionId::Ovs)]
+#[event_section]
 #[serde(tag = "event_type")]
 #[derive(PartialEq)]
 pub enum OvsEvent {
@@ -673,7 +673,7 @@ impl fmt::Display for Ufid {
 }
 
 /// The OVS flow information event
-#[event_section(SectionId::OvsFlowInfo)]
+#[event_section]
 pub struct OvsFlowInfoEvent {
     /// Unique FLow ID
     pub ufid: Ufid,

--- a/retis-events/src/python.rs
+++ b/retis-events/src/python.rs
@@ -106,7 +106,10 @@ impl PyEvent {
     /// Returns a dictionary with all key<>data stored (recursively) in the
     /// event, eg. `e.raw()['skb']['dev']`.
     fn raw(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(to_pyobject(&self.0.borrow(py).to_json().unwrap(), py))
+        Ok(to_pyobject(
+            &serde_json::to_value(self.0.borrow(py).clone()).unwrap(),
+            py,
+        ))
     }
 
     /// Returns a string representation of the event

--- a/retis-events/src/python.rs
+++ b/retis-events/src/python.rs
@@ -3,12 +3,12 @@
 //! This module contains python bindings for retis events so that they can
 //! be inspected in post-processing tools written in python.
 
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, ffi::CString, path::PathBuf};
 
 use pyo3::{
     exceptions::{PyKeyError, PyRuntimeError},
     prelude::*,
-    types::{PyBool, PyList},
+    types::{IntoPyDict, PyBool, PyList},
 };
 
 use super::*;
@@ -54,7 +54,7 @@ use super::*;
 ///   if 15 (p1_p) 2001:db8:dead::1.20 > 2001:db8:dead::2.80 ttl 64 len 20 proto TCP (6) flags [S] seq 0 win 8192
 /// ```
 #[pyclass(name = "Event")]
-pub struct PyEvent(Event);
+pub struct PyEvent(Py<Event>);
 
 // We need this to make it a pyclass.
 //
@@ -62,8 +62,8 @@ pub struct PyEvent(Event);
 unsafe impl Sync for PyEvent {}
 
 impl PyEvent {
-    pub(crate) fn new(event: Event) -> Self {
-        Self(event)
+    pub(crate) fn new(py: Python<'_>, event: Event) -> PyResult<Self> {
+        Ok(Self(Py::new(py, event)?))
     }
 }
 
@@ -71,50 +71,64 @@ impl PyEvent {
 impl PyEvent {
     /// Controls how the PyEvent is represented, eg. what is the output of
     /// `print(e)`.
-    fn __repr__<'a>(&'a self, py: Python<'a>) -> String {
-        let raw = self.raw(py);
-        let dict: &Bound<'_, PyAny> = raw.bind(py);
-        dict.repr().unwrap().to_string()
+    fn __repr__<'a>(&'a self, py: Python<'a>) -> PyResult<String> {
+        Ok(self.raw(py)?.to_string())
     }
 
-    /// Allows to use the object as a dictionary, eg. `e['skb']`.
+    /// Allows to use the object as a dictionary, e.g. `e['skb']`.
+    /// The use of direct attribute access is prefered, e.g: `e.skb`.
     fn __getitem__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
-        if let Ok(id) = SectionId::from_str(attr) {
-            if let Some(section) = self.0.get(id) {
-                return Ok(section.to_py(py));
-            }
+        let item = self
+            .__getattr__(py, attr)
+            .map_err(|_| PyKeyError::new_err(attr.to_string()))?;
+
+        if item.is_none(py) {
+            Err(PyKeyError::new_err(attr.to_string()))
+        } else {
+            Ok(item)
         }
-        Err(PyKeyError::new_err(attr.to_string()))
     }
 
-    /// Allows to check if a section is present inthe event, e.g: `'skb' in e`
-    fn __contains__<'a>(&'a self, _py: Python<'a>, attr: &str) -> PyResult<bool> {
-        if let Ok(id) = SectionId::from_str(attr) {
-            if self.0.get(id).is_some() {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+    /// Return a section or None if it's not present.
+    fn __getattr__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
+        // For backwards compatibility reasons, we allow accessing sections in kebab-case.
+        self.0.getattr(py, attr.replace("-", "_"))
+    }
+
+    /// Allows to check if a section is present in the event, e.g: `'skb' in e`.
+    /// Prefer using __getattr__ directly, i.e: `if e.skb is not None`
+    fn __contains__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<bool> {
+        Ok(self.__getattr__(py, attr).is_ok_and(|x| !x.is_none(py)))
     }
 
     /// Returns internal data as a dictionary
     ///
     /// Returns a dictionary with all key<>data stored (recursively) in the
     /// event, eg. `e.raw()['skb']['dev']`.
-    fn raw(&self, py: Python<'_>) -> PyObject {
-        to_pyobject(&self.0.to_json(), py)
+    fn raw(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(to_pyobject(&self.0.borrow(py).to_json().unwrap(), py))
     }
 
     /// Returns a string representation of the event
-    fn show(&self) -> String {
+    fn show(&self, py: Python<'_>) -> String {
         let format = crate::DisplayFormat::new().multiline(true);
-        format!("{}", self.0.display(&format, &crate::FormatterConf::new()))
+        format!(
+            "{}",
+            self.0
+                .borrow(py)
+                .display(&format, &crate::FormatterConf::new())
+        )
     }
 
     /// Returns a list of existing section names.
     pub fn sections(&self, py: Python<'_>) -> PyResult<Py<PyList>> {
-        let sections: Vec<&str> = self.0.sections().map(|s| s.to_str()).collect();
-        PyList::new(py, sections).unwrap().extract()
+        let globals = [("event", self.0.bind(py))].into_py_dict(py)?;
+
+        Ok(py.eval(
+            &CString::new("[v for v in dir(event) if not callable(v) and getattr(event,v) and not v.startswith('__')]")?,
+            Some(&globals),
+            None,
+        )?.downcast_into()?.unbind())
     }
 }
 
@@ -148,7 +162,7 @@ impl PyEventSeries {
     pub(crate) fn new(py: Python<'_>, mut series: EventSeries) -> PyResult<Self> {
         let mut events = Vec::new();
         series.events.drain(..).try_for_each(|e| -> PyResult<()> {
-            events.push(Py::new(py, PyEvent::new(e))?);
+            events.push(Py::new(py, PyEvent::new(py, e)?)?);
             Ok(())
         })?;
         Ok(Self { events, idx: 0 })
@@ -167,7 +181,9 @@ impl PyEventSeries {
             .ok_or_else(|| PyRuntimeError::new_err("Malformed Series with < 1 events"))?
             .try_borrow(py)?
             .0
-            .get_section::<CommonEvent>(SectionId::Common)
+            .try_borrow(py)?
+            .common
+            .as_ref()
             .unwrap()
             .timestamp;
         Ok(format!(
@@ -246,7 +262,7 @@ impl PyEventReader {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
         {
             Some(event) => {
-                let pyevent: Bound<'_, PyEvent> = Bound::new(py, PyEvent::new(event))?;
+                let pyevent: Bound<'_, PyEvent> = Bound::new(py, PyEvent::new(py, event)?)?;
                 Ok(Some(pyevent.into_any().into()))
             }
             None => Ok(None),

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{event_section, event_type, Formatter};
 
 /// Skb event section.
-#[event_section(SectionId::Skb)]
+#[event_section]
 #[derive(Default)]
 pub struct SkbEvent {
     /// Ethernet fields, if any.

--- a/retis-events/src/skb_drop.rs
+++ b/retis-events/src/skb_drop.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Skb drop event section.
-#[event_section(SectionId::SkbDrop)]
+#[event_section]
 pub struct SkbDropEvent {
     /// Sub-system who generated the below drop reason. None for core reasons.
     pub subsys: Option<String>,

--- a/retis-events/src/skb_tracking.rs
+++ b/retis-events/src/skb_tracking.rs
@@ -14,7 +14,7 @@ use crate::{event_section, Formatter};
 ///
 /// Tl;dr; the tracking unique id is `(timestamp, orig_head)` and `skb` can be
 /// used to distinguished between clones.
-#[event_section(SectionId::SkbTracking)]
+#[event_section]
 #[derive(Default, Copy, PartialEq)]
 #[repr(C)]
 pub struct SkbTrackingEvent {
@@ -55,7 +55,7 @@ impl EventFmt for SkbTrackingEvent {
 
 /// Tracking event section. Generated at postprocessing with combined skb and ovs
 /// tracking information.
-#[event_section(SectionId::Tracking)]
+#[event_section]
 pub struct TrackingInfo {
     /// Tracking information of the original packet.
     pub skb: SkbTrackingEvent,

--- a/retis-events/src/user.rs
+++ b/retis-events/src/user.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::*;
 use crate::{event_section, Formatter};
 
-#[event_section(SectionId::Userspace)]
+#[event_section]
 pub struct UserEvent {
     /// Probe type: for now only "usdt" is supported.
     pub probe_type: String,

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -321,15 +321,13 @@ impl Collectors {
     // Generate an initial event with the startup section.
     fn initial_event(&mut self) -> Result<()> {
         self.events_factory.add_event(|event| {
-            event.insert_section(
-                SectionId::Startup,
-                Box::new(StartupEvent {
-                    retis_version: option_env!("RELEASE_VERSION")
-                        .unwrap_or("unspec")
-                        .to_string(),
-                    clock_monotonic_offset: monotonic_clock_offset()?,
-                }),
-            )
+            event.startup = Some(StartupEvent {
+                retis_version: option_env!("RELEASE_VERSION")
+                    .unwrap_or("unspec")
+                    .to_string(),
+                clock_monotonic_offset: monotonic_clock_offset()?,
+            });
+            Ok(())
         })
     }
 

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -29,8 +29,8 @@ pub(crate) struct CtEventFactory {
 }
 
 impl RawEventSectionFactory for CtEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = CtEvent {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut ct = CtEvent {
             state: {
                 let raw = parse_raw_section::<ct_meta_event>(
                     raw_sections
@@ -65,10 +65,10 @@ impl RawEventSectionFactory for CtEventFactory {
             .iter()
             .find(|s| s.header.data_type as u32 == SECTION_PARENT_CONN)
         {
-            event.parent = Some(self.unmarshal_ct(raw_section)?);
+            ct.parent = Some(self.unmarshal_ct(raw_section)?);
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(ct.id())?, Box::new(ct))
     }
 }
 

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -68,7 +68,8 @@ impl RawEventSectionFactory for CtEventFactory {
             ct.parent = Some(self.unmarshal_ct(raw_section)?);
         }
 
-        event.insert_section(SectionId::from_u8(ct.id())?, Box::new(ct))
+        event.ct = Some(ct);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/nft/bpf.rs
+++ b/retis/src/collect/collector/nft/bpf.rs
@@ -69,6 +69,7 @@ impl RawEventSectionFactory for NftEventFactory {
             nft.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
         }
 
-        event.insert_section(SectionId::from_u8(nft.id())?, Box::new(nft))
+        event.nft = Some(nft);
+        Ok(())
     }
 }

--- a/retis/src/collect/collector/nft/bpf.rs
+++ b/retis/src/collect/collector/nft/bpf.rs
@@ -34,16 +34,16 @@ pub(super) const VERD_MAX: u64 = VERD_REPEAT;
 pub(crate) struct NftEventFactory {}
 
 impl RawEventSectionFactory for NftEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = NftEvent::default();
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut nft = NftEvent::default();
         let raw = parse_single_raw_section::<nft_event>(&raw_sections)?;
 
-        event.table_name = raw_to_string!(&raw.table_name)?;
-        event.chain_name = raw_to_string!(&raw.chain_name)?;
-        event.table_handle = raw.t_handle;
-        event.chain_handle = raw.c_handle;
-        event.policy = raw.policy == 1;
-        event.rule_handle = match raw.r_handle {
+        nft.table_name = raw_to_string!(&raw.table_name)?;
+        nft.chain_name = raw_to_string!(&raw.chain_name)?;
+        nft.table_handle = raw.t_handle;
+        nft.chain_handle = raw.c_handle;
+        nft.policy = raw.policy == 1;
+        nft.rule_handle = match raw.r_handle {
             -1 => None,
             _ => Some(raw.r_handle),
         };
@@ -62,13 +62,13 @@ impl RawEventSectionFactory for NftEventFactory {
             5 => "stop",
             _ => "unknown",
         }
-        .clone_into(&mut event.verdict);
+        .clone_into(&mut nft.verdict);
 
         // Destination chain is only valid for NFT_JUMP/NFT_GOTO.
         if raw.verdict as i32 == -3 || raw.verdict as i32 == -4 {
-            event.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
+            nft.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(nft.id())?, Box::new(nft))
     }
 }

--- a/retis/src/collect/collector/ovs/bpf.rs
+++ b/retis/src/collect/collector/ovs/bpf.rs
@@ -412,7 +412,7 @@ impl RawEventSectionFactory for OvsEventFactory {
                     ovs = Some(self.unmarshall_exec(section)?);
                 }
                 OvsDataType::FlowLookup => {
-                    event = Some(self.unmarshall_flow_lookup(section)?);
+                    ovs = Some(self.unmarshall_flow_lookup(section)?);
                 }
                 OvsDataType::ActionExecTrack => unmarshall_exec_track(
                     section,
@@ -443,7 +443,8 @@ impl RawEventSectionFactory for OvsEventFactory {
         }
 
         let ovs = ovs.ok_or_else(|| anyhow!("Incomplete OVS event"))?;
-        event.insert_section(SectionId::from_u8(ovs.id())?, Box::new(ovs))
+        event.ovs = Some(ovs);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/ovs/flow_info.rs
+++ b/retis/src/collect/collector/ovs/flow_info.rs
@@ -261,7 +261,8 @@ impl FlowEnricher {
 
 fn fill_event(info: &'_ OvsFlowInfoEvent) -> impl Fn(&mut Event) -> Result<()> + use<'_> {
     move |event| -> Result<()> {
-        event.insert_section(SectionId::OvsFlowInfo, Box::new(info.clone()))
+        event.ovs_detrace = Some(info.clone());
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb/bpf.rs
+++ b/retis/src/collect/collector/skb/bpf.rs
@@ -312,23 +312,23 @@ impl SkbEventFactory {
 }
 
 impl RawEventSectionFactory for SkbEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = SkbEvent::default();
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut skb = SkbEvent::default();
 
         for section in raw_sections.iter() {
             match section.header.data_type as u32 {
-                SECTION_VLAN => event.vlan = Some(unmarshal_vlan(section)?),
-                SECTION_DEV => event.dev = unmarshal_dev(section)?,
-                SECTION_NS => event.ns = Some(unmarshal_ns(section)?),
-                SECTION_META => event.meta = Some(unmarshal_meta(section)?),
-                SECTION_DATA_REF => event.data_ref = Some(unmarshal_data_ref(section)?),
-                SECTION_GSO => event.gso = Some(unmarshal_gso(section)?),
-                SECTION_PACKET => unmarshal_packet(&mut event, section, self.report_eth)?,
+                SECTION_VLAN => skb.vlan = Some(unmarshal_vlan(section)?),
+                SECTION_DEV => skb.dev = unmarshal_dev(section)?,
+                SECTION_NS => skb.ns = Some(unmarshal_ns(section)?),
+                SECTION_META => skb.meta = Some(unmarshal_meta(section)?),
+                SECTION_DATA_REF => skb.data_ref = Some(unmarshal_data_ref(section)?),
+                SECTION_GSO => skb.gso = Some(unmarshal_gso(section)?),
+                SECTION_PACKET => unmarshal_packet(&mut skb, section, self.report_eth)?,
                 x => bail!("Unknown data type ({x})"),
             }
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(skb.id())?, Box::new(skb))
     }
 }
 

--- a/retis/src/collect/collector/skb/bpf.rs
+++ b/retis/src/collect/collector/skb/bpf.rs
@@ -328,7 +328,8 @@ impl RawEventSectionFactory for SkbEventFactory {
             }
         }
 
-        event.insert_section(SectionId::from_u8(skb.id())?, Box::new(skb))
+        event.skb = Some(skb);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb_drop/bpf.rs
+++ b/retis/src/collect/collector/skb_drop/bpf.rs
@@ -72,7 +72,8 @@ impl RawEventSectionFactory for SkbDropEventFactory {
             drop_reason,
         };
 
-        event.insert_section(SectionId::from_u8(drop.id())?, Box::new(drop))
+        event.skb_drop = Some(drop);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb_drop/bpf.rs
+++ b/retis/src/collect/collector/skb_drop/bpf.rs
@@ -61,16 +61,18 @@ pub(crate) struct SkbDropEventFactory {
 }
 
 impl RawEventSectionFactory for SkbDropEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         let raw = parse_single_raw_section::<skb_drop_event>(&raw_sections)?;
 
         let drop_reason = raw.drop_reason;
         let (subsys, drop_reason) = self.get_reason(drop_reason);
 
-        Ok(Box::new(SkbDropEvent {
+        let drop = SkbDropEvent {
             subsys,
             drop_reason,
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(drop.id())?, Box::new(drop))
     }
 }
 

--- a/retis/src/collect/collector/skb_tracking/skb_tracking.rs
+++ b/retis/src/collect/collector/skb_tracking/skb_tracking.rs
@@ -42,16 +42,18 @@ impl Collector for SkbTrackingCollector {
 pub(crate) struct SkbTrackingEventFactory {}
 
 impl RawEventSectionFactory for SkbTrackingEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         // Both raw event and actual event map 1:1 but we still want
         // to keep the bindings for consistency
         let raw = parse_single_raw_section::<skb_tracking_event>(&raw_sections)?;
 
-        Ok(Box::new(SkbTrackingEvent {
+        let track = SkbTrackingEvent {
             orig_head: raw.orig_head,
             timestamp: raw.timestamp,
             skb: raw.skb,
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(track.id())?, Box::new(track))
     }
 }
 

--- a/retis/src/collect/collector/skb_tracking/skb_tracking.rs
+++ b/retis/src/collect/collector/skb_tracking/skb_tracking.rs
@@ -53,7 +53,8 @@ impl RawEventSectionFactory for SkbTrackingEventFactory {
             skb: raw.skb,
         };
 
-        event.insert_section(SectionId::from_u8(track.id())?, Box::new(track))
+        event.skb_tracking = Some(track);
+        Ok(())
     }
 }
 

--- a/retis/src/core/events/factory.rs
+++ b/retis/src/core/events/factory.rs
@@ -26,20 +26,17 @@ impl RetisEventsFactory {
     }
 
     /// Add a new event. The provided closure accepts an event whose
-    /// `SectionId::Common` section has already been initialized and is expected
+    /// `common` section has already been initialized and is expected
     /// to add additional sections to it.
     pub(crate) fn add_event<F>(&self, f: F) -> Result<()>
     where
         F: Fn(&mut Event) -> Result<()>,
     {
         let mut event = Event::new();
-        event.insert_section(
-            SectionId::Common,
-            Box::new(CommonEvent {
-                timestamp: monotonic_timestamp()?,
-                ..Default::default()
-            }),
-        )?;
+        event.common = Some(CommonEvent {
+            timestamp: monotonic_timestamp()?,
+            ..Default::default()
+        });
 
         f(&mut event)?;
         self.queue.lock().unwrap().push_front(event);

--- a/retis/src/core/probe/kernel/kernel.rs
+++ b/retis/src/core/probe/kernel/kernel.rs
@@ -145,7 +145,8 @@ impl RawEventSectionFactory for KernelEventFactory {
         #[cfg(not(test))]
         self.unmarshal_stackid(&mut kernel, raw.stack_id as i32)?;
 
-        event.insert_section(SectionId::from_u8(kernel.id())?, Box::new(kernel))
+        event.kernel = Some(kernel);
+        Ok(())
     }
 }
 

--- a/retis/src/core/probe/kernel/kernel.rs
+++ b/retis/src/core/probe/kernel/kernel.rs
@@ -120,12 +120,12 @@ impl KernelEventFactory {
 }
 
 impl RawEventSectionFactory for KernelEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         let raw = parse_single_raw_section::<kernel_event>(&raw_sections)?;
-        let mut event = KernelEvent::default();
+        let mut kernel = KernelEvent::default();
 
         let symbol_addr = raw.symbol;
-        event.symbol = match self.symbols_cache.get(&symbol_addr) {
+        kernel.symbol = match self.symbols_cache.get(&symbol_addr) {
             Some(name) => name.clone(),
             None => {
                 let name = Symbol::from_addr(symbol_addr)?.name();
@@ -134,7 +134,7 @@ impl RawEventSectionFactory for KernelEventFactory {
             }
         };
 
-        event.probe_type = match raw.type_ {
+        kernel.probe_type = match raw.type_ {
             0 => "kprobe",
             1 => "kretprobe",
             2 => "raw_tracepoint",
@@ -143,9 +143,9 @@ impl RawEventSectionFactory for KernelEventFactory {
         .to_string();
 
         #[cfg(not(test))]
-        self.unmarshal_stackid(&mut event, raw.stack_id as i32)?;
+        self.unmarshal_stackid(&mut kernel, raw.stack_id as i32)?;
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(kernel.id())?, Box::new(kernel))
     }
 }
 

--- a/retis/src/core/probe/kernel/probe_stack.rs
+++ b/retis/src/core/probe/kernel/probe_stack.rs
@@ -12,7 +12,7 @@ use crate::{
         kernel::Symbol,
         probe::{Probe, ProbeOption, ProbeRuntimeManager},
     },
-    events::{Event, KernelEvent, SectionId},
+    events::{Event, KernelEvent},
 };
 
 /// Probe-stack consume stack traces and add additional probes for compatible
@@ -48,7 +48,7 @@ impl ProbeStack {
         mgr: &mut ProbeRuntimeManager,
         event: &mut Event,
     ) -> Result<()> {
-        let kernel = match event.get_section_mut::<KernelEvent>(SectionId::Kernel) {
+        let kernel = match &mut event.kernel {
             Some(kernel) => kernel,
             None => return Ok(()),
         };

--- a/retis/src/core/probe/user/user.rs
+++ b/retis/src/core/probe/user/user.rs
@@ -86,7 +86,7 @@ pub(crate) struct UserEventFactory {
 }
 
 impl RawEventSectionFactory for UserEventFactory {
-    fn create(&mut self, mut raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, mut raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         if raw_sections.len() != 1 {
             bail!("User event from BPF must be a single section")
         }
@@ -129,7 +129,7 @@ impl RawEventSectionFactory for UserEventFactory {
             .get_note_from_symbol(symbol)?
             .ok_or_else(|| anyhow!("Failed to get symbol information"))?;
 
-        Ok(Box::new(UserEvent {
+        let user = UserEvent {
             pid,
             tid,
             symbol: format!("{note}"),
@@ -144,6 +144,8 @@ impl RawEventSectionFactory for UserEventFactory {
                 _ => "unknown",
             }
             .to_string(),
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(user.id())?, Box::new(user))
     }
 }

--- a/retis/src/core/probe/user/user.rs
+++ b/retis/src/core/probe/user/user.rs
@@ -146,6 +146,7 @@ impl RawEventSectionFactory for UserEventFactory {
             .to_string(),
         };
 
-        event.insert_section(SectionId::from_u8(user.id())?, Box::new(user))
+        event.userspace = Some(user);
+        Ok(())
     }
 }

--- a/retis/src/process/display.rs
+++ b/retis/src/process/display.rs
@@ -46,7 +46,7 @@ impl PrintEvent {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&e.to_json()?)?;
+                let mut event = serde_json::to_vec(&e)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }
@@ -107,7 +107,7 @@ impl PrintSeries {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&series.to_json()?)?;
+                let mut event = serde_json::to_vec(&series)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }

--- a/retis/src/process/display.rs
+++ b/retis/src/process/display.rs
@@ -28,8 +28,8 @@ impl PrintEvent {
     pub(crate) fn process_one(&mut self, e: &Event) -> Result<()> {
         match self.format {
             PrintEventFormat::Text(ref mut format) => {
-                if let Some(common) = e.get_section::<StartupEvent>(SectionId::Startup) {
-                    format.monotonic_offset = Some(common.clock_monotonic_offset);
+                if let Some(startup) = &e.startup {
+                    format.monotonic_offset = Some(startup.clock_monotonic_offset);
                 }
 
                 let mut event = format!("{}", e.display(format, &FormatterConf::new()));
@@ -46,7 +46,7 @@ impl PrintEvent {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&e.to_json())?;
+                let mut event = serde_json::to_vec(&e.to_json()?)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }
@@ -81,8 +81,8 @@ impl PrintSeries {
                 let mut first = true;
 
                 for event in series.events.iter() {
-                    if let Some(common) = event.get_section::<StartupEvent>(SectionId::Startup) {
-                        format.monotonic_offset = Some(common.clock_monotonic_offset);
+                    if let Some(startup) = &event.startup {
+                        format.monotonic_offset = Some(startup.clock_monotonic_offset);
                     }
 
                     content.push_str(&format!("{}", event.display(format, &fconf)));
@@ -107,7 +107,7 @@ impl PrintSeries {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&series.to_json())?;
+                let mut event = serde_json::to_vec(&series.to_json()?)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }


### PR DESCRIPTION
The dynamic nature the events was inherited from the dynamic module design.
Now that we're going towards a statically defined set of modules, having a well-defined `Event` struct gives us a cleaner internal code and python bindings.

See patch 2 for a list of cleanups that can be achieved.

Apart from a cleaner code base, this yields a significant performance.

| TEST                          | main    | PR      | Improvement |
|-------------------------------|---------|---------|-------------|
| 1M_print_single_singleline_us | 1031405 | 772205  | **25,13 %**     |
| 1M_print_single_multiline_us  | 1026959 | 804302  | **21,68 %**     |
| 1M_print_single_json_us       | 1787549 | 662200  | **62,95 %**     |
| 1M_print_series_singleline_us | 1247985 | 1006731 | **19,33 %**     |
| 1M_print_series_multiline_us  | 1183794 | 959220  | **18,97 %**     |
| 1M_print_series_json_us       | 2437512 | 766680  | **68,55 %**     |
| first_raw_event_parsing_us    | 328     | 320     | **2,44 %**      |
| 1M_raw_events_parsing_us      | 1776086 | 1255393 | **29,32 %**     |
