### PR TITLE
container: fix localversion

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,12 +1,5 @@
-**
-!.git
-!Makefile
-!ebpf.mk
-!**/Cargo.*
-!retis-derive
-!retis-events
-!retis-pnet
-!retis/profiles
-!retis/build.rs
-!retis/src
-!tools
+**/.out
+**/target
+**/__pycache__
+retis-events/.tox
+retis.data

--- a/Containerfile
+++ b/Containerfile
@@ -15,9 +15,8 @@ RUN dnf install -y \
     python3-devel \
     zlib-devel
 
-# Only the allowlisted files are copied,
-# see .containerignore for more details.
-COPY . .git /retis
+# Only the allowlisted files are copied, see .containerignore for more details.
+COPY . /retis
 
 # Build Retis
 RUN make clean-ebpf && make CARGO_CMD_OPTS=--locked V=1 release -j$(nproc)


### PR DESCRIPTION
./tools/localversion was reporting a "-dirty" version while building Retis in the container. This was because files where not properly copied over:

- .git was copied twice and one copy was set in the root dir.
- Some files where not copied and git thought they were deleted.

Fix this by copying .git once and by reworking the .containerignore list to only discard build artifacts that are not tracked.

Fixes #558.