### PR TITLE
collectors: fix duplicated collectors

### DIFF
--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -259,8 +259,11 @@ impl Collectors {
         }
 
         let collectors = match &collect.collectors {
-            Some(collectors) => collectors.iter().map(|c| c.as_ref()).collect::<Vec<&str>>(),
-            None => vec!["skb-tracking", "skb", "skb-drop", "ovs", "nft", "ct"],
+            Some(collectors) => collectors
+                .iter()
+                .map(|c| c.as_ref())
+                .collect::<HashSet<_>>(),
+            None => HashSet::from(["skb-tracking", "skb", "skb-drop", "ovs", "nft", "ct"]),
         };
 
         // Try initializing all collectors.


### PR DESCRIPTION
"-c | --collectors <COLLECTORS" can be specified more than once, and duplicates might arise, e.g: specifing a collector that was already added by a profile.

OTOH, it doesn't make sense to initialize the same collector more than once internally (and it actually causes all kinf of errors). E.g: `retis collect -c skb,skb` fails quite badly.

Deduplicate the collectors list before initializing them.