### PR TITLE
retis-events: flag version as dynamic

### DIFF
--- a/retis-events/pyproject.toml
+++ b/retis-events/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 description = "Python bindings for Retis events"
 readme = "PYTHON_LIB_README.md"
+dynamic = ["version"]  # Maturin gets the version from Cargo.toml.
 
 [project.urls]
 HomePage = "https://github.com/retis-org/retis"


### PR DESCRIPTION
According to the schema of `pyproject.toml` [1] `project.version` must be specified or marked as dynamic.

Maturin has started to nag [2][3][4] if it's not the case, making "maturin develop" executions fail.

Since maturin gets the version from Cargo.toml anyway, mark it as dynamic.

[1] https://json.schemastore.org/pyproject.json
[2] https://github.com/PyO3/maturin/pull/2417
[3] https://github.com/PyO3/maturin/issues/2416
[4] https://github.com/PyO3/maturin/pull/2418