### PR TITLE
[RFC] Proof of concept: Wireshark as retis UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__/
 retis.data
 retis-events/.tox
+tools/wireshark/retis.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,36 +49,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -90,9 +90,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base-x"
@@ -112,7 +112,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -123,7 +123,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -134,9 +134,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "btf-rs"
@@ -150,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byteorder"
@@ -177,9 +177,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -258,9 +258,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -306,36 +306,36 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.47"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
+checksum = "aad5b1b4de04fead402672b48897030eec1f3bfe1550776322f59f6d6e6a5677"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -389,7 +389,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -493,9 +493,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -610,9 +610,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -674,7 +674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -748,7 +748,7 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93edd9cd673087fa7518fd63ad6c87be2cd9b4e35034b1873f3e3258c018275b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libbpf-sys",
  "libc",
  "vsprintf",
@@ -756,29 +756,29 @@ dependencies = [
 
 [[package]]
 name = "libbpf-sys"
-version = "1.5.0+v1.5.0"
+version = "1.5.1+v1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8306b516a70a129cb6afed17c1e51e162d35aadfcc6339364addcebe32de90"
+checksum = "912fae30b08bcbdb861d4b85bd09c05352c0ac9d7b93765ced5ca23709e7e590"
 dependencies = [
  "cc",
- "nix",
+ "nix 0.30.1",
  "pkg-config",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -789,9 +789,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -805,9 +805,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -844,9 +844,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -857,7 +857,19 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -901,6 +913,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "ovs-unixctl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,9 +941,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -933,15 +951,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1012,7 +1030,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1038,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "powerfmt"
@@ -1050,12 +1068,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1127,7 +1145,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1140,7 +1158,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1154,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rbpf"
@@ -1173,11 +1191,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1197,7 +1215,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1251,7 +1269,7 @@ dependencies = [
  "log",
  "memmap2 0.9.5",
  "memoffset",
- "nix",
+ "nix 0.29.0",
  "once_cell",
  "ovs-unixctl",
  "pager",
@@ -1282,7 +1300,7 @@ name = "retis-derive"
 version = "1.5.0"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1319,12 +1337,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
- "errno 0.3.11",
+ "bitflags 2.9.1",
+ "errno 0.3.12",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
@@ -1332,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1373,7 +1391,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1429,7 +1447,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1440,7 +1458,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1457,15 +1475,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1475,14 +1494,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1520,7 +1539,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1546,9 +1565,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1565,18 +1584,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "standback"
@@ -1655,9 +1671,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1672,9 +1688,9 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1710,7 +1726,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1721,7 +1737,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
  "test-case-core",
 ]
 
@@ -1751,7 +1767,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1762,7 +1778,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1905,7 +1921,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -1927,7 +1943,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1974,9 +1990,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -1993,7 +2009,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2004,29 +2020,29 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -2050,7 +2066,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2059,14 +2075,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2074,6 +2106,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2088,6 +2126,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,10 +2144,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2118,6 +2174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,10 +2192,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2148,10 +2222,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,12 +961,12 @@ dependencies = [
 
 [[package]]
 name = "pcap-file"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+version = "3.0.0-rc1"
+source = "git+https://github.com/amorenoz/pcap-file.git?branch=custom-blocks#e6ed2f6e555452a1c78790fd28d4135f8fbfb399"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
+ "once_cell",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1175,6 +1181,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1264,7 @@ dependencies = [
  "regex",
  "retis-derive",
  "retis-events",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -1269,6 +1296,7 @@ dependencies = [
  "once_cell",
  "pyo3",
  "retis-derive",
+ "schemars",
  "serde",
  "serde_json",
  "serde_with",
@@ -1324,6 +1352,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1426,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/python.md
+++ b/docs/python.md
@@ -46,9 +46,9 @@ available. It is of type `EventFile`.
 ```python
 $ cat myscript.py
 for event in reader.events():
-    if "skb" in event and getattr(event["skb"], "tcp", None):
+    if event.skb and event.skb.tcp:
         print("TCP event with dport: {}".format(
-            event["skb"].tcp.dport))
+            event.skb.tcp.dport))
 
 $ retis python myscript.py
 ```

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -3,7 +3,7 @@ use syn::{parse_macro_input, Fields, Ident, Item, ItemStruct};
 
 #[proc_macro_attribute]
 pub fn event_section(
-    args: proc_macro::TokenStream,
+    _args: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
     let input: Item = parse_macro_input!(item);
@@ -13,21 +13,11 @@ pub fn event_section(
         _ => panic!("event types must be enums or structs"),
     };
 
-    let id: syn::Expr = syn::parse(args).expect("Invalid event id");
-
     let output = quote! {
         #[crate::event_type]
         #input
 
-        impl #ident {
-            pub(crate) const SECTION_ID: u8 = #id as u8;
-        }
-
         impl EventSectionInternal for #ident {
-            fn id(&self) -> u8 {
-                Self::SECTION_ID
-            }
-
             fn as_any(&self) -> &dyn std::any::Any
                 where Self: Sized,
             {

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -17,37 +17,11 @@ pub fn event_section(
         #[crate::event_type]
         #input
 
-        impl EventSectionInternal for #ident {
-            fn as_any(&self) -> &dyn std::any::Any
-                where Self: Sized,
-            {
-                self
-            }
-
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any
-                where Self: Sized,
-            {
-                self
-            }
-
-            fn to_json(&self) -> serde_json::Value
-                where Self: serde::Serialize,
-            {
-                serde_json::json!(self)
-            }
-
-            #[cfg(feature = "python")]
-            fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
-                use pyo3::IntoPyObject;
-                self.clone().into_pyobject(py).unwrap().into_any().unbind()
-            }
-        }
-
         #[cfg_attr(feature = "python", pyo3::pymethods)]
         #[cfg(feature = "python")]
         impl #ident {
             fn raw(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
-                crate::python::to_pyobject(&self.to_json(), py)
+                crate::python::to_pyobject(&serde_json::json!(self), py)
             }
 
             fn show(&self) -> String {

--- a/retis-derive/src/lib.rs
+++ b/retis-derive/src/lib.rs
@@ -78,6 +78,7 @@ pub fn event_type(
         quote!(Debug),
         quote!(serde::Serialize),
         quote!(serde::Deserialize),
+        quote!(schemars::JsonSchema),
     ];
 
     if props.enum_is_simple {

--- a/retis-events/Cargo.toml
+++ b/retis-events/Cargo.toml
@@ -23,3 +23,4 @@ pyo3 = {version = "0.24", features = ["multiple-pymethods"], optional = true}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 serde_with = "3.0"
+schemars = "0.9"

--- a/retis-events/pytests/test_event.py
+++ b/retis-events/pytests/test_event.py
@@ -1,0 +1,31 @@
+from retis import Event, EventFile
+
+import pytest
+
+
+def test_event_inspection():
+    """Test Event sections can be accessed"""
+    f = EventFile("test_data/test_events.json")
+    events = f.events()
+
+    e = next(events)
+
+    # Access via getitem and contains
+    assert "kernel" in e
+    assert "userspace" not in e
+    assert "foo" not in e
+    assert e["kernel"]
+
+    with pytest.raises(KeyError):
+        assert e["userspace"]
+
+    # Direct access
+    assert e.kernel
+    assert e.userspace is None
+
+    # Sections
+    sections = e.sections()
+    assert isinstance(e.sections(), list)
+    assert "kernel" in e.sections()
+    assert "userspace" not in e.sections()
+    assert "foo" not in e.sections()

--- a/retis-events/src/common.rs
+++ b/retis-events/src/common.rs
@@ -6,7 +6,7 @@ use crate::*;
 
 /// Startup event section. Contains global information about a collection as a
 /// whole, with data gathered at collection startup time.
-#[event_section(SectionId::Startup)]
+#[event_section]
 pub struct StartupEvent {
     /// Retis version used while collecting events.
     pub retis_version: String,
@@ -33,7 +33,7 @@ pub struct TaskEvent {
 }
 
 /// Common event section.
-#[event_section(SectionId::Common)]
+#[event_section]
 #[derive(Default)]
 pub struct CommonEvent {
     /// Timestamp of when the event was generated.

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -111,7 +111,7 @@ pub enum CtState {
     Untracked,
 }
 /// Conntrack event
-#[event_section(SectionId::Ct)]
+#[event_section]
 pub struct CtEvent {
     /// Packet's conntrack state
     pub state: CtState,

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -37,7 +37,7 @@ use crate::{display::*, *};
 
 /// Full event. Internal representation
 #[serde_with::skip_serializing_none]
-#[derive(Default, Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Default, Debug, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
 pub struct Event {

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -33,8 +33,6 @@
 
 #![allow(clippy::wrong_self_convention)]
 
-use std::any::Any;
-
 use anyhow::{anyhow, Result};
 
 use crate::{display::*, *};
@@ -151,54 +149,6 @@ impl EventFmt for Event {
 
         f.conf.reset_level();
         Ok(())
-    }
-}
-
-/// Event section, should map 1:1 with a SectionId. Requiring specific traits to
-/// be implemented helps handling those sections in the core directly without
-/// requiring all section to serialize and deserialize their part by hand
-/// (except for the special case of BPF section events as there is an n:1
-/// mapping there).
-///
-/// Please use `#[retis_derive::event_section]` to implement the common traits.
-///
-/// The underlying objects are free to hold their data in any way, although
-/// having a proper structure is encouraged as it allows easier consumption at
-/// post-processing. Those objects can also define their own specialized
-/// helpers.
-pub trait EventSection: EventSectionInternal + for<'a> EventDisplay<'a> + Send {}
-impl<T> EventSection for T where T: EventSectionInternal + for<'a> EventDisplay<'a> + Send {}
-
-/// EventSection helpers defined in the core for all events. Common definition
-/// needs Sized but that is a requirement for all EventSection.
-///
-/// There should not be a need to have per-object implementations for this.
-pub trait EventSectionInternal {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-    fn to_json(&self) -> serde_json::Value;
-    #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject;
-}
-
-// We need this as the value given as the input when deserializing something
-// into an event could be mapped to (), e.g. serde_json::Value::Null.
-impl EventSectionInternal for () {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn to_json(&self) -> serde_json::Value {
-        serde_json::Value::Null
-    }
-
-    #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyObject {
-        py.None()
     }
 }
 

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -31,105 +31,61 @@
 //!     ]
 //! }
 
-#![allow(dead_code)] // FIXME
 #![allow(clippy::wrong_self_convention)]
 
-use std::{any::Any, collections::HashMap, fmt, str::FromStr};
+use std::any::Any;
 
-use anyhow::{anyhow, bail, Result};
-use log::debug;
-use once_cell::sync::OnceCell;
+use anyhow::{anyhow, Result};
 
 use crate::{display::*, *};
 
-/// Full event. Internal representation. The first key is the collector from
-/// which the event sections originate. The second one is the field name of a
-/// given (collector) event field.
-#[derive(Default)]
-pub struct Event(HashMap<SectionId, Box<dyn EventSection>>);
+/// Full event. Internal representation
+#[serde_with::skip_serializing_none]
+#[derive(Default, Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "python", pyo3::pyclass(get_all))]
+pub struct Event {
+    /// Common section.
+    pub common: Option<CommonEvent>,
+    /// Kernel section.
+    pub kernel: Option<KernelEvent>,
+    /// Userpace section.
+    pub userspace: Option<UserEvent>,
+    /// Tracking section.
+    pub tracking: Option<TrackingInfo>,
+    /// Skb tracking section.
+    pub skb_tracking: Option<SkbTrackingEvent>,
+    /// Skb drop section.
+    pub skb_drop: Option<SkbDropEvent>,
+    /// Skb section.
+    pub skb: Option<SkbEvent>,
+    /// OVS section.
+    pub ovs: Option<OvsEvent>,
+    /// OVS-detrace section.
+    pub ovs_detrace: Option<OvsFlowInfoEvent>,
+    /// Nft section
+    pub nft: Option<NftEvent>,
+    /// Ct section
+    pub ct: Option<CtEvent>,
+    /// Startup event
+    pub startup: Option<StartupEvent>,
+
+    #[cfg(feature = "test-events")]
+    pub test: Option<TestEvent>,
+}
 
 impl Event {
     pub fn new() -> Event {
         Event::default()
     }
 
-    /// Create an Event from a json object.
-    pub(crate) fn from_json_obj(mut obj: HashMap<String, serde_json::Value>) -> Result<Event> {
-        let mut event = Event::new();
-
-        for (owner, value) in obj.drain() {
-            let parser = event_sections()?
-                .get(&owner)
-                .ok_or_else(|| anyhow!("json contains an unsupported event {}", owner))?;
-
-            debug!("Unmarshaling event section {owner}: {value}");
-            let section = parser(value).map_err(|e| {
-                anyhow!("Failed to create EventSection for owner {owner} from json: {e}")
-            })?;
-            event.insert_section(SectionId::from_u8(section.id())?, section)?;
-        }
-        Ok(event)
-    }
-
     /// Create an Event from a json string.
     pub(crate) fn from_json(line: String) -> Result<Event> {
-        let event_js: HashMap<String, serde_json::Value> = serde_json::from_str(line.as_str())
-            .map_err(|e| anyhow!("Failed to parse json event at line {line}: {e}"))?;
-
-        Self::from_json_obj(event_js)
+        Ok(serde_json::from_str(line.as_str())?)
     }
 
-    /// Insert a new event field into an event.
-    pub fn insert_section(
-        &mut self,
-        owner: SectionId,
-        section: Box<dyn EventSection>,
-    ) -> Result<()> {
-        if self.0.contains_key(&owner) {
-            bail!("Section for {} already found in the event", owner);
-        }
-
-        self.0.insert(owner, section);
-        Ok(())
-    }
-
-    /// Get a reference to an event field by its owner and key.
-    pub fn get_section<T: EventSection + 'static>(&self, owner: SectionId) -> Option<&T> {
-        match self.0.get(&owner) {
-            Some(section) => section.as_any().downcast_ref::<T>(),
-            None => None,
-        }
-    }
-
-    /// Get a reference to an event field by its owner and key.
-    pub fn get_section_mut<T: EventSection + 'static>(
-        &mut self,
-        owner: SectionId,
-    ) -> Option<&mut T> {
-        match self.0.get_mut(&owner) {
-            Some(section) => section.as_any_mut().downcast_mut::<T>(),
-            None => None,
-        }
-    }
-
-    #[allow(clippy::borrowed_box)]
-    pub(super) fn get(&self, owner: SectionId) -> Option<&Box<dyn EventSection>> {
-        self.0.get(&owner)
-    }
-
-    pub fn to_json(&self) -> serde_json::Value {
-        let mut event = serde_json::Map::new();
-
-        for (owner, section) in self.0.iter() {
-            event.insert(owner.to_str().to_string(), section.to_json());
-        }
-
-        serde_json::Value::Object(event)
-    }
-
-    /// Iterator over the existing sections
-    pub fn sections(&self) -> impl Iterator<Item = SectionId> + '_ {
-        self.0.keys().map(|s| s.to_owned())
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(self)?)
     }
 }
 
@@ -137,28 +93,25 @@ impl EventFmt for Event {
     fn event_fmt(&self, f: &mut Formatter, format: &DisplayFormat) -> std::fmt::Result {
         // First format the first event line starting with the always-there
         // {common} section, followed by the {kernel} or {user} one.
-        self.0
-            .get(&SectionId::Common)
-            .unwrap()
-            .event_fmt(f, format)?;
-        if let Some(kernel) = self.0.get(&SectionId::Kernel) {
+        self.common.as_ref().unwrap().event_fmt(f, format)?;
+        if let Some(kernel) = &self.kernel {
             write!(f, " ")?;
             kernel.event_fmt(f, format)?;
-        } else if let Some(user) = self.0.get(&SectionId::Userspace) {
+        } else if let Some(user) = &self.userspace {
             write!(f, " ")?;
             user.event_fmt(f, format)?;
         }
 
         // If we do have tracking and/or drop sections, put them there too.
         // Special case the global tracking information from here for now.
-        if let Some(tracking) = self.0.get(&SectionId::Tracking) {
+        if let Some(tracking) = &self.tracking {
             write!(f, " ")?;
             tracking.event_fmt(f, format)?;
-        } else if let Some(skb_tracking) = self.0.get(&SectionId::SkbTracking) {
+        } else if let Some(skb_tracking) = &self.skb_tracking {
             write!(f, " ")?;
             skb_tracking.event_fmt(f, format)?;
         }
-        if let Some(skb_drop) = self.0.get(&SectionId::SkbDrop) {
+        if let Some(skb_drop) = &self.skb_drop {
             write!(f, " ")?;
             skb_drop.event_fmt(f, format)?;
         }
@@ -167,7 +120,7 @@ impl EventFmt for Event {
         let sep = if format.multiline { '\n' } else { ' ' };
 
         // If we have a stack trace, show it.
-        if let Some(kernel) = self.get_section::<KernelEvent>(SectionId::Kernel) {
+        if let Some(kernel) = &self.kernel {
             if let Some(stack) = &kernel.stack_trace {
                 f.conf.inc_level(4);
                 write!(f, "{sep}")?;
@@ -178,144 +131,27 @@ impl EventFmt for Event {
 
         f.conf.inc_level(2);
 
-        // Finally show all sections.
-        (SectionId::Skb as u8..SectionId::_MAX as u8)
-            .collect::<Vec<u8>>()
-            .iter()
-            .filter_map(|id| self.0.get(&SectionId::from_u8(*id).unwrap()))
-            .try_for_each(|section| {
+        /* Format the rest of the optional fields. */
+        [
+            self.skb.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ovs.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ovs_detrace.as_ref().map(|f| f as &dyn EventDisplay),
+            self.nft.as_ref().map(|f| f as &dyn EventDisplay),
+            self.ct.as_ref().map(|f| f as &dyn EventDisplay),
+            self.startup.as_ref().map(|f| f as &dyn EventDisplay),
+        ]
+        .iter()
+        .try_for_each(|field| {
+            if let Some(field) = field {
                 write!(f, "{sep}")?;
-                section.event_fmt(f, format)
-            })?;
+                return field.event_fmt(f, format);
+            }
+            Ok(())
+        })?;
 
         f.conf.reset_level();
         Ok(())
     }
-}
-
-/// List of unique event sections owners.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub enum SectionId {
-    Common = 1,
-    Kernel = 2,
-    Userspace = 3,
-    Tracking = 4,
-    SkbTracking = 5,
-    SkbDrop = 6,
-    Skb = 7,
-    Ovs = 8,
-    Nft = 9,
-    Ct = 10,
-    Startup = 11,
-    OvsFlowInfo = 12,
-    // TODO: use std::mem::variant_count once in stable.
-    _MAX = 13,
-}
-
-impl SectionId {
-    /// Constructs an SectionId from a section unique identifier
-    pub fn from_u8(val: u8) -> Result<SectionId> {
-        use SectionId::*;
-        Ok(match val {
-            1 => Common,
-            2 => Kernel,
-            3 => Userspace,
-            4 => Tracking,
-            5 => SkbTracking,
-            6 => SkbDrop,
-            7 => Skb,
-            8 => Ovs,
-            9 => Nft,
-            10 => Ct,
-            11 => Startup,
-            12 => OvsFlowInfo,
-            x => bail!("Can't construct a SectionId from {}", x),
-        })
-    }
-
-    /// Converts an SectionId to a section unique str identifier.
-    pub fn to_str(self) -> &'static str {
-        use SectionId::*;
-        match self {
-            Common => "common",
-            Kernel => "kernel",
-            Userspace => "userspace",
-            Tracking => "tracking",
-            SkbTracking => "skb-tracking",
-            SkbDrop => "skb-drop",
-            Skb => "skb",
-            Ovs => "ovs",
-            Nft => "nft",
-            Ct => "ct",
-            Startup => "startup",
-            OvsFlowInfo => "ovs-detrace",
-            _MAX => "_max",
-        }
-    }
-}
-
-// Allow using SectionId in log messages.
-impl fmt::Display for SectionId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{self:?}")
-    }
-}
-
-impl FromStr for SectionId {
-    type Err = anyhow::Error;
-
-    /// Constructs an SectionId from a section unique str identifier.
-    fn from_str(val: &str) -> Result<Self> {
-        use SectionId::*;
-        Ok(match val {
-            "common" => Common,
-            "kernel" => Kernel,
-            "userspace" => Userspace,
-            "tracking" => Tracking,
-            "skb-tracking" => SkbTracking,
-            "skb-drop" => SkbDrop,
-            "skb" => Skb,
-            "ovs" => Ovs,
-            "nft" => Nft,
-            "ct" => Ct,
-            "startup" => Startup,
-            "ovs-detrace" => OvsFlowInfo,
-            x => bail!("Can't construct a SectionId from {}", x),
-        })
-    }
-}
-
-type EventSectionMap = HashMap<String, fn(serde_json::Value) -> Result<Box<dyn EventSection>>>;
-static EVENT_SECTIONS: OnceCell<EventSectionMap> = OnceCell::new();
-
-macro_rules! insert_section {
-    ($events: expr, $ty: ty) => {
-        $events.insert(
-            SectionId::from_u8(<$ty>::SECTION_ID)?.to_str().to_string(),
-            |v| Ok(Box::new(serde_json::from_value::<$ty>(v)?)),
-        );
-    };
-}
-
-fn event_sections() -> Result<&'static EventSectionMap> {
-    EVENT_SECTIONS.get_or_try_init(|| {
-        let mut events = EventSectionMap::new();
-
-        insert_section!(events, CommonEvent);
-        insert_section!(events, KernelEvent);
-        insert_section!(events, UserEvent);
-        insert_section!(events, SkbTrackingEvent);
-        insert_section!(events, SkbDropEvent);
-        insert_section!(events, SkbEvent);
-        insert_section!(events, OvsEvent);
-        insert_section!(events, NftEvent);
-        insert_section!(events, CtEvent);
-        insert_section!(events, StartupEvent);
-        insert_section!(events, TrackingInfo);
-        insert_section!(events, OvsFlowInfoEvent);
-
-        Ok(events)
-    })
 }
 
 /// Event section, should map 1:1 with a SectionId. Requiring specific traits to
@@ -338,7 +174,6 @@ impl<T> EventSection for T where T: EventSectionInternal + for<'a> EventDisplay<
 ///
 /// There should not be a need to have per-object implementations for this.
 pub trait EventSectionInternal {
-    fn id(&self) -> u8;
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
     fn to_json(&self) -> serde_json::Value;
@@ -349,10 +184,6 @@ pub trait EventSectionInternal {
 // We need this as the value given as the input when deserializing something
 // into an event could be mapped to (), e.g. serde_json::Value::Null.
 impl EventSectionInternal for () {
-    fn id(&self) -> u8 {
-        SectionId::_MAX as u8
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -380,20 +211,24 @@ pub struct EventSeries {
 
 impl EventSeries {
     /// Encode the EventSeries into a json object.
-    pub fn to_json(&self) -> serde_json::Value {
-        serde_json::Value::Array(self.events.iter().map(|e| e.to_json()).collect())
+    pub fn to_json(&self) -> Result<serde_json::Value> {
+        let mut events = Vec::<serde_json::Value>::new();
+        self.events.iter().try_for_each(|e| -> Result<()> {
+            events.push(e.to_json()?);
+            Ok(())
+        })?;
+        Ok(serde_json::Value::Array(events))
     }
 
     /// Create an EventSeries from a json string.
     pub(crate) fn from_json(line: String) -> Result<EventSeries> {
         let mut series = EventSeries::default();
 
-        let mut series_js: Vec<HashMap<String, serde_json::Value>> =
-            serde_json::from_str(line.as_str())
-                .map_err(|e| anyhow!("Failed to parse json series at line {line}: {e}"))?;
+        let mut series_js: Vec<serde_json::Value> = serde_json::from_str(line.as_str())
+            .map_err(|e| anyhow!("Failed to parse json series at line {line}: {e}"))?;
 
         for obj in series_js.drain(..) {
-            let event = Event::from_json_obj(obj)?;
+            let event = serde_json::from_value(obj)?;
             series.events.push(event);
         }
         Ok(series)

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -33,8 +33,6 @@
 
 #![allow(clippy::wrong_self_convention)]
 
-use anyhow::{anyhow, Result};
-
 use crate::{display::*, *};
 
 /// Full event. Internal representation
@@ -75,15 +73,6 @@ pub struct Event {
 impl Event {
     pub fn new() -> Event {
         Event::default()
-    }
-
-    /// Create an Event from a json string.
-    pub(crate) fn from_json(line: String) -> Result<Event> {
-        Ok(serde_json::from_str(line.as_str())?)
-    }
-
-    pub fn to_json(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(self)?)
     }
 }
 
@@ -153,36 +142,11 @@ impl EventFmt for Event {
 }
 
 /// A set of sorted Events with the same tracking id.
-#[derive(Default)]
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
 pub struct EventSeries {
     /// Events that comprise the Series.
     pub events: Vec<Event>,
-}
-
-impl EventSeries {
-    /// Encode the EventSeries into a json object.
-    pub fn to_json(&self) -> Result<serde_json::Value> {
-        let mut events = Vec::<serde_json::Value>::new();
-        self.events.iter().try_for_each(|e| -> Result<()> {
-            events.push(e.to_json()?);
-            Ok(())
-        })?;
-        Ok(serde_json::Value::Array(events))
-    }
-
-    /// Create an EventSeries from a json string.
-    pub(crate) fn from_json(line: String) -> Result<EventSeries> {
-        let mut series = EventSeries::default();
-
-        let mut series_js: Vec<serde_json::Value> = serde_json::from_str(line.as_str())
-            .map_err(|e| anyhow!("Failed to parse json series at line {line}: {e}"))?;
-
-        for obj in series_js.drain(..) {
-            let event = serde_json::from_value(obj)?;
-            series.events.push(event);
-        }
-        Ok(series)
-    }
 }
 
 #[cfg(feature = "test-events")]

--- a/retis-events/src/file.rs
+++ b/retis-events/src/file.rs
@@ -54,7 +54,7 @@ impl FileEventsFactory {
         match self.reader.read_line(&mut line) {
             Err(e) => Err(e.into()),
             Ok(0) => Ok(None),
-            Ok(_) => Ok(Some(Event::from_json(line)?)),
+            Ok(_) => Ok(Some(serde_json::from_str(line.as_str())?)),
         }
     }
 
@@ -70,7 +70,7 @@ impl FileEventsFactory {
         match self.reader.read_line(&mut line) {
             Err(e) => Err(e.into()),
             Ok(0) => Ok(None),
-            Ok(_) => Ok(Some(EventSeries::from_json(line)?)),
+            Ok(_) => Ok(Some(serde_json::from_str(line.as_str())?)),
         }
     }
 
@@ -111,7 +111,7 @@ mod tests {
 
         let mut events = Vec::new();
         while let Some(event) = fact.next_event().unwrap() {
-            println!("event: {:#?}", event.to_json());
+            println!("event: {:#?}", serde_json::json!(event));
             events.push(event)
         }
         assert!(events.len() == 4);

--- a/retis-events/src/helpers.rs
+++ b/retis-events/src/helpers.rs
@@ -78,7 +78,7 @@ impl U128 {
 /// Represents a raw packet. Stored internally as a `Vec<u8>`.
 /// We don't use #[event_type] as we're implementing serde::Serialize and
 /// serde::Deserialize manually.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, schemars::JsonSchema)]
 #[cfg_attr(feature = "python", derive(pyo3::IntoPyObject))]
 pub struct RawPacket(pub Vec<u8>);
 

--- a/retis-events/src/kernel.rs
+++ b/retis-events/src/kernel.rs
@@ -3,14 +3,16 @@ use std::fmt;
 use super::*;
 use crate::{event_section, event_type, Formatter};
 
+/// Kernel Event section.
 #[event_section(SectionId::Kernel)]
 #[derive(Default)]
 pub struct KernelEvent {
-    /// Kernel symbol name associated with the event (i.e. which probe generated
-    /// the event).
+    /// Kernel symbol name associated with the event. I.e: which probe
+    /// generated the event.
     pub symbol: String,
-    /// Probe type: one of "kprobe", "kretprobe" or "raw_tracepoint".
+    /// Probe type. Oone of "kprobe", "kretprobe" or "raw_tracepoint".
     pub probe_type: String,
+    /// Stack trace.
     pub stack_trace: Option<StackTrace>,
 }
 

--- a/retis-events/src/lib.rs
+++ b/retis-events/src/lib.rs
@@ -4,8 +4,6 @@
 //! well as some ancillary structs and helpers to facilitate parsing, displaying and
 //! inspecting events.
 
-//#![allow(dead_code)]
-
 pub mod events;
 pub use events::*;
 

--- a/retis-events/src/lib.rs
+++ b/retis-events/src/lib.rs
@@ -4,7 +4,7 @@
 //! well as some ancillary structs and helpers to facilitate parsing, displaying and
 //! inspecting events.
 
-#![allow(dead_code)]
+//#![allow(dead_code)]
 
 pub mod events;
 pub use events::*;

--- a/retis-events/src/nft.rs
+++ b/retis-events/src/nft.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Nft event section
-#[event_section(SectionId::Nft)]
+#[event_section]
 #[derive(Default)]
 pub struct NftEvent {
     pub table_name: String,

--- a/retis-events/src/ovs.rs
+++ b/retis-events/src/ovs.rs
@@ -7,7 +7,7 @@ use super::*;
 use crate::{event_section, event_type, Formatter};
 
 ///The OVS Event
-#[event_section(SectionId::Ovs)]
+#[event_section]
 #[serde(tag = "event_type")]
 #[derive(PartialEq)]
 pub enum OvsEvent {
@@ -673,7 +673,7 @@ impl fmt::Display for Ufid {
 }
 
 /// The OVS flow information event
-#[event_section(SectionId::OvsFlowInfo)]
+#[event_section]
 pub struct OvsFlowInfoEvent {
     /// Unique FLow ID
     pub ufid: Ufid,

--- a/retis-events/src/python.rs
+++ b/retis-events/src/python.rs
@@ -105,7 +105,10 @@ impl PyEvent {
     /// Returns a dictionary with all key<>data stored (recursively) in the
     /// event, eg. `e.raw()['skb']['dev']`.
     fn raw(&self, py: Python<'_>) -> PyResult<PyObject> {
-        Ok(to_pyobject(&self.0.borrow(py).to_json().unwrap(), py))
+        Ok(to_pyobject(
+            &serde_json::to_value(self.0.borrow(py).clone()).unwrap(),
+            py,
+        ))
     }
 
     /// Returns a string representation of the event

--- a/retis-events/src/python.rs
+++ b/retis-events/src/python.rs
@@ -3,12 +3,12 @@
 //! This module contains python bindings for retis events so that they can
 //! be inspected in post-processing tools written in python.
 
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, ffi::CString, path::PathBuf};
 
 use pyo3::{
     exceptions::{PyKeyError, PyRuntimeError},
     prelude::*,
-    types::{PyBool, PyList},
+    types::{IntoPyDict, PyBool, PyList},
 };
 
 use super::*;
@@ -54,7 +54,7 @@ use super::*;
 ///   if 15 (p1_p) 2001:db8:dead::1.20 > 2001:db8:dead::2.80 ttl 64 len 20 proto TCP (6) flags [S] seq 0 win 8192
 /// ```
 #[pyclass(name = "Event")]
-pub struct PyEvent(Event);
+pub struct PyEvent(Py<Event>);
 
 // We need this to make it a pyclass.
 //
@@ -62,8 +62,8 @@ pub struct PyEvent(Event);
 unsafe impl Sync for PyEvent {}
 
 impl PyEvent {
-    pub(crate) fn new(event: Event) -> Self {
-        Self(event)
+    pub(crate) fn new(py: Python<'_>, event: Event) -> PyResult<Self> {
+        Ok(Self(Py::new(py, event)?))
     }
 }
 
@@ -71,50 +71,63 @@ impl PyEvent {
 impl PyEvent {
     /// Controls how the PyEvent is represented, eg. what is the output of
     /// `print(e)`.
-    fn __repr__<'a>(&'a self, py: Python<'a>) -> String {
-        let raw = self.raw(py);
-        let dict: &Bound<'_, PyAny> = raw.bind(py);
-        dict.repr().unwrap().to_string()
+    fn __repr__<'a>(&'a self, py: Python<'a>) -> PyResult<String> {
+        Ok(self.raw(py)?.to_string())
     }
 
-    /// Allows to use the object as a dictionary, eg. `e['skb']`.
+    /// Allows to use the object as a dictionary, e.g. `e['skb']`.
+    /// The use of direct attribute access is prefered, e.g: `e.skb`.
     fn __getitem__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
-        if let Ok(id) = SectionId::from_str(attr) {
-            if let Some(section) = self.0.get(id) {
-                return Ok(section.to_py(py));
-            }
+        let item = self
+            .__getattr__(py, attr)
+            .map_err(|_| PyKeyError::new_err(attr.to_string()))?;
+
+        if item.is_none(py) {
+            Err(PyKeyError::new_err(attr.to_string()))
+        } else {
+            Ok(item)
         }
-        Err(PyKeyError::new_err(attr.to_string()))
     }
 
-    /// Allows to check if a section is present inthe event, e.g: `'skb' in e`
-    fn __contains__<'a>(&'a self, _py: Python<'a>, attr: &str) -> PyResult<bool> {
-        if let Ok(id) = SectionId::from_str(attr) {
-            if self.0.get(id).is_some() {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+    /// Return a section or None if it's not present.
+    fn __getattr__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
+        self.0.getattr(py, attr)
+    }
+
+    /// Allows to check if a section is present in the event, e.g: `'skb' in e`.
+    /// Prefer using __getattr__ directly, i.e: `if e.skb is not None`
+    fn __contains__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<bool> {
+        Ok(self.0.getattr(py, attr).is_ok_and(|x| !x.is_none(py)))
     }
 
     /// Returns internal data as a dictionary
     ///
     /// Returns a dictionary with all key<>data stored (recursively) in the
     /// event, eg. `e.raw()['skb']['dev']`.
-    fn raw(&self, py: Python<'_>) -> PyObject {
-        to_pyobject(&self.0.to_json(), py)
+    fn raw(&self, py: Python<'_>) -> PyResult<PyObject> {
+        Ok(to_pyobject(&self.0.borrow(py).to_json().unwrap(), py))
     }
 
     /// Returns a string representation of the event
-    fn show(&self) -> String {
+    fn show(&self, py: Python<'_>) -> String {
         let format = crate::DisplayFormat::new().multiline(true);
-        format!("{}", self.0.display(&format, &crate::FormatterConf::new()))
+        format!(
+            "{}",
+            self.0
+                .borrow(py)
+                .display(&format, &crate::FormatterConf::new())
+        )
     }
 
     /// Returns a list of existing section names.
     pub fn sections(&self, py: Python<'_>) -> PyResult<Py<PyList>> {
-        let sections: Vec<&str> = self.0.sections().map(|s| s.to_str()).collect();
-        PyList::new(py, sections).unwrap().extract()
+        let globals = [("event", self.0.bind(py))].into_py_dict(py)?;
+
+        Ok(py.eval(
+            &CString::new("[v for v in dir(event) if not callable(v) and getattr(event,v) and not v.startswith('__')]")?,
+            Some(&globals),
+            None,
+        )?.downcast_into()?.unbind())
     }
 }
 
@@ -148,7 +161,7 @@ impl PyEventSeries {
     pub(crate) fn new(py: Python<'_>, mut series: EventSeries) -> PyResult<Self> {
         let mut events = Vec::new();
         series.events.drain(..).try_for_each(|e| -> PyResult<()> {
-            events.push(Py::new(py, PyEvent::new(e))?);
+            events.push(Py::new(py, PyEvent::new(py, e)?)?);
             Ok(())
         })?;
         Ok(Self { events, idx: 0 })
@@ -167,7 +180,9 @@ impl PyEventSeries {
             .ok_or_else(|| PyRuntimeError::new_err("Malformed Series with < 1 events"))?
             .try_borrow(py)?
             .0
-            .get_section::<CommonEvent>(SectionId::Common)
+            .try_borrow(py)?
+            .common
+            .as_ref()
             .unwrap()
             .timestamp;
         Ok(format!(
@@ -246,7 +261,7 @@ impl PyEventReader {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
         {
             Some(event) => {
-                let pyevent: Bound<'_, PyEvent> = Bound::new(py, PyEvent::new(event))?;
+                let pyevent: Bound<'_, PyEvent> = Bound::new(py, PyEvent::new(py, event)?)?;
                 Ok(Some(pyevent.into_any().into()))
             }
             None => Ok(None),

--- a/retis-events/src/skb.rs
+++ b/retis-events/src/skb.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{event_section, event_type, Formatter};
 
 /// Skb event section.
-#[event_section(SectionId::Skb)]
+#[event_section]
 #[derive(Default)]
 pub struct SkbEvent {
     /// Ethernet fields, if any.

--- a/retis-events/src/skb_drop.rs
+++ b/retis-events/src/skb_drop.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{event_section, Formatter};
 
 /// Skb drop event section.
-#[event_section(SectionId::SkbDrop)]
+#[event_section]
 pub struct SkbDropEvent {
     /// Sub-system who generated the below drop reason. None for core reasons.
     pub subsys: Option<String>,

--- a/retis-events/src/skb_tracking.rs
+++ b/retis-events/src/skb_tracking.rs
@@ -14,7 +14,7 @@ use crate::{event_section, Formatter};
 ///
 /// Tl;dr; the tracking unique id is `(timestamp, orig_head)` and `skb` can be
 /// used to distinguished between clones.
-#[event_section(SectionId::SkbTracking)]
+#[event_section]
 #[derive(Default, Copy, PartialEq)]
 #[repr(C)]
 pub struct SkbTrackingEvent {
@@ -55,7 +55,7 @@ impl EventFmt for SkbTrackingEvent {
 
 /// Tracking event section. Generated at postprocessing with combined skb and ovs
 /// tracking information.
-#[event_section(SectionId::Tracking)]
+#[event_section]
 pub struct TrackingInfo {
     /// Tracking information of the original packet.
     pub skb: SkbTrackingEvent,

--- a/retis-events/src/user.rs
+++ b/retis-events/src/user.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use super::*;
 use crate::{event_section, Formatter};
 
-#[event_section(SectionId::Userspace)]
+#[event_section]
 pub struct UserEvent {
     /// Probe type: for now only "usdt" is supported.
     pub probe_type: String,

--- a/retis/Cargo.toml
+++ b/retis/Cargo.toml
@@ -48,7 +48,7 @@ once_cell = "1.15"
 ovs-unixctl = { version = "0.1.0" }
 pager = "0.16"
 pcap = "2.2"
-pcap-file = "2.0"
+pcap-file = { git = "https://github.com/amorenoz/pcap-file.git", branch = "custom-blocks" }
 plain = "0.2"
 pnet_packet = "0.35"
 rbpf = {version = "0.3", optional = true}

--- a/retis/Cargo.toml
+++ b/retis/Cargo.toml
@@ -62,6 +62,7 @@ signal-hook = "0.3"
 termcolor = "1.3"
 time = { version = "0.3", features = ["formatting", "macros"] }
 thiserror = "2.0"
+schemars = "0.9"
 
 [build-dependencies]
 bindgen = "0.71"

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -321,15 +321,13 @@ impl Collectors {
     // Generate an initial event with the startup section.
     fn initial_event(&mut self) -> Result<()> {
         self.events_factory.add_event(|event| {
-            event.insert_section(
-                SectionId::Startup,
-                Box::new(StartupEvent {
-                    retis_version: option_env!("RELEASE_VERSION")
-                        .unwrap_or("unspec")
-                        .to_string(),
-                    clock_monotonic_offset: monotonic_clock_offset()?,
-                }),
-            )
+            event.startup = Some(StartupEvent {
+                retis_version: option_env!("RELEASE_VERSION")
+                    .unwrap_or("unspec")
+                    .to_string(),
+                clock_monotonic_offset: monotonic_clock_offset()?,
+            });
+            Ok(())
         })
     }
 

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -29,8 +29,8 @@ pub(crate) struct CtEventFactory {
 }
 
 impl RawEventSectionFactory for CtEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = CtEvent {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut ct = CtEvent {
             state: {
                 let raw = parse_raw_section::<ct_meta_event>(
                     raw_sections
@@ -65,10 +65,10 @@ impl RawEventSectionFactory for CtEventFactory {
             .iter()
             .find(|s| s.header.data_type as u32 == SECTION_PARENT_CONN)
         {
-            event.parent = Some(self.unmarshal_ct(raw_section)?);
+            ct.parent = Some(self.unmarshal_ct(raw_section)?);
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(ct.id())?, Box::new(ct))
     }
 }
 

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -68,7 +68,8 @@ impl RawEventSectionFactory for CtEventFactory {
             ct.parent = Some(self.unmarshal_ct(raw_section)?);
         }
 
-        event.insert_section(SectionId::from_u8(ct.id())?, Box::new(ct))
+        event.ct = Some(ct);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/nft/bpf.rs
+++ b/retis/src/collect/collector/nft/bpf.rs
@@ -69,6 +69,7 @@ impl RawEventSectionFactory for NftEventFactory {
             nft.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
         }
 
-        event.insert_section(SectionId::from_u8(nft.id())?, Box::new(nft))
+        event.nft = Some(nft);
+        Ok(())
     }
 }

--- a/retis/src/collect/collector/nft/bpf.rs
+++ b/retis/src/collect/collector/nft/bpf.rs
@@ -34,16 +34,16 @@ pub(super) const VERD_MAX: u64 = VERD_REPEAT;
 pub(crate) struct NftEventFactory {}
 
 impl RawEventSectionFactory for NftEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = NftEvent::default();
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut nft = NftEvent::default();
         let raw = parse_single_raw_section::<nft_event>(&raw_sections)?;
 
-        event.table_name = raw_to_string!(&raw.table_name)?;
-        event.chain_name = raw_to_string!(&raw.chain_name)?;
-        event.table_handle = raw.t_handle;
-        event.chain_handle = raw.c_handle;
-        event.policy = raw.policy == 1;
-        event.rule_handle = match raw.r_handle {
+        nft.table_name = raw_to_string!(&raw.table_name)?;
+        nft.chain_name = raw_to_string!(&raw.chain_name)?;
+        nft.table_handle = raw.t_handle;
+        nft.chain_handle = raw.c_handle;
+        nft.policy = raw.policy == 1;
+        nft.rule_handle = match raw.r_handle {
             -1 => None,
             _ => Some(raw.r_handle),
         };
@@ -62,13 +62,13 @@ impl RawEventSectionFactory for NftEventFactory {
             5 => "stop",
             _ => "unknown",
         }
-        .clone_into(&mut event.verdict);
+        .clone_into(&mut nft.verdict);
 
         // Destination chain is only valid for NFT_JUMP/NFT_GOTO.
         if raw.verdict as i32 == -3 || raw.verdict as i32 == -4 {
-            event.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
+            nft.verdict_chain_name = raw_to_string_opt!(&raw.verdict_chain_name)?;
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(nft.id())?, Box::new(nft))
     }
 }

--- a/retis/src/collect/collector/ovs/bpf.rs
+++ b/retis/src/collect/collector/ovs/bpf.rs
@@ -412,7 +412,7 @@ impl RawEventSectionFactory for OvsEventFactory {
                     ovs = Some(self.unmarshall_exec(section)?);
                 }
                 OvsDataType::FlowLookup => {
-                    event = Some(self.unmarshall_flow_lookup(section)?);
+                    ovs = Some(self.unmarshall_flow_lookup(section)?);
                 }
                 OvsDataType::ActionExecTrack => unmarshall_exec_track(
                     section,
@@ -443,7 +443,8 @@ impl RawEventSectionFactory for OvsEventFactory {
         }
 
         let ovs = ovs.ok_or_else(|| anyhow!("Incomplete OVS event"))?;
-        event.insert_section(SectionId::from_u8(ovs.id())?, Box::new(ovs))
+        event.ovs = Some(ovs);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/ovs/flow_info.rs
+++ b/retis/src/collect/collector/ovs/flow_info.rs
@@ -261,7 +261,8 @@ impl FlowEnricher {
 
 fn fill_event(info: &'_ OvsFlowInfoEvent) -> impl Fn(&mut Event) -> Result<()> + use<'_> {
     move |event| -> Result<()> {
-        event.insert_section(SectionId::OvsFlowInfo, Box::new(info.clone()))
+        event.ovs_detrace = Some(info.clone());
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb/bpf.rs
+++ b/retis/src/collect/collector/skb/bpf.rs
@@ -312,23 +312,23 @@ impl SkbEventFactory {
 }
 
 impl RawEventSectionFactory for SkbEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
-        let mut event = SkbEvent::default();
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
+        let mut skb = SkbEvent::default();
 
         for section in raw_sections.iter() {
             match section.header.data_type as u32 {
-                SECTION_VLAN => event.vlan = Some(unmarshal_vlan(section)?),
-                SECTION_DEV => event.dev = unmarshal_dev(section)?,
-                SECTION_NS => event.ns = Some(unmarshal_ns(section)?),
-                SECTION_META => event.meta = Some(unmarshal_meta(section)?),
-                SECTION_DATA_REF => event.data_ref = Some(unmarshal_data_ref(section)?),
-                SECTION_GSO => event.gso = Some(unmarshal_gso(section)?),
-                SECTION_PACKET => unmarshal_packet(&mut event, section, self.report_eth)?,
+                SECTION_VLAN => skb.vlan = Some(unmarshal_vlan(section)?),
+                SECTION_DEV => skb.dev = unmarshal_dev(section)?,
+                SECTION_NS => skb.ns = Some(unmarshal_ns(section)?),
+                SECTION_META => skb.meta = Some(unmarshal_meta(section)?),
+                SECTION_DATA_REF => skb.data_ref = Some(unmarshal_data_ref(section)?),
+                SECTION_GSO => skb.gso = Some(unmarshal_gso(section)?),
+                SECTION_PACKET => unmarshal_packet(&mut skb, section, self.report_eth)?,
                 x => bail!("Unknown data type ({x})"),
             }
         }
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(skb.id())?, Box::new(skb))
     }
 }
 

--- a/retis/src/collect/collector/skb/bpf.rs
+++ b/retis/src/collect/collector/skb/bpf.rs
@@ -328,7 +328,8 @@ impl RawEventSectionFactory for SkbEventFactory {
             }
         }
 
-        event.insert_section(SectionId::from_u8(skb.id())?, Box::new(skb))
+        event.skb = Some(skb);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb_drop/bpf.rs
+++ b/retis/src/collect/collector/skb_drop/bpf.rs
@@ -72,7 +72,8 @@ impl RawEventSectionFactory for SkbDropEventFactory {
             drop_reason,
         };
 
-        event.insert_section(SectionId::from_u8(drop.id())?, Box::new(drop))
+        event.skb_drop = Some(drop);
+        Ok(())
     }
 }
 

--- a/retis/src/collect/collector/skb_drop/bpf.rs
+++ b/retis/src/collect/collector/skb_drop/bpf.rs
@@ -61,16 +61,18 @@ pub(crate) struct SkbDropEventFactory {
 }
 
 impl RawEventSectionFactory for SkbDropEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         let raw = parse_single_raw_section::<skb_drop_event>(&raw_sections)?;
 
         let drop_reason = raw.drop_reason;
         let (subsys, drop_reason) = self.get_reason(drop_reason);
 
-        Ok(Box::new(SkbDropEvent {
+        let drop = SkbDropEvent {
             subsys,
             drop_reason,
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(drop.id())?, Box::new(drop))
     }
 }
 

--- a/retis/src/collect/collector/skb_tracking/skb_tracking.rs
+++ b/retis/src/collect/collector/skb_tracking/skb_tracking.rs
@@ -42,16 +42,18 @@ impl Collector for SkbTrackingCollector {
 pub(crate) struct SkbTrackingEventFactory {}
 
 impl RawEventSectionFactory for SkbTrackingEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         // Both raw event and actual event map 1:1 but we still want
         // to keep the bindings for consistency
         let raw = parse_single_raw_section::<skb_tracking_event>(&raw_sections)?;
 
-        Ok(Box::new(SkbTrackingEvent {
+        let track = SkbTrackingEvent {
             orig_head: raw.orig_head,
             timestamp: raw.timestamp,
             skb: raw.skb,
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(track.id())?, Box::new(track))
     }
 }
 

--- a/retis/src/collect/collector/skb_tracking/skb_tracking.rs
+++ b/retis/src/collect/collector/skb_tracking/skb_tracking.rs
@@ -53,7 +53,8 @@ impl RawEventSectionFactory for SkbTrackingEventFactory {
             skb: raw.skb,
         };
 
-        event.insert_section(SectionId::from_u8(track.id())?, Box::new(track))
+        event.skb_tracking = Some(track);
+        Ok(())
     }
 }
 

--- a/retis/src/core/events/factory.rs
+++ b/retis/src/core/events/factory.rs
@@ -26,20 +26,17 @@ impl RetisEventsFactory {
     }
 
     /// Add a new event. The provided closure accepts an event whose
-    /// `SectionId::Common` section has already been initialized and is expected
+    /// `common` section has already been initialized and is expected
     /// to add additional sections to it.
     pub(crate) fn add_event<F>(&self, f: F) -> Result<()>
     where
         F: Fn(&mut Event) -> Result<()>,
     {
         let mut event = Event::new();
-        event.insert_section(
-            SectionId::Common,
-            Box::new(CommonEvent {
-                timestamp: monotonic_timestamp()?,
-                ..Default::default()
-            }),
-        )?;
+        event.common = Some(CommonEvent {
+            timestamp: monotonic_timestamp()?,
+            ..Default::default()
+        });
 
         f(&mut event)?;
         self.queue.lock().unwrap().push_front(event);

--- a/retis/src/core/probe/kernel/kernel.rs
+++ b/retis/src/core/probe/kernel/kernel.rs
@@ -145,7 +145,8 @@ impl RawEventSectionFactory for KernelEventFactory {
         #[cfg(not(test))]
         self.unmarshal_stackid(&mut kernel, raw.stack_id as i32)?;
 
-        event.insert_section(SectionId::from_u8(kernel.id())?, Box::new(kernel))
+        event.kernel = Some(kernel);
+        Ok(())
     }
 }
 

--- a/retis/src/core/probe/kernel/kernel.rs
+++ b/retis/src/core/probe/kernel/kernel.rs
@@ -120,12 +120,12 @@ impl KernelEventFactory {
 }
 
 impl RawEventSectionFactory for KernelEventFactory {
-    fn create(&mut self, raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         let raw = parse_single_raw_section::<kernel_event>(&raw_sections)?;
-        let mut event = KernelEvent::default();
+        let mut kernel = KernelEvent::default();
 
         let symbol_addr = raw.symbol;
-        event.symbol = match self.symbols_cache.get(&symbol_addr) {
+        kernel.symbol = match self.symbols_cache.get(&symbol_addr) {
             Some(name) => name.clone(),
             None => {
                 let name = Symbol::from_addr(symbol_addr)?.name();
@@ -134,7 +134,7 @@ impl RawEventSectionFactory for KernelEventFactory {
             }
         };
 
-        event.probe_type = match raw.type_ {
+        kernel.probe_type = match raw.type_ {
             0 => "kprobe",
             1 => "kretprobe",
             2 => "raw_tracepoint",
@@ -143,9 +143,9 @@ impl RawEventSectionFactory for KernelEventFactory {
         .to_string();
 
         #[cfg(not(test))]
-        self.unmarshal_stackid(&mut event, raw.stack_id as i32)?;
+        self.unmarshal_stackid(&mut kernel, raw.stack_id as i32)?;
 
-        Ok(Box::new(event))
+        event.insert_section(SectionId::from_u8(kernel.id())?, Box::new(kernel))
     }
 }
 

--- a/retis/src/core/probe/kernel/probe_stack.rs
+++ b/retis/src/core/probe/kernel/probe_stack.rs
@@ -12,7 +12,7 @@ use crate::{
         kernel::Symbol,
         probe::{Probe, ProbeOption, ProbeRuntimeManager},
     },
-    events::{Event, KernelEvent, SectionId},
+    events::{Event, KernelEvent},
 };
 
 /// Probe-stack consume stack traces and add additional probes for compatible
@@ -48,7 +48,7 @@ impl ProbeStack {
         mgr: &mut ProbeRuntimeManager,
         event: &mut Event,
     ) -> Result<()> {
-        let kernel = match event.get_section_mut::<KernelEvent>(SectionId::Kernel) {
+        let kernel = match &mut event.kernel {
             Some(kernel) => kernel,
             None => return Ok(()),
         };

--- a/retis/src/core/probe/user/user.rs
+++ b/retis/src/core/probe/user/user.rs
@@ -86,7 +86,7 @@ pub(crate) struct UserEventFactory {
 }
 
 impl RawEventSectionFactory for UserEventFactory {
-    fn create(&mut self, mut raw_sections: Vec<BpfRawSection>) -> Result<Box<dyn EventSection>> {
+    fn create(&mut self, mut raw_sections: Vec<BpfRawSection>, event: &mut Event) -> Result<()> {
         if raw_sections.len() != 1 {
             bail!("User event from BPF must be a single section")
         }
@@ -129,7 +129,7 @@ impl RawEventSectionFactory for UserEventFactory {
             .get_note_from_symbol(symbol)?
             .ok_or_else(|| anyhow!("Failed to get symbol information"))?;
 
-        Ok(Box::new(UserEvent {
+        let user = UserEvent {
             pid,
             tid,
             symbol: format!("{note}"),
@@ -144,6 +144,8 @@ impl RawEventSectionFactory for UserEventFactory {
                 _ => "unknown",
             }
             .to_string(),
-        }))
+        };
+
+        event.insert_section(SectionId::from_u8(user.id())?, Box::new(user))
     }
 }

--- a/retis/src/core/probe/user/user.rs
+++ b/retis/src/core/probe/user/user.rs
@@ -146,6 +146,7 @@ impl RawEventSectionFactory for UserEventFactory {
             .to_string(),
         };
 
-        event.insert_section(SectionId::from_u8(user.id())?, Box::new(user))
+        event.userspace = Some(user);
+        Ok(())
     }
 }

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -2,24 +2,28 @@ use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
     fs::{File, OpenOptions},
+    io::Write,
     path::{Path, PathBuf},
     time::Duration,
 };
 
 use anyhow::{anyhow, bail, Result};
 use clap::{arg, Args, Parser};
-use log::{info, warn};
+use log::warn;
 use pcap_file::{
     pcapng::{
         blocks::{
+            custom::CustomCopiable,
             enhanced_packet::{EnhancedPacketBlock, EnhancedPacketOption},
             interface_description::{InterfaceDescriptionBlock, InterfaceDescriptionOption},
+            opt_common::CustomUtf8Option,
             Block,
         },
         PcapNgBlock, PcapNgWriter,
     },
-    DataLink,
+    DataLink, PcapError,
 };
+use schemars::{schema_for, Schema};
 
 use crate::{
     cli::*,
@@ -53,6 +57,8 @@ struct EventParser {
     stats: EventParserStats,
     /// Time offset
     ts_off: Option<TimeSpec>,
+    /// Whether the header was written
+    wrote_header: bool,
 }
 
 // Unwrap a Some(_) value or return from the function.
@@ -68,6 +74,39 @@ macro_rules! some_or_return {
     };
 }
 
+// TODO: Register with IANA?
+const RETIS_PEN: u32 = 70000;
+
+/// Custom block containing the JSON-Schema of events.
+struct SchemaBlock {
+    schema: Schema,
+}
+
+impl SchemaBlock {
+    fn new() -> Result<Self> {
+        Ok(SchemaBlock {
+            schema: schema_for!(Event),
+        })
+    }
+}
+
+impl CustomCopiable<'_> for SchemaBlock {
+    const PEN: u32 = RETIS_PEN;
+
+    fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), PcapError> {
+        let bytes = serde_json::to_vec(&self.schema)
+            .map_err(|_| PcapError::InvalidField("Invalid schema block"))?;
+        writer.write_all(&bytes[..])?;
+        Ok(())
+    }
+
+    fn from_slice(slice: &[u8]) -> Result<Option<Self>, PcapError> {
+        let schema: Schema = serde_json::from_slice(slice)
+            .map_err(|_| PcapError::InvalidField("Invalid schema block"))?;
+        Ok(Some(SchemaBlock { schema }))
+    }
+}
+
 impl EventParser {
     /// Creates a new EventParser from a PcapNgWriter<W: Write>.
     fn new() -> Self {
@@ -75,6 +114,7 @@ impl EventParser {
             ifaces: HashMap::new(),
             stats: EventParserStats::default(),
             ts_off: None,
+            wrote_header: false,
         }
     }
 
@@ -116,8 +156,13 @@ impl EventParser {
             }
         };
 
-        // If we see this iface for the first time, add a description block.
         let mut v = Vec::new();
+        if !self.wrote_header {
+            v.push(SchemaBlock::new()?.into_custom_block()?.into_block());
+            self.wrote_header = true;
+        }
+
+        // If we see this iface for the first time, add a description block.
         let key: u64 = ((netns as u64) << 32) | ifindex as u64;
         let id = match self.ifaces.contains_key(&key) {
             // Unwrap if contains is true.
@@ -157,10 +202,17 @@ impl EventParser {
                 ) as u64),
                 original_len: packet.len,
                 data: Cow::Borrowed(&packet.packet.0),
-                options: vec![EnhancedPacketOption::Comment(Cow::Owned(format!(
-                    "probe={}:{}",
-                    &kernel.probe_type, &kernel.symbol
-                )))],
+                options: vec![
+                    EnhancedPacketOption::Comment(Cow::Owned(format!(
+                        "probe={}:{}",
+                        &kernel.probe_type, &kernel.symbol
+                    ))),
+                    EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
+                        code: 2988, // Custom Option containing a UTF-8 string.
+                        pen: RETIS_PEN,
+                        value: Cow::Owned(serde_json::to_string(&event)?),
+                    }),
+                ],
             }
             .into_owned()
             .into_block(),
@@ -172,8 +224,6 @@ impl EventParser {
     /// Report parser statistics. Should be called after processing was
     /// completed.
     fn report_stats(&self) {
-        info!("{} event(s) were processed", self.stats.processed);
-
         if self.stats.missing_skb != 0 {
             warn!(
                 "{} event(s) were skipped because of missing skb information",
@@ -396,6 +446,11 @@ mod tests {
                 "ovs_dp_upcall",
                 Ok(()),
                 vec![
+                    SchemaBlock::new()
+                        .expect("Failed to create SchemaBlock")
+                        .into_custom_block()
+                        .expect("Failed to convert SchemaBlock into block")
+                        .into_block(),
                     Block::InterfaceDescription(InterfaceDescriptionBlock {
                         linktype: DataLink::ETHERNET,
                         snaplen: 65535,
@@ -421,9 +476,18 @@ mod tests {
                         interface_id: 0,
                         timestamp: Duration::from_nanos(1742339565860167909),
                         original_len: 98,
-                        options: vec![EnhancedPacketOption::Comment(Cow::Owned(
-                            "probe=kretprobe:ovs_dp_upcall".to_string(),
-                        ))],
+                        options: vec![
+                            EnhancedPacketOption::Comment(Cow::Owned(
+                                "probe=kretprobe:ovs_dp_upcall".to_string(),
+                            )),
+                            EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
+                                code: 2988,
+                                pen: RETIS_PEN,
+                                value: Cow::Owned(String::from(
+                                    r#"{"common":{"timestamp":30419169125909,"smp_id":6,"task":{"pid":11330,"tgid":11330,"comm":"ping"}},"kernel":{"symbol":"ovs_dp_upcall","probe_type":"kretprobe"},"skb-tracking":{"orig_head":18446619372617628672,"timestamp":30419169061793,"skb":18446619372874141952},"skb":{"eth":{"etype":2048,"src":"a6:c2:11:71:59:45","dst":"fa:5c:bd:8e:cc:01"},"ip":{"saddr":"192.168.125.10","daddr":"192.168.125.11","v4":{"tos":0,"id":41977,"flags":2,"offset":0},"protocol":1,"len":84,"ttl":64,"ecn":0},"icmp":{"type":8,"code":0},"dev":{"name":"veth-ns01-ovs","ifindex":10,"rx_ifindex":10},"ns":{"netns":4026531840},"meta":{"len":98,"data_len":0,"hash":2116835702,"ip_summed":0,"csum":2770033380,"csum_level":0,"priority":0},"data_ref":{"nohdr":false,"cloned":false,"fclone":0,"users":1,"dataref":1},"packet":{"len":98,"capture_len":98,"packet":"+ly9jswBpsIRcVlFCABFAABUo/lAAEABG0nAqH0KwKh9CwgAQFpxTAAB7f3ZZwAAAACzHw0AAAAAABAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc="}},"ovs":{"event_type":"upcall_return","upcall_ts":30419169098548,"upcall_cpu":6,"ret":0}}"#,
+                                )),
+                            }),
+                        ],
                     }),
                     Block::InterfaceDescription(InterfaceDescriptionBlock {
                         linktype: DataLink::ETHERNET,
@@ -450,9 +514,18 @@ mod tests {
                         interface_id: 1,
                         timestamp: Duration::from_nanos(1742339565860414774),
                         original_len: 98,
-                        options: vec![EnhancedPacketOption::Comment(Cow::Owned(
-                            "probe=kretprobe:ovs_dp_upcall".to_string(),
-                        ))],
+                        options: vec![
+                            EnhancedPacketOption::Comment(Cow::Owned(
+                                "probe=kretprobe:ovs_dp_upcall".to_string(),
+                            )),
+                            EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
+                                code: 2988,
+                                pen: RETIS_PEN,
+                                value: Cow::Owned(String::from(
+                                    r#"{"common":{"timestamp":30419169372774,"smp_id":6,"task":{"pid":985,"tgid":995,"comm":"handler8"}},"kernel":{"symbol":"ovs_dp_upcall","probe_type":"kretprobe"},"skb-tracking":{"orig_head":18446619372617628672,"timestamp":30419169353765,"skb":18446619372874142208},"skb":{"eth":{"etype":2048,"src":"fa:5c:bd:8e:cc:01","dst":"a6:c2:11:71:59:45"},"ip":{"saddr":"192.168.125.11","daddr":"192.168.125.10","v4":{"tos":0,"id":19491,"flags":0,"offset":0},"protocol":1,"len":84,"ttl":64,"ecn":0},"icmp":{"type":0,"code":0},"dev":{"name":"veth-ns02-ovs","ifindex":12,"rx_ifindex":12},"ns":{"netns":4026531840},"meta":{"len":98,"data_len":0,"hash":2116835702,"ip_summed":0,"csum":2753213483,"csum_level":0,"priority":0},"data_ref":{"nohdr":false,"cloned":false,"fclone":0,"users":1,"dataref":1},"packet":{"len":98,"capture_len":98,"packet":"psIRcVlF+ly9jswBCABFAABUTCMAAEABsx/AqH0LwKh9CgAASFpxTAAB7f3ZZwAAAACzHw0AAAAAABAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc="}},"ovs":{"event_type":"upcall_return","upcall_ts":30419169364667,"upcall_cpu":6,"ret":0}}"#,
+                                )),
+                            }),
+                        ],
                     }),
                 ],
             ),

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -126,10 +126,6 @@ impl EventParser {
             .common
             .as_ref()
             .ok_or_else(|| anyhow!("No common section in event"))?;
-        let kernel = event
-            .kernel
-            .as_ref()
-            .ok_or_else(|| anyhow!("No skb section in event"))?;
 
         self.stats.processed += 1;
 
@@ -193,6 +189,8 @@ impl EventParser {
             }
         };
 
+        let format = DisplayFormat::new().multiline(true);
+
         // Add the packet itself.
         v.push(
             EnhancedPacketBlock {
@@ -204,8 +202,8 @@ impl EventParser {
                 data: Cow::Borrowed(&packet.packet.0),
                 options: vec![
                     EnhancedPacketOption::Comment(Cow::Owned(format!(
-                        "probe={}:{}",
-                        &kernel.probe_type, &kernel.symbol
+                        "{}",
+                        event.display(&format, &FormatterConf::new())
                     ))),
                     EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
                         code: 2988, // Custom Option containing a UTF-8 string.
@@ -477,9 +475,7 @@ mod tests {
                         timestamp: Duration::from_nanos(1742339565860167909),
                         original_len: 98,
                         options: vec![
-                            EnhancedPacketOption::Comment(Cow::Owned(
-                                "probe=kretprobe:ovs_dp_upcall".to_string(),
-                            )),
+                            EnhancedPacketOption::Comment(Cow::Owned("30419169125909 (6) [ping] 11330 [kr] ovs_dp_upcall #1baa83c42ba1ffff8e95c3b67c00 (skb ffff8e95d3009100)\n  ns 4026531840 if 10 (veth-ns01-ovs) rxif 10 a6:c2:11:71:59:45 > fa:5c:bd:8e:cc:01 ethertype IPv4 (0x0800) 192.168.125.10 > 192.168.125.11 ttl 64 tos 0x0 id 41977 off 0 [DF] len 84 proto ICMP (1) type 8 code 0 skb [csum none hash 0x7e2c5976 len 98 priority 0 users 1 dataref 1]\n  upcall_ret (6/30419169098548) ret 0".to_string())),
                             EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
                                 code: 2988,
                                 pen: RETIS_PEN,
@@ -515,8 +511,7 @@ mod tests {
                         timestamp: Duration::from_nanos(1742339565860414774),
                         original_len: 98,
                         options: vec![
-                            EnhancedPacketOption::Comment(Cow::Owned(
-                                "probe=kretprobe:ovs_dp_upcall".to_string(),
+                            EnhancedPacketOption::Comment(Cow::Owned("30419169372774 (6) [handler8] 985/995 [kr] ovs_dp_upcall #1baa83c8a025ffff8e95c3b67c00 (skb ffff8e95d3009200)\n  ns 4026531840 if 12 (veth-ns02-ovs) rxif 12 fa:5c:bd:8e:cc:01 > a6:c2:11:71:59:45 ethertype IPv4 (0x0800) 192.168.125.11 > 192.168.125.10 ttl 64 tos 0x0 id 19491 off 0 len 84 proto ICMP (1) type 0 code 0 skb [csum none hash 0x7e2c5976 len 98 priority 0 users 1 dataref 1]\n  upcall_ret (6/30419169364667) ret 0".to_string()
                             )),
                             EnhancedPacketOption::CustomUtf8(CustomUtf8Option {
                                 code: 2988,

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -42,17 +42,13 @@ struct EventParserStats {
     missing_skb: u32,
     /// Events w/o a packet section (skipped).
     missing_packet: u32,
-    /// Events w/o a dev section (fake one was used instead).
-    missing_dev: u32,
-    /// Events w/o a netns section (fake one was used instead).
-    missing_ns: u32,
 }
 
 /// Events parser: handles the logic to convert our events to the PCAP format
 /// that is represented by the internal writer.
 struct EventParser {
-    /// Known network interfaces and their PCAP id: netns|ifindex -> pcap id.
-    ifaces: HashMap<u64, u32>,
+    /// Fake network interfaces and their PCAP ids.
+    ifaces: HashMap<String, u32>,
     /// Statistics.
     stats: EventParserStats,
     /// Time offset
@@ -135,21 +131,13 @@ impl EventParser {
         let skb = some_or_return!(&event.skb, self.stats.missing_skb);
         let packet = some_or_return!(skb.packet.as_ref(), self.stats.missing_packet);
 
-        // The dev & ns sections are best to have but not mandatory to generate
-        // an event. If not found, fake them.
-        let (ifindex, ifname) = match skb.dev.as_ref() {
-            Some(dev) => (dev.ifindex, dev.name.as_str()),
-            None => {
-                self.stats.missing_dev += 1;
-                (0, "?")
-            }
-        };
-        let netns = match skb.ns.as_ref() {
-            Some(ns) => ns.netns,
-            None => {
-                self.stats.missing_ns += 1;
-                0
-            }
+        // Use a fake ifname based on probe.
+        let ifname = if let Some(kernel) = &event.kernel {
+            format!("{}/{}", kernel.probe_type, kernel.symbol)
+        } else if let Some(user) = &event.userspace {
+            format!("{}/{}", user.probe_type, user.symbol)
+        } else {
+            bail!("no kernel or userspace sections");
         };
 
         let mut v = Vec::new();
@@ -159,24 +147,19 @@ impl EventParser {
         }
 
         // If we see this iface for the first time, add a description block.
-        let key: u64 = ((netns as u64) << 32) | ifindex as u64;
-        let id = match self.ifaces.contains_key(&key) {
+        let id = match self.ifaces.contains_key(&ifname) {
             // Unwrap if contains is true.
-            true => *self.ifaces.get(&key).unwrap(),
+            true => *self.ifaces.get(&ifname).unwrap(),
             false => {
                 v.push(
                     InterfaceDescriptionBlock {
                         linktype: DataLink::ETHERNET,
                         snaplen: 0xffff,
                         options: vec![
-                            InterfaceDescriptionOption::IfName(Cow::Owned(format!(
-                                "{} ({})",
-                                ifname, netns
-                            ))),
-                            InterfaceDescriptionOption::IfDescription(Cow::Owned(match ifindex {
-                                0 => "Fake interface".to_string(),
-                                _ => format!("ifindex={}", ifindex),
-                            })),
+                            InterfaceDescriptionOption::IfName(Cow::Owned(ifname.clone())),
+                            InterfaceDescriptionOption::IfDescription(Cow::Owned(
+                                "Fake interface based on retis probe".to_string(),
+                            )),
                             InterfaceDescriptionOption::IfTsResol(9),
                         ],
                     }
@@ -184,7 +167,7 @@ impl EventParser {
                 );
 
                 let id = self.ifaces.len() as u32;
-                self.ifaces.insert(key, id);
+                self.ifaces.insert(ifname, id);
                 id
             }
         };
@@ -232,18 +215,6 @@ impl EventParser {
             warn!(
                 "{} event(s) were skipped because of missing raw packet",
                 self.stats.missing_packet
-            );
-        }
-        if self.stats.missing_dev != 0 {
-            warn!(
-                "{} event(s) are using a fake net device (no device information was found)",
-                self.stats.missing_dev
-            );
-        }
-        if self.stats.missing_ns != 0 {
-            warn!(
-                "{} event(s) are using a fake netns (no netns information was found)",
-                self.stats.missing_ns
             );
         }
     }

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Result};
-use clap::{arg, Args, Parser};
+use clap::{arg, Parser};
 use log::warn;
 use pcap_file::{
     pcapng::{
@@ -253,8 +253,6 @@ impl EventParser {
 #[derive(Parser, Debug, Default)]
 #[command(name = "pcap")]
 pub(crate) struct Pcap {
-    #[command(flatten)]
-    cmd: PcapCmd,
     #[arg(
         short,
         long,
@@ -264,15 +262,12 @@ pub(crate) struct Pcap {
     pub(super) out: Option<PathBuf>,
     #[arg(default_value = "retis.data", help = "File from which to read events")]
     pub(super) input: PathBuf,
-}
-#[derive(Args, Debug, Default)]
-#[group(required = true, multiple = false)]
-pub(crate) struct PcapCmd {
     #[arg(short, long, help = "List probes that are available in the input file")]
     pub(super) list_probes: bool,
     #[arg(
         short,
         long,
+        conflicts_with = "list_probes",
         help = "Filter events from this probe. Probes should follow the [TYPE:]TARGET pattern.
 See `retis collect --help` for more details on the probe format"
     )]
@@ -281,23 +276,26 @@ See `retis collect --help` for more details on the probe format"
 
 impl SubCommandParserRunner for Pcap {
     fn run(&mut self, _: &MainConfig) -> Result<()> {
-        if self.cmd.list_probes {
+        if self.list_probes {
             let probes = list_probes(self.input.as_path())?;
             probes.iter().for_each(|p| println!("{p}"));
             return Ok(());
         }
         // The following unwrap() will never fail as Clap makes sure that either
         // list_probes is true, or probe is Some().
-        let probe = self.cmd.probe.as_ref().unwrap();
-        let (probe_type, target, _) = parse_cli_probe(probe)?;
-        let symbol = Symbol::from_name_no_inspect(target);
+        let filter: &dyn Fn(&str, &str) -> bool = if let Some(probe) = self.probe.as_ref() {
+            let (probe_type, target, _) = parse_cli_probe(probe)?;
+            let symbol = Symbol::from_name_no_inspect(target);
 
-        // Filtering logic.
-        let filter = |r#type: &str, name: &str| -> bool {
-            if name == symbol.name() && r#type == probe_type.to_str() {
-                return true;
+            // Filtering logic.
+            &move |r#type: &str, name: &str| -> bool {
+                if name == symbol.name() && r#type == probe_type.to_str() {
+                    return true;
+                }
+                false
             }
-            false
+        } else {
+            &|_t: &str, _n: &str| -> bool { true }
         };
 
         let mut writer: Option<PcapNgWriter<File>> = None;

--- a/retis/src/process/display.rs
+++ b/retis/src/process/display.rs
@@ -46,7 +46,7 @@ impl PrintEvent {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&e.to_json()?)?;
+                let mut event = serde_json::to_vec(&e)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }
@@ -107,7 +107,7 @@ impl PrintSeries {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&series.to_json()?)?;
+                let mut event = serde_json::to_vec(&series)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }

--- a/retis/src/process/display.rs
+++ b/retis/src/process/display.rs
@@ -28,8 +28,8 @@ impl PrintEvent {
     pub(crate) fn process_one(&mut self, e: &Event) -> Result<()> {
         match self.format {
             PrintEventFormat::Text(ref mut format) => {
-                if let Some(common) = e.get_section::<StartupEvent>(SectionId::Startup) {
-                    format.monotonic_offset = Some(common.clock_monotonic_offset);
+                if let Some(startup) = &e.startup {
+                    format.monotonic_offset = Some(startup.clock_monotonic_offset);
                 }
 
                 let mut event = format!("{}", e.display(format, &FormatterConf::new()));
@@ -46,7 +46,7 @@ impl PrintEvent {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&e.to_json())?;
+                let mut event = serde_json::to_vec(&e.to_json()?)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }
@@ -81,8 +81,8 @@ impl PrintSeries {
                 let mut first = true;
 
                 for event in series.events.iter() {
-                    if let Some(common) = event.get_section::<StartupEvent>(SectionId::Startup) {
-                        format.monotonic_offset = Some(common.clock_monotonic_offset);
+                    if let Some(startup) = &event.startup {
+                        format.monotonic_offset = Some(startup.clock_monotonic_offset);
                     }
 
                     content.push_str(&format!("{}", event.display(format, &fconf)));
@@ -107,7 +107,7 @@ impl PrintSeries {
                 }
             }
             PrintEventFormat::Json => {
-                let mut event = serde_json::to_vec(&series.to_json())?;
+                let mut event = serde_json::to_vec(&series.to_json()?)?;
                 event.push(b'\n');
                 self.writer.write_all(&event)?;
             }

--- a/tools/wireshark/Makefile
+++ b/tools/wireshark/Makefile
@@ -1,0 +1,33 @@
+PLUGIN_NAME = retis
+
+SRC_FILES := $(wildcard *.c)
+HEADERS := $(wildcard *.h)
+OUTFILE = $(PLUGIN_NAME).so
+
+CC = gcc
+CFLAGS = -g -O0 -Wall -fPIC -I. $(shell pkg-config --cflags wireshark json-c)
+LDFLAGS = -shared $(shell pkg-config --libs wireshark json-c)
+
+WIRESHARK_VERSION_FULL := $(shell pkg-config --modversion wireshark json-c)
+WIRESHARK_VERSION := $(shell echo $(WIRESHARK_VERSION_FULL) | cut -d. -f1,2)
+
+WIRESHARK_PLUGIN_BASE_DIR ?= $(HOME)/.local/lib/wireshark/plugins
+WIRESHARK_PLUGIN_DIR := $(WIRESHARK_PLUGIN_BASE_DIR)/$(WIRESHARK_VERSION)/epan
+
+.PHONY: all clean check install
+
+all: check $(OUTFILE)
+
+check:
+	@pkg-config --exists wireshark || (echo "Wireshark development headers not found. Please install them (e.g., 'libwireshark-devel')." && false)
+	@pkg-config --exists json-c || (echo "Json-c development headers not found. Please install them (e.g., 'json-c-devel')." && false)
+
+$(OUTFILE): $(SRC_FILES) $(HEADERS)
+	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
+
+install: all
+	@mkdir -p "$(WIRESHARK_PLUGIN_DIR)"
+	@cp -v $(OUTFILE) "$(WIRESHARK_PLUGIN_DIR)"
+
+clean:
+	rm -f $(OUTFILE)

--- a/tools/wireshark/plugin.c
+++ b/tools/wireshark/plugin.c
@@ -1,0 +1,717 @@
+#define WS_BUILD_DLL
+
+#include <stdlib.h>
+
+#include <epan/proto.h>
+#include <epan/packet.h>
+#include <epan/expert.h>
+#include <epan/column.h>
+#include <epan/column-info.h>
+
+#include <wiretap/wtap.h>
+#include <wiretap/pcapng_module.h>
+#include <wiretap/wtap_opttypes.h>
+
+#include <ws_symbol_export.h>
+#include <wsutil/plugins.h>
+#include <wsutil/wslog.h>
+#include <json.h>
+
+#ifndef VERSION
+#define VERSION "0.0.0"
+#endif
+
+#define RETIS_SCHEMA_BLOCK_TYPE 70000
+
+static int proto_retis = -1;
+static json_object *schema = NULL;
+
+static int ett_retis_base = -1; /* Base of retis tree types */
+
+/* Dynamic field information */
+struct retis_field_info {
+	hf_register_info hfinfo;
+	int id;
+};
+
+/* Static array of hf_register_info used for Wireshark field_info
+ * registration */
+static hf_register_info *retis_register_info;
+/* Hashmap of json paths to struct retis_field_info_t */
+static GHashTable *retis_field_info = NULL;
+/* Hashmap of json paths to ETT IDs filled by Wireshark. */
+static GHashTable *retis_ett = NULL;
+/* Static array of integers used for Wireshark ett registration. */
+static int **retis_register_ett;
+
+/* Expert fields */
+static expert_field ei_retis_schema_not_loaded = EI_INIT;
+static expert_field ei_retis_json_parse_error = EI_INIT;
+static expert_field ei_retis_payload_not_json_object = EI_INIT;
+static expert_field ei_retis_schema_parse_error = EI_INIT;
+static expert_field ei_retis_field_not_in_schema = EI_INIT;
+static expert_field ei_retis_schema_block_empty = EI_INIT;
+
+/* Whether columns have been reloaded yet. */
+static bool cols_reloaded = false;
+/* Forward declarations */
+static void object_parse(json_object *props, const gchar *path,
+			 const gchar *name);
+static int dissect_retis_postdissector(tvbuff_t *tvb, packet_info *pinfo,
+				       proto_tree *tree, void *data);
+
+static json_object *resolve_json_reference(json_object *obj)
+{
+	json_object *ref, *defs, *target;
+	const char *ref_string;
+
+	if (!schema || !obj || !json_object_is_type(obj, json_type_object)) {
+		return NULL;
+	}
+
+	if (!json_object_object_get_ex(obj, "$ref", &ref) ||
+	    !json_object_is_type(ref, json_type_string)) {
+		return NULL;
+	}
+
+	ref_string = json_object_get_string(ref);
+	if (strlen(ref_string) <= 8 || strncmp(ref_string, "#/$defs/", 8)) {
+		ws_warning("Failed to resolve reference, invalid ref: %s",
+			   ref_string);
+		return NULL;
+	}
+	ref_string += 8;
+
+	if (!json_object_object_get_ex(schema, "$defs", &defs) ||
+	    !json_object_is_type(defs, json_type_object)) {
+		return NULL;
+	}
+
+	if (!json_object_object_get_ex(defs, ref_string, &target) ||
+	    !json_object_is_type(target, json_type_object)) {
+		return NULL;
+	}
+
+	return target;
+}
+
+static const char *definition_get_type(json_object *def)
+{
+	json_object *type;
+
+	if (!json_object_object_get_ex(def, "type", &type)) {
+		json_object *one_of = json_object_object_get(def, "oneOf");
+
+		if (one_of && json_object_is_type(one_of, json_type_array) &&
+		    json_object_array_length(one_of) > 1 &&
+		    json_object_is_type(json_object_array_get_idx(one_of, 0),
+					json_type_object)) {
+			/* This is an object that can take different forms. */
+			return "object";
+		} else {
+			ws_warning("Type definition not supported: %s",
+				   json_object_to_json_string(def));
+			return NULL;
+		}
+	}
+
+	if (json_object_is_type(type, json_type_string)) {
+		return json_object_get_string(type);
+	} else if (json_object_is_type(type, json_type_array)) {
+		if (!(json_object_array_length(type) == 2 &&
+		      json_object_is_type(json_object_array_get_idx(type, 0),
+					  json_type_string) &&
+		      json_object_is_type(json_object_array_get_idx(type, 1),
+					  json_type_string) &&
+		      !strncmp(json_object_get_string(
+				       json_object_array_get_idx(type, 1)),
+			       "null", 4))) {
+			ws_warning(
+				"The only multi-type objects supported are nullable primitives: %s",
+				json_object_to_json_string(def));
+			return NULL;
+		}
+		return json_object_get_string(
+			json_object_array_get_idx(type, 0));
+	} else {
+		ws_warning("Type definition not supported: %s",
+			   json_object_to_json_string(def));
+		return NULL;
+	}
+}
+
+static void definition_parse(json_object *def, const gchar *path,
+			     const gchar *name)
+{
+	struct retis_field_info *field_info;
+	const char *type_str;
+	json_object *ref;
+
+	ref = resolve_json_reference(def);
+	if (ref) {
+		ws_debug("Parsing ref: %s", json_object_to_json_string(def));
+		definition_parse(ref, path, name);
+		return;
+	}
+
+	type_str = definition_get_type(def);
+	if (!type_str) {
+		ws_warning("Malformed definition. No type: %s",
+			   json_object_to_json_string(def));
+		return;
+	}
+
+	field_info = g_malloc0(sizeof *field_info);
+
+	field_info->id = -1; /* Will be populated by Wireshark. */
+	field_info->hfinfo.p_id = &field_info->id;
+	field_info->hfinfo.hfinfo.name = name;
+	field_info->hfinfo.hfinfo.abbrev = g_strdup_printf("retis.%s", path);
+
+	if (!strncmp(type_str, "string", 6)) {
+		ws_info("retis proto registering key %s as string", path);
+		field_info->hfinfo.hfinfo.type = FT_STRING;
+		field_info->hfinfo.hfinfo.display = BASE_NONE;
+		/* TODO: Add support for enums? */
+	} else if (strcmp(type_str, "integer") == 0) {
+		ws_info("retis proto registering key %s as integer", path);
+		field_info->hfinfo.hfinfo.type = FT_UINT64;
+		field_info->hfinfo.hfinfo.display = BASE_DEC;
+	} else if (strcmp(type_str, "number") == 0) {
+		ws_info("retis proto registering key %s as double", path);
+		field_info->hfinfo.hfinfo.type = FT_DOUBLE;
+		field_info->hfinfo.hfinfo.display = BASE_NONE;
+	} else if (strcmp(type_str, "boolean") == 0) {
+		ws_info("retis proto registering key %s as boolean", path);
+		field_info->hfinfo.hfinfo.type = FT_BOOLEAN;
+		field_info->hfinfo.hfinfo.display = BASE_NONE;
+	} else if (strcmp(type_str, "array") == 0) {
+		ws_info("retis proto registering key %s as array", path);
+		field_info->hfinfo.hfinfo.type = FT_STRINGZ;
+		field_info->hfinfo.hfinfo.display = BASE_NONE;
+	} else if (!strncmp(type_str, "object", 6)) {
+		ws_info("retis proto registering key %s as object", path);
+
+		int *p_ett_id;
+
+		field_info->hfinfo.hfinfo.type = FT_NONE;
+
+		/* Create and store the pointer to where Wireshark will put the ETT ID */
+		p_ett_id = malloc(sizeof(int));
+		*p_ett_id = -1;
+
+		g_hash_table_insert(retis_ett, g_strdup(path), p_ett_id);
+
+		object_parse(def, path, name);
+	} else {
+		ws_warning("Unsupported type: %s: %s", type_str,
+			   json_object_to_json_string(def));
+		g_free((gpointer)field_info->hfinfo.hfinfo.name);
+		g_free((gpointer)field_info->hfinfo.hfinfo.abbrev);
+		g_free(field_info);
+		return;
+	}
+	g_hash_table_insert(retis_field_info, g_strdup(path), field_info);
+}
+
+/* Best-effort attept to generate a "name" for a type */
+const char *definition_get_name(json_object *definition, const char *key)
+{
+	json_object *desc;
+	char *name;
+
+	if (json_object_object_get_ex(definition, "description", &desc) &&
+	    json_object_get_string_len(desc)) {
+		/* Get the first line without full stops. */
+		const char *desc_str = json_object_get_string(desc);
+		size_t off;
+		for (off = 0; off < strlen(desc_str); off++) {
+			if (desc_str[off] == '\n' || desc_str[off] == '\r' ||
+			    desc_str[off] == '.')
+				break;
+		}
+		name = malloc(off + 1);
+		name[off] = '\0';
+		memcpy(name, desc_str, off);
+	} else {
+		name = g_strdup(key);
+	}
+	return name;
+}
+
+static void object_properties_parse(json_object *props,
+				    const gchar *current_path,
+				    const gchar *name)
+{
+	if (!json_object_is_type(props, json_type_object)) {
+		ws_warning("properties is not an object: %s",
+			   json_object_to_json_string(props));
+		return;
+	}
+
+	json_object_object_foreach(props, prop_key, prop_value)
+	{
+		gchar *prop_json_path = g_strdup_printf(
+			"%s%s%s", current_path,
+			current_path[0] == '\0' ? "" : ".", prop_key);
+		// TODO: Maybe not prepend the name?
+		//gchar *prop_name = g_strdup_printf("%s %s", name, prop_key);
+		json_object *any_of, *definition = NULL;
+
+		if (json_object_object_get_ex(prop_value, "anyOf", &any_of)) {
+			for (size_t i = 0; i < json_object_array_length(any_of);
+			     i++) {
+				json_object *ref = resolve_json_reference(
+					json_object_array_get_idx(any_of, i));
+				if (ref) {
+					// Do we need to cache parsed defs??
+					definition = ref;
+					break;
+				}
+			}
+		} else {
+			definition = prop_value;
+		}
+
+		if (definition) {
+			definition_parse(definition, prop_json_path,
+					 definition_get_name(definition,
+							     prop_key));
+		} else {
+			ws_warning("No definition on %s", prop_key);
+		}
+	}
+}
+
+static void object_parse(json_object *obj, const gchar *current_path,
+			 const gchar *name)
+{
+	json_object *props, *one_of;
+
+	ws_debug("parsing object: %s", json_object_to_json_string(obj));
+	if (!json_object_is_type(obj, json_type_object)) {
+		ws_warning("Type is not an object: %s",
+			   json_object_to_json_string(obj));
+		return;
+	}
+
+	if (json_object_object_get_ex(obj, "properties", &props))
+		object_properties_parse(props, current_path, name);
+
+	/* Parse enum properties*/
+	if (json_object_object_get_ex(obj, "oneOf", &one_of)) {
+		if (!json_object_is_type(one_of, json_type_array)) {
+			ws_warning("oneOf is not an array: %s",
+				   json_object_to_json_string(obj));
+		}
+		for (size_t idx = 0; idx < json_object_array_length(one_of);
+		     idx++) {
+			object_parse(json_object_array_get_idx(one_of, idx),
+				     current_path, name);
+		}
+	}
+}
+
+/* Looks at global schema and registers fields in Wireshark */
+static int register_retis_fields_from_schema_json()
+{
+	json_object *properties;
+
+	if (!schema || proto_retis == -1) {
+		return -1;
+	}
+
+	retis_ett =
+		g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+	retis_field_info =
+		g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+	if (!json_object_object_get_ex(schema, "properties", &properties) ||
+	    !json_object_is_type(properties, json_type_object)) {
+		ws_warning("Malformed schema");
+		return 1;
+	}
+
+	object_parse(schema, "", "");
+
+	if (g_hash_table_size(retis_field_info)) {
+		gpointer key, value;
+		GHashTableIter iter;
+		guint i = 0;
+
+		retis_register_info = g_new(
+			hf_register_info, g_hash_table_size(retis_field_info));
+
+		g_hash_table_iter_init(&iter, retis_field_info);
+		while (g_hash_table_iter_next(&iter, &key, &value)) {
+			//ws_debug("retis proto has key %s", (const char *)key);
+			retis_register_info[i++] =
+				((struct retis_field_info *)(value))->hfinfo;
+		}
+
+		proto_register_field_array(proto_retis, retis_register_info, i);
+	} else {
+		ws_warning("retis proto registered no fields!!");
+	}
+
+	if (g_hash_table_size(retis_ett)) {
+		gpointer key, value;
+		GHashTableIter iter;
+		guint i = 0;
+
+		retis_register_ett = g_new(int *, g_hash_table_size(retis_ett));
+
+		g_hash_table_iter_init(&iter, retis_ett);
+		while (g_hash_table_iter_next(&iter, &key, &value)) {
+			//ws_debug("retis proto has key %s", (const char *)key);
+			retis_register_ett[i++] = (int *)value;
+		}
+
+		proto_register_subtree_array(retis_register_ett, i);
+	} else {
+		ws_warning("retis proto registered no ETT!!");
+	}
+
+	ws_info("retis proto registered!");
+
+	return 0;
+}
+
+static int dissect_retis_schema_custom_block(tvbuff_t *tvb, packet_info *pinfo,
+					     proto_tree *tree, void *data _U_)
+{
+	guint tvb_len = tvb_reported_length(tvb);
+	enum json_tokener_error error;
+	const char *json_schema_str;
+
+	if (schema) {
+		/* Columns and their values are processed before the first
+		 * dissector is called. This causes an issue if a column refers
+		 * to fields that are not yet
+		 * registered with the retis protocol.
+		 * To avoid it, we rebuild the columns here. */
+		if (pinfo->cinfo && !cols_reloaded) {
+			int num_cols = pinfo->cinfo->num_cols;
+
+			ws_debug("Reloading columns");
+			col_cleanup(pinfo->cinfo);
+			build_column_format_array(pinfo->cinfo, num_cols,
+						  false);
+			cols_reloaded = true;
+		}
+		return tvb_captured_length(tvb); /* Consumed the block */
+	}
+
+	/* The tvb here contains the payload of the custom block. */
+	if (tvb_len == 0) {
+		if (tree) {
+			expert_add_info(pinfo,
+					proto_tree_add_item(tree, proto_retis,
+							    tvb, 0, 0, ENC_NA),
+					&ei_retis_schema_block_empty);
+		}
+		return 0;
+	}
+
+	// Get the block data as a string.
+	// Use tvb_get_string_enc for safety,
+	// ensuring null termination for json_loads.
+	json_schema_str = (const char *)tvb_get_string_enc(
+		wmem_packet_scope(), tvb, 0, tvb_len, ENC_UTF_8 | ENC_NA);
+	if (!json_schema_str) {
+		if (tree) {
+			expert_add_info_format(
+				pinfo,
+				proto_tree_add_item(tree, proto_retis, tvb, 0,
+						    tvb_len, ENC_NA),
+				&ei_retis_schema_parse_error,
+				"Schema block data not valid UTF-8");
+		}
+		return tvb_captured_length(tvb);
+	}
+
+	schema = json_tokener_parse_verbose(json_schema_str, &error);
+
+	if (!schema) {
+		if (tree) {
+			expert_add_info_format(
+				pinfo,
+				proto_tree_add_item(tree, proto_retis, tvb, 0,
+						    tvb_len, ENC_NA),
+				&ei_retis_schema_parse_error,
+				"Failed to parse retis schema from custom block: %d",
+				error);
+		}
+		/*Even on error, we "consumed" the block's data from
+		 * pcapng.block_type's perspective. */
+		return tvb_captured_length(tvb);
+	}
+
+	/* Schema parsed successfully. Now register the dynamic fields. */
+	if (register_retis_fields_from_schema_json()) {
+		/* This is an internal error if parsing succeeded but */
+		if (tree) {
+			expert_add_info_format(
+				pinfo,
+				proto_tree_add_item(tree, proto_retis, tvb, 0,
+						    tvb_len, ENC_NA),
+				&ei_retis_schema_parse_error,
+				"retis schema parsed but failed to register"
+				"  fields with epan.");
+		}
+		json_object_put(schema);
+		schema = NULL;
+		return tvb_captured_length(tvb);
+	}
+
+	return tvb_captured_length(tvb);
+}
+
+static void populate_retis_subtree(proto_tree *tree, tvbuff_t *tvb,
+				   json_object *event, const gchar *path)
+{
+	if (!json_object_is_type(event, json_type_object) || !tree)
+		return;
+
+	json_object_object_foreach(event, key, value)
+	{
+		struct retis_field_info *field_info;
+		gchar *full_path = g_strdup_printf(
+			"%s%s%s", path, path[0] == '\0' ? "" : ".", key);
+
+		gpointer field_info_gptr =
+			g_hash_table_lookup(retis_field_info, full_path);
+
+		if (!field_info_gptr) {
+			proto_tree_add_expert_format(
+				tree, NULL, &ei_retis_field_not_in_schema, tvb,
+				0, 0,
+				"JSON data field '%s' not found in registered schema fields",
+				full_path);
+			g_free(full_path);
+			continue;
+		}
+		field_info = (struct retis_field_info *)field_info_gptr;
+		switch (json_object_get_type(value)) {
+		case json_type_string:
+			proto_tree_add_string(tree, field_info->id, NULL, 0, 0,
+					      json_object_get_string(value));
+			break;
+		case json_type_int:
+			proto_tree_add_uint64(tree, field_info->id, NULL, 0, 0,
+					      json_object_get_uint64(value));
+			break;
+		case json_type_double:
+			proto_tree_add_double(tree, field_info->id, NULL, 0, 0,
+					      json_object_get_double(value));
+			break;
+		case json_type_boolean:
+			proto_tree_add_boolean(tree, field_info->id, NULL, 0, 0,
+					       json_object_get_boolean(value));
+			break;
+		case json_type_object: {
+			gpointer ett_id_p_ptr =
+				g_hash_table_lookup(retis_ett, full_path);
+			if (ett_id_p_ptr) {
+				int *ett_id_actual_ptr = (int *)ett_id_p_ptr;
+				proto_item *sub_item = proto_tree_add_item(
+					tree, field_info->id, NULL, 0, 0,
+					ENC_NA);
+				proto_tree *sub_tree = proto_item_add_subtree(
+					sub_item, *ett_id_actual_ptr);
+				populate_retis_subtree(sub_tree, tvb, value,
+						       full_path);
+			} else {
+				proto_tree_add_expert_format(
+					tree, NULL,
+					&ei_retis_field_not_in_schema, tvb, 0,
+					0,
+					"JSON object data '%s' found, but no ETT (schema mismatch?)",
+					full_path);
+			}
+			break;
+		}
+		case json_type_array: {
+			const char *array_str = json_object_to_json_string_ext(
+				value, JSON_C_TO_STRING_PLAIN);
+			if (array_str) {
+				proto_tree_add_string(tree, field_info->id,
+						      NULL, 0, 0, array_str);
+			}
+			break;
+		}
+		case json_type_null:
+			proto_tree_add_string(tree, field_info->id, NULL, 0, 0,
+					      "(null)");
+			break;
+		default:
+			break;
+		}
+		g_free(full_path);
+	}
+}
+
+struct retis_option_foreach {
+	tvbuff_t *tvb;
+	packet_info *pinfo;
+	proto_tree *tree;
+};
+
+static bool process_retis_option(wtap_block_t block _U_, unsigned option_id,
+				 wtap_opttype_e option_type _U_,
+				 wtap_optval_t *option, void *user_data)
+{
+	struct retis_option_foreach *user;
+	json_object *retis_event;
+	json_tokener *tok = json_tokener_new();
+
+	if (option_id != OPT_CUSTOM_STR_COPY ||
+	    option->custom_opt.pen != RETIS_SCHEMA_BLOCK_TYPE) {
+		return true;
+	}
+
+	if (!schema) {
+		return false;
+	}
+
+	user = (struct retis_option_foreach *)user_data;
+
+	retis_event = json_tokener_parse_ex(
+		tok, option->custom_opt.data.generic_data.custom_data,
+		option->custom_opt.data.generic_data.custom_data_len);
+
+	if (!retis_event) {
+		const char *err =
+			json_tokener_error_desc(json_tokener_get_error(tok));
+		if (user->tree) {
+			expert_add_info_format(
+				user->pinfo, proto_tree_get_root(user->tree),
+				&ei_retis_json_parse_error,
+				"Custom EPB Option JSON Parse Error: %s", err);
+		}
+		ws_warning("Failed to parse retis event %s", err);
+		json_tokener_free(tok);
+		return false;
+	}
+	if (!json_object_is_type(retis_event, json_type_object)) {
+		if (user->tree) {
+			expert_add_info(user->pinfo,
+					proto_tree_get_root(user->tree),
+					&ei_retis_payload_not_json_object);
+		}
+		json_object_put(retis_event);
+		return 0;
+	}
+	if (user->tree) {
+		proto_item *ti = proto_tree_add_protocol_format(
+			user->tree, proto_retis, user->tvb, 0, 0,
+			"Retis Protocol (Metadata from Custom EPB Option)");
+		proto_tree *retis_main_tree =
+			proto_item_add_subtree(ti, ett_retis_base);
+		populate_retis_subtree(retis_main_tree, user->tvb, retis_event,
+				       "");
+	}
+	json_object_put(retis_event);
+	json_tokener_free(tok);
+
+	return true;
+}
+
+static int dissect_retis_postdissector(tvbuff_t *tvb, packet_info *pinfo,
+				       proto_tree *tree, void *data)
+{
+	if (!schema && pinfo) {
+		if (pinfo)
+			expert_add_info(pinfo, NULL,
+					&ei_retis_schema_not_loaded);
+		return 0;
+	}
+
+	struct retis_option_foreach opt_user_data;
+	opt_user_data.tvb = tvb;
+	opt_user_data.pinfo = pinfo;
+	opt_user_data.tree = tree;
+
+	wtap_block_foreach_option(pinfo->rec->block, process_retis_option,
+				  (void *)&opt_user_data);
+	return 0;
+}
+
+static void proto_register_retis(void)
+{
+	expert_module_t *expert_retis;
+
+	if (proto_retis != -1) {
+		return;
+	}
+
+	proto_retis = proto_register_protocol(
+		"Retis (Dynamic Retis Event Metadata)", "Retis", "retis");
+
+	static int *ett[] = { &ett_retis_base };
+	proto_register_subtree_array(ett, array_length(ett));
+
+	/* Expert items registration */
+	expert_retis = expert_register_protocol(proto_retis);
+	static ei_register_info ei[] = {
+		{ &ei_retis_schema_not_loaded,
+		  { "retis.schema.not_loaded", PI_DISSECTOR_BUG, PI_WARN,
+		    "retis schema not loaded from PCAPng file", EXPFILL } },
+		{ &ei_retis_json_parse_error,
+		  { "retis.json.parse_error", PI_MALFORMED, PI_WARN,
+		    "retis JSON parsing from packet comment failed",
+		    EXPFILL } },
+		{ &ei_retis_payload_not_json_object,
+		  { "retis.payload.not_object", PI_PROTOCOL, PI_WARN,
+		    "retis payload in comment is not a JSON object",
+		    EXPFILL } },
+		{ &ei_retis_schema_parse_error,
+		  { "retis.schema.parse_error", PI_MALFORMED, PI_WARN,
+		    "retis schema JSON parsing from custom block failed",
+		    EXPFILL } },
+		{ &ei_retis_field_not_in_schema,
+		  { "retis.field.not_in_schema", PI_PROTOCOL, PI_WARN,
+		    "JSON field from comment not defined in loaded schema",
+		    EXPFILL } },
+		{ &ei_retis_schema_block_empty,
+		  { "retis.schema.block_error", PI_DISSECTOR_BUG, PI_WARN,
+		    "Error processing retis schema custom block", EXPFILL } },
+	};
+	expert_register_field_array(expert_retis, ei, array_length(ei));
+}
+
+static void proto_reg_handoff_retis(void)
+{
+	static dissector_handle_t retis_postdissector_handle;
+	static dissector_handle_t retis_schema_custom_block_handle;
+
+	// Create handle for the post-dissector (for packet metadata)
+	retis_postdissector_handle = create_dissector_handle(
+		dissect_retis_postdissector, proto_retis);
+	register_postdissector(retis_postdissector_handle);
+
+	// Create handle for the custom PCAPng block dissector (for schema loading)
+	retis_schema_custom_block_handle = create_dissector_handle(
+		dissect_retis_schema_custom_block, proto_retis);
+	dissector_add_uint("pcapng_custom_block", RETIS_SCHEMA_BLOCK_TYPE,
+			   retis_schema_custom_block_handle);
+}
+
+/* Plugin versioning */
+WS_DLL_PUBLIC_DEF const gchar plugin_version[] = VERSION;
+WS_DLL_PUBLIC_DEF const int plugin_want_major = WIRESHARK_VERSION_MAJOR;
+WS_DLL_PUBLIC_DEF const int plugin_want_minor = WIRESHARK_VERSION_MINOR;
+
+/* Standard plugin entry points */
+WS_DLL_PUBLIC_DEF void plugin_register(void);
+WS_DLL_PUBLIC_DEF void plugin_reg_handoff(void);
+
+void plugin_register(void)
+{
+	ws_info("in retis register ");
+	static proto_plugin plug;
+
+	plug.register_protoinfo = proto_register_retis;
+	plug.register_handoff = proto_reg_handoff_retis;
+	proto_register_plugin(&plug);
+}


### PR DESCRIPTION
We all love Wireshark!
Here is a proof of concept of using Wireshark as UI for retis.

Code will surely need some refinement but sending it out soon for early feedback and experimentation.

In a nutshell, the PR does the following
- Uses `schemars` to build a Json-schema that represets our `Event`
- Adds a custom block to the beginning of the pcap file containing the json schema
- Adds a custom option to  each packet containing the json representation of the event
- Adds a wireshark plugin that:
   - Creates two dissectors, one for the custom block and one post-dissector (called for every packet): the Retis protocol
   - Dissects the json schema from the custom block and dynamically registers fields for the "Retis" protocol.
   - Dissects every packet option enriching each packet with the retis metadata.
- Relaxes the requirement of having to provide a probe filter on `retis pcap` .

The result is all the retis metadata inside Wireshark, the user can create columns and filters based on them.

Further  experiments:
- One of the obvious issues that I found was the TCP Analyzer engine flagging the same packet hitting different probes as a retransmit. I tried changing the interface name from "{dev}-{ns}" to {probe_type}/{probe_name}. That, plus setting "deinterlacing conversations" option to "VMI" (which adds VLAN, MAC and Interface to the 5-tuple), fixes some of the wrong TCP analysis, but not all. A packet can go multiple times through the same probe. For probes such as `netif_receive_skb` we could add `dev` and `ns` back (in addition to probe info) but for other probes (NFT, OVS) we are still going to  see the packet multiple times. So maybe we just need a warning somewhere. Maybe taking the issue upstream (in Wireshark community).
- The name of each field in the Retis protocol is extracted from the "description" in Json-schema which, itself, comes from the doc-comment of each struct. These comments are currently inconsistent, maybe we revisit some. Also, we sometimes tend to write multiple lines as comments (which of course is perfectly right), so I did some arguably dirty trick of truncating the string on the first "." or "\n". Any other ideas? We could also use the json "key" (which is the current fallback), i.e: the name of the field.

Dependencies:
- New dependency with [schemars](https://docs.rs/schemars/latest/schemars/index.html)
- Depends on #517 
- Depends on two unmerged PRs in pcap-file