### PR TITLE
collect: add command line to the startup event

### DIFF
--- a/retis-events/src/common.rs
+++ b/retis-events/src/common.rs
@@ -15,6 +15,8 @@ pub struct MachineInfo {
 pub struct StartupEvent {
     /// Retis version used while collecting events.
     pub retis_version: String,
+    /// Expanded command line used to invoke the application.
+    pub cmdline: String,
     /// CLOCK_MONOTONIC offset in regards to local machine time.
     pub clock_monotonic_offset: TimeSpec,
     /// Machine information retrieved while collecting events.
@@ -26,6 +28,8 @@ impl EventFmt for StartupEvent {
         let sep = if d.multiline { "\n" } else { " " };
 
         write!(f, "Retis version {}", self.retis_version)?;
+
+        write!(f, "{sep}Command line {}", self.cmdline)?;
 
         write!(
             f,

--- a/retis-events/src/compat/compat.rs
+++ b/retis-events/src/compat/compat.rs
@@ -33,6 +33,7 @@ const FIXUPS: &[&[CompatFixup]] = &[
             "startup/machine/hardware_name",
             CompatValue::String("unknown"),
         ),
+        Add("startup/cmdline", CompatValue::String("unknown")),
     ],
 ];
 

--- a/retis/src/benchmark/cli.rs
+++ b/retis/src/benchmark/cli.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use clap::{arg, builder::PossibleValuesParser, Parser};
+use clap::{builder::PossibleValuesParser, Parser};
 
 use crate::{benchmark::*, cli::*};
 

--- a/retis/src/cli/cli.rs
+++ b/retis/src/cli/cli.rs
@@ -172,6 +172,9 @@ pub(crate) struct MainConfig {
         help = "Path to an additional directory with custom profiles. Takes precedence over built-in profiles directories."
     )]
     pub(crate) extra_profiles_dir: Option<PathBuf>,
+    /// Expanded command line that was used to invoke retis
+    #[arg(skip)]
+    pub(crate) cmdline: String,
 }
 
 const HELP_TEMPLATE: &str = "\
@@ -338,13 +341,13 @@ impl RetisCli {
         RetisCli::enhance_profile(&main_config, subcommand.name().as_str(), &mut args)
             .map_err(|err| command.error(ErrorKind::InvalidValue, format!("{err}")))?;
 
-        debug!(
-            "Resulting CLI arguments: {}",
-            args.iter()
-                .map(|o| o.as_os_str().to_str().unwrap_or("<encoding error>"))
-                .collect::<Vec<&str>>()
-                .join(" ")
-        );
+        let cmdline = args
+            .iter()
+            .map(|o| o.as_os_str().to_str().unwrap_or("<encoding error>"))
+            .collect::<Vec<&str>>()
+            .join(" ");
+
+        debug!("Resulting CLI arguments: {cmdline}");
 
         // Final round of parsing.
         let matches = match cfg!(test) {
@@ -364,6 +367,9 @@ impl RetisCli {
                 .update_from_arg_matches(matches)
                 .unwrap_or_else(|e| e.exit()),
         }
+
+        // Store the command line for use in initial event
+        main_config.cmdline = cmdline;
 
         Ok(CliConfig {
             command,

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -342,7 +342,7 @@ impl Collectors {
     }
 
     // Generate an initial event with the startup section.
-    fn initial_event(&mut self) -> Result<()> {
+    fn initial_event(&mut self, cmdline: &str) -> Result<()> {
         let uname = uname().map_err(|e| anyhow!("Failed to get system information: {e}"))?;
         let release = uname.release().to_string_lossy();
         let version = uname.version().to_string_lossy();
@@ -353,6 +353,7 @@ impl Collectors {
                 retis_version: option_env!("RELEASE_VERSION")
                     .unwrap_or("unspec")
                     .to_string(),
+                cmdline: cmdline.to_string(),
                 clock_monotonic_offset: self.monotonic_offset,
                 machine: MachineInfo {
                     kernel_release: release.to_string(),
@@ -489,7 +490,7 @@ impl Collectors {
         let mut section_factories = section_factories()?;
 
         self.run.register_term_signals()?;
-        self.initial_event()?;
+        self.initial_event(&main_config.cmdline)?;
         self.init_collectors(&mut section_factories, collect)?;
         self.config_filters(collect)?;
         self.register_probes(collect, main_config)?;


### PR DESCRIPTION
RFC only to double-check for potential objections.
This is normally useful when:

-  the capture is performed by a third party
-  when captures are revisited after a long time