### PR TITLE
docs: event: Fix several spelling errors.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,9 +31,9 @@ nav:
         - Filtering: filtering.md
         - Profiles: profiles.md
         - Python bindings: python.md
-        - Compatiblity: compatibility.md
+        - Compatibility: compatibility.md
         - Limitations: limitations.md
-    - Resourses:
+    - Resources:
         - External: resources.md
         - Contributing: CONTRIBUTING.md
 

--- a/retis-events/src/compat/compat.rs
+++ b/retis-events/src/compat/compat.rs
@@ -62,7 +62,7 @@ impl CompatVersion {
         for (req, version) in VERSION_MATCHES {
             let req = VersionReq::parse(req)?;
             if req.matches(&retis_version) {
-                log::debug!("Detected compatibilty version {version:?}");
+                log::debug!("Detected compatibility version {version:?}");
                 return Ok(*version);
             }
         }

--- a/retis-events/src/events.rs
+++ b/retis-events/src/events.rs
@@ -38,7 +38,7 @@ use crate::{display::*, *};
 /// Full event. Internal representation
 #[derive(Default)]
 #[event_section]
-// For backwards compatiblity reasons, we keep section names in kebab-case.
+// For backwards compatibility reasons, we keep section names in kebab-case.
 #[serde(rename_all = "kebab-case")]
 pub struct Event {
     /// Common section.

--- a/retis-events/src/python.rs
+++ b/retis-events/src/python.rs
@@ -68,7 +68,7 @@ impl PyEvent {
     }
 
     /// Allows to use the object as a dictionary, e.g. `e['skb']`.
-    /// The use of direct attribute access is prefered, e.g: `e.skb`.
+    /// The use of direct attribute access is preferred, e.g: `e.skb`.
     fn __getitem__<'a>(&'a self, py: Python<'a>, attr: &str) -> PyResult<Py<PyAny>> {
         let item = self
             .__getattr__(py, attr)


### PR DESCRIPTION
Fix several spelling errors in the Documentation and code comments.