### PR TITLE
retis-event: fix geneve opts_len printing

### DIFF
--- a/retis-events/src/packet.rs
+++ b/retis-events/src/packet.rs
@@ -788,7 +788,7 @@ impl RawPacket {
         }
 
         if geneve.get_options_len() > 0 {
-            write!(f, " opts_len {}", geneve.get_options_len())?;
+            write!(f, " opts_len {}", geneve.get_options_len() * 4)?;
         }
 
         write!(f, " ")?;


### PR DESCRIPTION
The option len field of the geneve header is expressed in 4-byte multiples.