### PR TITLE
collectors: Ensure std::str module is in scope.

### DIFF
--- a/retis/src/collect/collector/dev/dev.rs
+++ b/retis/src/collect/collector/dev/dev.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{str, sync::Arc};
 
 use anyhow::Result;
 


### PR DESCRIPTION
This fixes building with rust 1.84 and avoids this error:

    error[E0599]: no function or associated item named `from_utf8` found for type `str` in the current scope

Fixes: #587