### PR TITLE
Support reading split files in Python

### DIFF
--- a/retis-events/pytests/test_reader.py
+++ b/retis-events/pytests/test_reader.py
@@ -36,6 +36,12 @@ def test_event_reader():
     verify_event_reader(r)
 
 
+def test_event_rotation_reader():
+    """Test event reader is capable of reading rotated events"""
+    r = EventReader.with_rotation("test_data/test_events.json")
+    verify_event_reader(r)
+
+
 def test_series_reader():
     """Test SeriesReader is capable of reading sorted events"""
     r = SeriesReader("test_data/test_events_sorted.json")

--- a/retis-events/src/file/file.rs
+++ b/retis-events/src/file/file.rs
@@ -42,7 +42,6 @@ impl FileEventsFactory {
         Self::from_event_file(EventFile {
             path: file.as_ref().to_path_buf(),
             use_rotation: false,
-            try_split: false,
         })
     }
 
@@ -50,7 +49,7 @@ impl FileEventsFactory {
         // Using the RotateReader in both cases should work but not using it
         // will save some cycles without impacting maintenance too much.
         let mut reader: BufReader<Box<dyn ReadSeek>> = BufReader::new(match file.use_rotation {
-            true => Box::new(RotateReader::new(file.path, file.try_split)?),
+            true => Box::new(RotateReader::new(file.path)?),
             false => Box::new(
                 File::open(file.path.clone())
                     .map_err(|e| anyhow!("Could not open {}: {e}", file.path.display()))?,

--- a/retis-events/src/file/file.rs
+++ b/retis-events/src/file/file.rs
@@ -8,6 +8,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Result};
 
+use super::rotate::*;
 use crate::{
     compat::{json, CompatVersion},
     Event, EventSeries,
@@ -38,13 +39,24 @@ impl FileEventsFactory {
     where
         P: AsRef<Path>,
     {
-        Self::new(Box::new(File::open(&file).map_err(|e| {
-            anyhow!("Could not open {}: {e}", file.as_ref().display())
-        })?))
+        Self::from_event_file(EventFile {
+            path: file.as_ref().to_path_buf(),
+            use_rotation: false,
+            try_split: false,
+        })
     }
 
-    pub fn new(reader: Box<dyn ReadSeek>) -> Result<Self> {
-        let mut reader = BufReader::new(reader);
+    pub fn from_event_file(file: EventFile) -> Result<Self> {
+        // Using the RotateReader in both cases should work but not using it
+        // will save some cycles without impacting maintenance too much.
+        let mut reader: BufReader<Box<dyn ReadSeek>> = BufReader::new(match file.use_rotation {
+            true => Box::new(RotateReader::new(file.path, file.try_split)?),
+            false => Box::new(
+                File::open(file.path.clone())
+                    .map_err(|e| anyhow!("Could not open {}: {e}", file.path.display()))?,
+            ),
+        });
+
         let (filetype, compat_version) = Self::detect_type(&mut reader)?;
 
         Ok(FileEventsFactory {

--- a/retis-events/src/file/rotate.rs
+++ b/retis-events/src/file/rotate.rs
@@ -20,9 +20,6 @@ pub struct EventFile {
     pub path: PathBuf,
     /// Read split event files in sequence, if any.
     pub use_rotation: bool,
-    /// Allow to fallback reading the event file using a known split file
-    /// extension.
-    pub try_split: bool,
 }
 
 /// Rotation policy
@@ -236,8 +233,8 @@ pub struct RotateReader {
 }
 
 impl RotateReader {
-    pub fn new<P: AsRef<Path>>(file: P, try_split: bool) -> Result<Self> {
-        let (target, index, policy) = Self::detect_policy(file.as_ref(), try_split)?;
+    pub fn new<P: AsRef<Path>>(file: P) -> Result<Self> {
+        let (target, index, policy) = Self::detect_policy(file.as_ref().to_path_buf())?;
         if let Some(policy) = &policy {
             log::debug!(
                 "Opening {} with rotation policy {policy:?}",
@@ -254,38 +251,16 @@ impl RotateReader {
         })
     }
 
-    /// Detects a rotation policy given an input file name.
-    fn detect_policy(
-        path: &Path,
-        try_split: bool,
-    ) -> Result<(PathBuf, u32, Option<RotationPolicy>)> {
-        // First, try the target file.
-        if path.is_file() {
-            return Self::detect_policy_from_events(&path.to_path_buf());
-        }
-
-        // If allowed, fallback to trying using a known split file extension.
-        if try_split {
-            let target = PathBuf::from(format!("{}.0", path.display()));
-            if target.is_file() {
-                return Self::detect_policy_from_events(&target);
-            }
-        }
-
-        Err(anyhow!("Cannot open {}", path.display()))
-    }
-
     /// Given a file, detect the rotation policy reading the startup event, if
     /// any. It's important to check for the file existence before to throw real
     /// errors from this.
     ///
     /// Returns the target file base (filename w/o the split extension), index
     /// and rotation policy).
-    fn detect_policy_from_events(path: &PathBuf) -> Result<(PathBuf, u32, Option<RotationPolicy>)> {
+    fn detect_policy(mut path: PathBuf) -> Result<(PathBuf, u32, Option<RotationPolicy>)> {
         // Use a temporary BufReader to benefit from the `read_line`
         // implementation.
-        let mut reader = BufReader::new(File::open(path)?);
-        let mut path = path.clone();
+        let mut reader = BufReader::new(File::open(&path)?);
 
         let mut line = String::new();
         if reader.read_line(&mut line)? == 0 {

--- a/retis-events/src/file/rotate.rs
+++ b/retis-events/src/file/rotate.rs
@@ -13,6 +13,18 @@ use nix::sys::utsname::uname;
 
 use crate::{compat::json, file::guess_version, helpers::time::*, *};
 
+/// Represent an event file and how it should be used wrt rotation.
+#[derive(Clone, Debug)]
+pub struct EventFile {
+    /// Path to the event file.
+    pub path: PathBuf,
+    /// Read split event files in sequence, if any.
+    pub use_rotation: bool,
+    /// Allow to fallback reading the event file using a known split file
+    /// extension.
+    pub try_split: bool,
+}
+
 /// Rotation policy
 ///
 /// How the output files are split depending on internal rules.

--- a/retis-events/src/python/python.rs
+++ b/retis-events/src/python/python.rs
@@ -8,10 +8,13 @@ use std::{collections::HashMap, ffi::CString, path::PathBuf};
 use pyo3::{
     exceptions::{PyKeyError, PyRuntimeError},
     prelude::*,
-    types::{IntoPyDict, PyBool, PyList},
+    types::*,
 };
 
-use crate::{file::*, *};
+use crate::{
+    file::{rotate::*, *},
+    *,
+};
 
 /// Python representation of an Event.
 ///
@@ -207,14 +210,12 @@ impl PyEventSeries {
 /// ```
 #[pyclass(name = "EventReader")]
 pub(crate) struct PyEventReader {
-    pub(crate) factory: FileEventsFactory,
+    factory: FileEventsFactory,
 }
 
-#[pymethods]
 impl PyEventReader {
-    #[new]
-    pub(crate) fn new(path: PathBuf) -> PyResult<Self> {
-        let factory = FileEventsFactory::from_path(path)
+    fn from_event_file(file: EventFile) -> PyResult<Self> {
+        let factory = FileEventsFactory::from_event_file(file)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
 
         if matches!(factory.file_type(), FileType::Series) {
@@ -222,7 +223,29 @@ impl PyEventReader {
                 "Cannot create a EventReader from a sorted file. Use an SeriesReader instead",
             ));
         }
+
         Ok(PyEventReader { factory })
+    }
+}
+
+#[pymethods]
+impl PyEventReader {
+    #[new]
+    pub(crate) fn new(path: PathBuf) -> PyResult<Self> {
+        Self::from_event_file(EventFile {
+            path,
+            use_rotation: false,
+            try_split: false,
+        })
+    }
+
+    #[classmethod]
+    pub(crate) fn with_rotation(_: &Bound<'_, PyType>, path: PathBuf) -> PyResult<Self> {
+        Self::from_event_file(EventFile {
+            path,
+            use_rotation: true,
+            try_split: false,
+        })
     }
 
     // Implementation of the iterator protocol.
@@ -327,7 +350,7 @@ impl PySeriesReader {
 /// ```
 #[pyclass(name = "EventFile")]
 pub(crate) struct PyEventFile {
-    path: PathBuf,
+    file: EventFile,
     ftype: FileType,
 }
 
@@ -338,10 +361,31 @@ impl PyEventFile {
         let temp = FileEventsFactory::from_path(&path)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         let ftype = temp.file_type();
-        Ok(PyEventFile {
+
+        let file = EventFile {
             path,
+            use_rotation: false,
+            try_split: false,
+        };
+
+        Ok(Self {
+            file,
             ftype: ftype.clone(),
         })
+    }
+
+    #[classmethod]
+    pub(crate) fn with_rotation(_: &Bound<'_, PyType>, path: PathBuf) -> PyResult<Self> {
+        let mut slf = Self::new(path)?;
+
+        if matches!(slf.ftype, FileType::Series) {
+            return Err(PyRuntimeError::new_err(
+                "Cannot use rotation on event series",
+            ));
+        }
+
+        slf.file.use_rotation = true;
+        Ok(slf)
     }
 
     // Returns whether the file is sorted.
@@ -353,11 +397,11 @@ impl PyEventFile {
     }
 
     pub(crate) fn events(&self) -> PyResult<PyEventReader> {
-        PyEventReader::new(self.path.clone())
+        PyEventReader::from_event_file(self.file.clone())
     }
 
     pub(crate) fn series(&self) -> PyResult<PySeriesReader> {
-        PySeriesReader::new(self.path.clone())
+        PySeriesReader::new(self.file.path.clone())
     }
 }
 

--- a/retis-events/src/python/python.rs
+++ b/retis-events/src/python/python.rs
@@ -235,7 +235,6 @@ impl PyEventReader {
         Self::from_event_file(EventFile {
             path,
             use_rotation: false,
-            try_split: false,
         })
     }
 
@@ -244,7 +243,6 @@ impl PyEventReader {
         Self::from_event_file(EventFile {
             path,
             use_rotation: true,
-            try_split: false,
         })
     }
 
@@ -374,7 +372,6 @@ impl PyEventFile {
         let file = EventFile {
             path,
             use_rotation: false,
-            try_split: false,
         };
 
         Self::from_event_file(file)

--- a/retis-events/src/python/python.rs
+++ b/retis-events/src/python/python.rs
@@ -354,24 +354,30 @@ pub(crate) struct PyEventFile {
     ftype: FileType,
 }
 
+impl PyEventFile {
+    pub(crate) fn from_event_file(file: EventFile) -> PyResult<Self> {
+        let temp = FileEventsFactory::from_event_file(file.clone())
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let ftype = temp.file_type();
+
+        Ok(Self {
+            file,
+            ftype: ftype.clone(),
+        })
+    }
+}
+
 #[pymethods]
 impl PyEventFile {
     #[new]
     pub(crate) fn new(path: PathBuf) -> PyResult<Self> {
-        let temp = FileEventsFactory::from_path(&path)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        let ftype = temp.file_type();
-
         let file = EventFile {
             path,
             use_rotation: false,
             try_split: false,
         };
 
-        Ok(Self {
-            file,
-            ftype: ftype.clone(),
-        })
+        Self::from_event_file(file)
     }
 
     #[classmethod]

--- a/retis-events/src/python/shell.rs
+++ b/retis-events/src/python/shell.rs
@@ -8,10 +8,11 @@ use anyhow::{anyhow, Result};
 use pyo3::{prelude::*, types::PyDict};
 
 use super::python::*;
+use crate::file::rotate::EventFile;
 
 /// Create a python shell and execute the provided script.
-pub fn shell_execute(file: PathBuf, script: Option<&PathBuf>, args: &[String]) -> Result<()> {
-    let event_file = PyEventFile::new(file)?;
+pub fn shell_execute(file: EventFile, script: Option<&PathBuf>, args: &[String]) -> Result<()> {
+    let event_file = PyEventFile::from_event_file(file)?;
 
     let argv = match script {
         Some(script) => {

--- a/retis/src/helpers/file_rotate.rs
+++ b/retis/src/helpers/file_rotate.rs
@@ -34,11 +34,7 @@ pub(crate) fn rotation_policy_from_str(limit: &str) -> Result<RotationPolicy> {
 // Custom argument type to represent the input file. This automatically handles
 // the rotation logic, if any. Can be used within `clap` directly.
 #[derive(Clone, Debug)]
-pub(crate) struct InputDataFile {
-    pub(crate) path: PathBuf,
-    use_rotation: bool,
-    try_split: bool,
-}
+pub(crate) struct InputDataFile(pub(crate) EventFile);
 
 impl InputDataFile {
     // Help text to be used in the cli argument directly.
@@ -50,28 +46,17 @@ impl InputDataFile {
     }
 
     pub(crate) fn to_factory(&self) -> Result<FileEventsFactory> {
-        if self.use_rotation {
-            FileEventsFactory::new(Box::new(RotateReader::new(
-                self.path.clone(),
-                self.try_split,
-            )?))
-        } else {
-            let path_str = self
-                .path
-                .to_str()
-                .ok_or_else(|| anyhow!("Cannot convert path to str"))?;
-            FileEventsFactory::from_path(path_str)
-        }
+        FileEventsFactory::from_event_file(self.0.clone())
     }
 }
 
 impl Default for InputDataFile {
     fn default() -> Self {
-        Self {
+        Self(EventFile {
             path: PathBuf::from("retis.data"),
             use_rotation: true,
             try_split: true,
-        }
+        })
     }
 }
 
@@ -80,19 +65,19 @@ impl FromStr for InputDataFile {
 
     fn from_str(path: &str) -> std::result::Result<Self, Self::Err> {
         let input = match path.strip_suffix("..") {
-            Some(path_first) => Self {
+            Some(path_first) => Self(EventFile {
                 path: PathBuf::from(path_first),
                 use_rotation: true,
                 try_split: false,
-            },
-            None => Self {
+            }),
+            None => Self(EventFile {
                 path: PathBuf::from(path),
                 use_rotation: false,
                 try_split: false,
-            },
+            }),
         };
 
-        if !&input.path.exists() {
+        if !&input.0.path.exists() {
             return Err("No such file or directory".to_string());
         }
 

--- a/retis/src/helpers/file_rotate.rs
+++ b/retis/src/helpers/file_rotate.rs
@@ -52,10 +52,14 @@ impl InputDataFile {
 
 impl Default for InputDataFile {
     fn default() -> Self {
+        let mut path = PathBuf::from("retis.data");
+        if !path.is_file() {
+            path = PathBuf::from("retis.data.0");
+        }
+
         Self(EventFile {
-            path: PathBuf::from("retis.data"),
+            path,
             use_rotation: true,
-            try_split: true,
         })
     }
 }
@@ -68,12 +72,10 @@ impl FromStr for InputDataFile {
             Some(path_first) => Self(EventFile {
                 path: PathBuf::from(path_first),
                 use_rotation: true,
-                try_split: false,
             }),
             None => Self(EventFile {
                 path: PathBuf::from(path),
                 use_rotation: false,
-                try_split: false,
             }),
         };
 

--- a/retis/src/process/cli/python.rs
+++ b/retis/src/process/cli/python.rs
@@ -3,7 +3,7 @@ use std::{env, path::PathBuf};
 use anyhow::{bail, Result};
 use clap::Parser;
 
-use crate::{cli::*, events::python::shell::shell_execute};
+use crate::{cli::*, events::python::shell::shell_execute, helpers::file_rotate::*};
 
 #[derive(Parser, Debug, Default)]
 #[command(name = "python", about = "Runs Python scripts with events imported.")]
@@ -11,10 +11,9 @@ pub(crate) struct PythonCli {
     #[arg(
         long,
         short,
-        default_value = "retis.data",
-        help = "File from which to read events"
+        help = InputDataFile::help()
     )]
-    pub(super) input: PathBuf,
+    pub(super) input: Option<InputDataFile>,
     #[arg(
         help = "Python script to execute. Omit to drop into an interactive shell. Alternatively scripts can be stored in $HOME/.config/retis/python and /usr/share/retis/python, in which case the file name only (without the .py extension) can be provided."
     )]
@@ -49,7 +48,8 @@ impl SubCommandParserRunner for PythonCli {
             }
         }
 
-        shell_execute(self.input.clone(), script_path.as_ref(), &self.args)
+        let input = self.input.clone().unwrap_or_default();
+        shell_execute(input.0, script_path.as_ref(), &self.args)
     }
 }
 

--- a/retis/src/process/cli/sort.rs
+++ b/retis/src/process/cli/sort.rs
@@ -98,7 +98,7 @@ impl SubCommandParserRunner for Sort {
             //
             // Due to the default input file logic and the range format, we
             // only due this check best-effort.
-            if let Ok(input) = &input.path.canonicalize() {
+            if let Ok(input) = &input.0.path.canonicalize() {
                 let out = match out.canonicalize() {
                     Ok(out) => out,
                     // If the file doesn't exist we can't use fs::canonicalize() but it is not needed

--- a/tests/next/rotation.sh
+++ b/tests/next/rotation.sh
@@ -61,6 +61,29 @@ rotation_by_size() {
 		first_ts=$f_ts
 		last_ts=$l_ts
 	done
+
+	# Check using rotated events in the Python sub-command.
+	if $retis python -h &>/dev/null; then
+		cat >test.py <<EOF
+for e in reader.events():
+	print(e)
+EOF
+
+		out=$($retis python test.py)
+		echo $out | grep "file id 0"
+		echo $out | grep "file id 1"
+		echo $out | grep "file id 2"
+
+		out=$($retis python --input retis.data.1 test.py)
+		echo $out | grep -v "file id 0"
+		echo $out | grep "file id 1"
+		echo $out | grep -v "file id 2"
+
+		out=$($retis python --input retis.data.1.. test.py)
+		echo $out | grep -v "file id 0"
+		echo $out | grep "file id 1"
+		echo $out | grep "file id 2"
+	fi
 }
 
 run_tests rotation_by_size


### PR DESCRIPTION
Some pre-requisites required to convey the rotation config down to the Python helpers. This is actually improving things for all users.