### PR TITLE
fix: remove manual installation of Vagrant for runtime tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -152,12 +152,7 @@ functional_task:
   # Initialization of the test environment
   setup_script: &vagrant_setup
     - grep -q vmx /proc/cpuinfo # Ensure nested virtualization is enabled
-      # The version of vagrant shipped with ubuntu fails to download some boxes (e.g: f38).
-      # See https://bugs.launchpad.net/vagrant/+bug/2017828.
-      # Installing it from Hashicorp directly
-    - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
-    - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
-    - DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractiven apt-get -y install vagrant ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make ruby-nokogiri
+    - DEBIAN_FRONTEND=noninteractive apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install vagrant ruby-libvirt qemu-kvm virt-manager libvirt-daemon-system virtinst libvirt-clients bridge-utils pkg-config libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev gcc make ruby-nokogiri
     - vagrant plugin install vagrant-libvirt
     - systemctl enable --now libvirtd
 


### PR DESCRIPTION
Removes the manual installation of Vagrant from the Hashicorp repository in the Cirrus CI configuration. Since the original issue (broken box downloads in Ubuntu's Vagrant version) has been addressed in newer releases, we can simplify the setup and use the system-provided package.\n\nAlso fixes a small typo in the environment variable:  -> .\n\nFixes #153