### PR TITLE
collectors: nft: add struct nft_traceinfo to the known types

### DIFF
--- a/retis/src/collect/collector/nft/nft.rs
+++ b/retis/src/collect/collector/nft/nft.rs
@@ -123,6 +123,10 @@ impl Collector for NftCollector {
         Ok(Self::default())
     }
 
+    fn known_kernel_types(&self) -> Option<Vec<&'static str>> {
+        Some(vec!["struct nft_traceinfo *"])
+    }
+
     fn can_run(&mut self, cli: &Collect) -> Result<()> {
         let inspector = inspect::inspector()?;
 


### PR DESCRIPTION
Since adding support for per-probe options, the nft profile is partially working and we can see the following error:

  No probe was attached to __nft_trace_packet as no collector could retrieve data from it

In fact, a probe is added to the above function but the per-probe stack option defined in the profile is not.

What happens is since we switch from a global --stack option to a per-probe one, __nft_trace_packet is seens as a user probe when using the nft profile. But it doesn't have a known type in its arguments. Also the nft collector doesn't report any type.

This adds 'struct nft_traceinfo *' to the nft collector known types. This is true and correctly handled in its hook (offsets are dynamic). This wasn't done before as a single probe matches and the collector was setting it already.