### PR TITLE
Add auto-stale checks

### DIFF
--- a/.github/workflows/daily_change_check.yaml
+++ b/.github/workflows/daily_change_check.yaml
@@ -21,3 +21,44 @@ jobs:
           gh workflow run build_push_image.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  stale-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Do not consider issues/PRs with a milestone set.
+          exempt-all-milestones: true
+          # When 'NoStale' is set, PRs and issues are exempted from going stale.
+          # 'Stale' is the default label of PRs reaching the stale state.
+          exempt-pr-labels: 'NoStale'
+          exempt-issue-labels: 'NoStale'
+          # Override the default stale/close (60d/7d) inactivity timeouts
+          days-before-stale: ${{ env.AUTO_STALE_THRESHOLD }}
+          days-before-close: ${{ env.AUTO_CLOSE_THRESHOLD }}
+          # Given environment variables cannot be referenced in the same map (and there's no apparent way to discriminate between
+          # PR and issues), use a custom + common part in the stale messages.
+          stale-pr-message: |
+            This PR has been automatically marked as stale due to ${{ env.AUTO_STALE_THRESHOLD }} day(s) of inactivity.
+            If this remains inactive for an additional ${{ env.AUTO_CLOSE_THRESHOLD }} day(s), it will be automatically closed.
+            ${{ env.AUTO_STALE_COMMON }}
+          stale-issue-message: |
+            This issue has been automatically marked as stale due to ${{ env.AUTO_STALE_THRESHOLD }} day(s) of inactivity.
+            If this remains inactive for an additional ${{ env.AUTO_CLOSE_THRESHOLD }} day(s), it will be automatically closed.
+            ${{ env.AUTO_STALE_COMMON }}
+          close-pr-message: ${{ env.AUTO_CLOSE_MSG }}
+          close-issue-message: ${{ env.AUTO_CLOSE_MSG }}
+        env:
+          AUTO_STALE_THRESHOLD: 200
+          AUTO_CLOSE_THRESHOLD: 60
+          AUTO_STALE_COMMON: |
+            In case this was incorrectly marked as stale, please, remove the `stale` label (or simply add a comment), and do one
+            or more of the following:
+              - Add it to a milestone, if applicable
+              - Label it as `NoStale`
+
+            If you do not have sufficient permissions to complete any of the previous steps, feel free to reach out to the maintainers.
+          AUTO_CLOSE_MSG: |
+            The item has been automatically closed for inactivity.
+            If this was not intended, please, reopen the item and follow the instructions included in the stale warning.


### PR DESCRIPTION
The idea is to mark a PR or an issue as stale and close it after a given number of days.

- PRs/issues in a milestone do not go stale
- PRs/issues with 'NoStale'
- Adding a comment to a stale PR/issue refreshes the state and removes the label

The current values:
AUTO_STALE_THRESHOLD: 200
AUTO_CLOSE_THRESHOLD: 60

can be reduced as they are admittedly a bit loose.