### PR TITLE
filter/btf: fix array issue due to wrong jump offset

### DIFF
--- a/retis/src/core/filters/meta/filter.rs
+++ b/retis/src/core/filters/meta/filter.rs
@@ -848,6 +848,12 @@ impl<'a> MetaExpr<'a> {
                     imm: -1,
                 },
             ),
+        ]);
+
+        // These two blocks cannot be coalesced because the following
+        // has a dependency on the filter length based on the previous
+        // instructions.
+        self.filter.add_multi(&[
             eBpfInsn::jmp(
                 eBpfJmpOpExt::Bpf(BpfJmpOp::Gt),
                 JmpInfo::Imm {


### PR DESCRIPTION
Simple, plain fix. Initially part of #541 posted separately for convenience (v1.6 release)