### PR TITLE
Introduce exit callbacks

### DIFF
--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -121,15 +121,12 @@ impl Collectors {
         let factory = BpfEventsFactory::new()?;
         let probes = ProbeManager::new()?;
 
-        let run = Running::new();
-        run.register_term_signals()?;
-
         Ok(Collectors {
             collectors: HashMap::new(),
             probes,
             factory,
             known_kernel_types: HashSet::new(),
-            run,
+            run: Running::new()?,
             tracking_gc: None,
             tracking_config_map: None,
             stack_tracking_config_map: None,

--- a/retis/src/collect/collector/ovs/ovs.rs
+++ b/retis/src/collect/collector/ovs/ovs.rs
@@ -61,7 +61,6 @@ pub(crate) struct OvsCollectorArgs {
     ovs_enrich_rate: u32,
 }
 
-#[derive(Default)]
 pub(crate) struct OvsCollector {
     track: bool,
     inflight_upcalls_map: Option<libbpf_rs::MapHandle>,
@@ -81,7 +80,18 @@ pub(crate) struct OvsCollector {
 
 impl Collector for OvsCollector {
     fn new() -> Result<Self> {
-        Ok(Self::default())
+        Ok(Self {
+            track: false,
+            inflight_upcalls_map: None,
+            inflight_exec_map: None,
+            flow_exec_tracking_fd: 0,
+            upcall_tracking_fd: 0,
+            gc: None,
+            running: Running::ignore_signals(),
+            upcall_batches: None,
+            pid_to_batch: None,
+            flow_enricher: None,
+        })
     }
 
     // Check if the OvS collector can run. Some potential errors are silenced,

--- a/retis/src/core/events/bpf.rs
+++ b/retis/src/core/events/bpf.rs
@@ -143,7 +143,7 @@ impl BpfEventsFactory {
             rxc: None,
             handle: None,
             log_handle: None,
-            run_state: Running::new(),
+            run_state: Running::ignore_signals(),
             time_format: Default::default(),
             monotonic_offset: None,
         })

--- a/retis/src/process/cli/pcap.rs
+++ b/retis/src/process/cli/pcap.rs
@@ -323,8 +323,7 @@ where
     F: FnMut(&Block) -> Result<()>,
 {
     // Create running instance that will handle signal termination.
-    let run = Running::new();
-    run.register_term_signals()?;
+    let run = Running::new()?;
 
     // Start our events factory.
     let mut factory = input.to_factory()?;
@@ -368,8 +367,7 @@ fn list_probes(input: &InputDataFile) -> Result<Vec<String>> {
     let mut probe_set: HashSet<String> = HashSet::new();
 
     // Create running instance that will handle signal termination.
-    let run = Running::new();
-    run.register_term_signals()?;
+    let run = Running::new()?;
 
     // Start our events factory.
     let mut factory = input.to_factory()?;

--- a/retis/src/process/cli/print.rs
+++ b/retis/src/process/cli/print.rs
@@ -32,8 +32,7 @@ pub(crate) struct Print {
 impl SubCommandParserRunner for Print {
     fn run(&mut self, _: &MainConfig) -> Result<()> {
         // Create running instance that will handle signal termination.
-        let run = Running::new();
-        run.register_term_signals()?;
+        let run = Running::new()?;
 
         // Create event factory.
         let mut factory = self.input.clone().unwrap_or_default().to_factory()?;

--- a/retis/src/process/cli/sort.rs
+++ b/retis/src/process/cli/sort.rs
@@ -72,8 +72,7 @@ A value of zero means the buffer can grow endlessly."
 impl SubCommandParserRunner for Sort {
     fn run(&mut self, _: &MainConfig) -> Result<()> {
         // Create running instance that will handle signal termination.
-        let run = Running::new();
-        run.register_term_signals()?;
+        let run = Running::new()?;
 
         // Create event factory.
         let input = self.input.clone().unwrap_or_default();


### PR DESCRIPTION
Callbacks can be registered to be run at either termination signal time or exit time:

- `Running` is converted to use exit callbacks.
- Auto-mounted paths are unmounted at exit time using this new mechanism.

Fixes #527.