### PR TITLE
Pcap fix timestamp

### DIFF
--- a/retis-events/src/time.rs
+++ b/retis-events/src/time.rs
@@ -73,6 +73,12 @@ impl From<TimeSpec> for DateTime<Utc> {
     }
 }
 
+impl From<TimeSpec> for i64 {
+    fn from(ts: TimeSpec) -> Self {
+        ts.sec * TimeSpec::NSECS_IN_SEC + ts.nsec
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::TimeSpec;

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -134,6 +134,7 @@ impl EventParser {
                                 0 => "Fake interface".to_string(),
                                 _ => format!("ifindex={}", ifindex),
                             })),
+                            InterfaceDescriptionOption::IfTsResol(9),
                         ],
                     }
                     .into_block(),


### PR DESCRIPTION
Timestamps in pcapng generated with the pcap command are essentially broken.
The series fixes both a resolution problem and applies the offset from the startup event.
Now the timestamps look reliable compared to captures taken in parallel.