### PR TITLE
tree: use tracefs instead of debugfs when possible

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -132,7 +132,7 @@ $ file ./target/aarch64-unknown-linux-gnu/release/retis
 ### Running as non-root
 
 Retis can run as non-root if it has the right capabilities. Note that doing this
-alone often means `debugfs` won't be available as it's usually owned by `root`
+alone often means `tracefs` won't be available as it's usually owned by `root`
 only and Retis won't be able to fully filter probes.
 
 ```none

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -5,9 +5,9 @@
 - By default Retis does not modify the system (e.g. load kernel modules, mount
   filesystems, change the configuration, add a firewalling rule). This is done
   on purpose but might mean some prerequisites will be missing if not added
-  manually. The only notable examples are the `nft` module and the `debugfs`.
+  manually. The only notable examples are the `nft` module and `tracefs`.
   The former requires a specific nft rule to be inserted. If that rule is not
-  there, no nft event will be reported. The latter, `debugfs`, although not
+  there, no nft event will be reported. The latter, `tracefs`, although not
   mandatory, is preferable to have it mounted as it is accessed by Retis to
   better determine traceable events and functions.
   To allow Retis to modify the system, use the `--allow-system-changes` option

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -8,8 +8,9 @@ the `collect` sub-command.
   [set of options](#kernel-kconfig-options).
 - Access to `/sys/kernel/btf` and `/proc/kallsyms` to parse kernel functions and
   types.
-- `debugfs` should be mounted to `/sys/kernel/debug` to allow filtering
-  functions and events (or `--allow-system-changes` must be set).
+- `tracefs` should be mounted to `/sys/kernel/tracing` or
+  `/sys/kernel/debug/tracing` to allow filtering functions and events (or
+  `--allow-system-changes` must be set).
 
 ## Kernel Kconfig options
 

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -136,8 +136,9 @@ Notes:
         help = r#"Allow the tool to setup all the system changes needed to make the tracing
 fully operational:
 
-- Mounting debugfs to /sys/kernel/debug if not already mounted. If Retis mounted debugfs it
-  will unmount it when stopped.
+- Mounting tracefs to /sys/kernel/tracing if not already mounted. If Retis mounted tracefs it
+  will unmount it when stopped. On older kernels it might mount (and unmount) debugfs to
+  /sys/kernel/debug instead.
 
 - In the case the nft collector is used, creating a dummy table called "Retis_Table"
   as the following:

--- a/retis/src/core/kernel/symbol.rs
+++ b/retis/src/core/kernel/symbol.rs
@@ -35,11 +35,11 @@ impl Symbol {
     /// Create a new symbol given its name. We'll try hard to induce its type,
     /// using different techniques depending on what is available.
     pub(crate) fn from_name(name: &str) -> Result<Symbol> {
-        let mut debugfs = false;
+        let mut tracefs = false;
 
         // First try to see if the symbol is a traceable event.
         if let Some(traceable) = inspector()?.kernel.is_event_traceable(name) {
-            debugfs = true;
+            tracefs = true;
             if traceable {
                 return Symbol::Event(name.to_string()).check();
             }
@@ -51,12 +51,12 @@ impl Symbol {
                 return Symbol::Func(name.to_string()).check();
             }
         } else {
-            debugfs = false;
+            tracefs = false;
         }
 
-        // We had access to debugfs for inducing the symbol type and we didn't
+        // We had access to tracefs for inducing the symbol type and we didn't
         // find anything. The symbol isn't traceable.
-        if debugfs {
+        if tracefs {
             bail!("Symbol {} does not exist or isn't traceable", name);
         }
 

--- a/tools/retis_in_container.sh
+++ b/tools/retis_in_container.sh
@@ -45,6 +45,10 @@ if [[ -z $kconfig_map ]]; then
 	echo "You can place your configuration file in the current directory and use the '--kconf' option"
 fi
 
+# Find tracefs; keep mounting debugfs for older RETIS_TAG.
+[ -d /sys/kernel/tracing ] && tracefs="-v /sys/kernel/tracing:/sys/kernel/tracing:ro"
+[ -d /sys/kernel/debug ] && debugfs="-v /sys/kernel/debug:/sys/kernel/debug:ro"
+
 # Map local config if exist.
 local_conf=$HOME/.config/retis
 [ -d $local_conf ] && local_conf="-v $local_conf:/root/.config/retis:ro" || local_conf=""
@@ -59,7 +63,7 @@ exec $runtime run $extra_args $term_opts --privileged --rm --pid=host \
       -e PAGER -e NOPAGER -e TERM -e LC_ALL="C.UTF-8" \
       --cap-add SYS_ADMIN --cap-add BPF --cap-add SYSLOG \
       -v /sys/kernel/btf:/sys/kernel/btf:ro \
-      -v /sys/kernel/debug:/sys/kernel/debug:ro \
+      $tracefs $debugfs \
       -v $(pwd):/data:rw \
       $kconfig_legacy_map $kconfig_map \
       $local_conf \


### PR DESCRIPTION
Initially tracefs was part of debugfs and only accessible when debugfs was mounted. However this changed and tracefs can now be mounted even if debugfs is not. This is now a common behavior by default in many distributions.

This is indeed better; in Retis try using the standalone tracefs mount instead of the nested one.