### PR TITLE
ct: add vtag to orig and reply direction

### DIFF
--- a/docs/events/ct.md
+++ b/docs/events/ct.md
@@ -27,9 +27,12 @@ for the bitset representing the corresponding values.
 This starts by a protocol specific part. For TCP, UDP and SCTP,
 
 ```none
-{protocol name} ({proto state if any}) orig [{src ip}.{src port} > {dst ip}.{dst port}]
-    reply [{src ip}.{src port} > {dst ip}.{dst port}] mark {mark} labels {labels}
+{protocol name} ({proto state if any}) orig [{src ip}.{src port} > {dst ip}.{dst port} {proto specific}]
+    reply [{src ip}.{src port} > {dst ip}.{dst port} {proto specific}] mark {mark} labels {labels}
 ```
+
+where `{proto specific}` is optional protocol-specific information. For SCTP,
+the verification tags are reported as `vtag {vtag}` in hex format.
 
 For ICMP,
 

--- a/docs/events/packet.md
+++ b/docs/events/packet.md
@@ -174,11 +174,15 @@ vtag {vtag} [{chunk}] [{chunk}] ...
 [INIT init_tag {init_tag} rwnd {rwnd} OS {os} MIS {mis} init_TSN {tsn}]
 ```
 
+- `init_tag` is printed as hex.
+
 **INIT ACK**
 
 ```none
 [INIT ACK init_tag {init_tag} rwnd {rwnd} OS {os} MIS {mis} init_TSN {tsn}]
 ```
+
+- `init_tag` is printed as hex.
 
 **SACK**
 

--- a/retis-events/src/ct.rs
+++ b/retis-events/src/ct.rs
@@ -53,6 +53,8 @@ pub struct CtSctp {
     pub sport: u16,
     /// Destination port.
     pub dport: u16,
+    /// Verification tag.
+    pub vtag: u32,
 }
 
 #[event_type]
@@ -240,16 +242,18 @@ impl CtEvent {
             (CtProto::Sctp { sctp: sctp_orig }, CtProto::Sctp { sctp: sctp_reply }) => {
                 write!(
                     f,
-                    "sctp ({}) orig [{}.{} > {}.{}] reply [{}.{} > {}.{}] ",
+                    "sctp ({}) orig [{}.{} > {}.{} vtag {:#x}] reply [{}.{} > {}.{} vtag {:#x}] ",
                     conn.proto_state.as_ref().unwrap_or(&"UNKNOWN".to_string()),
                     conn.orig.ip.src,
                     sctp_orig.sport,
                     conn.orig.ip.dst,
                     sctp_orig.dport,
+                    sctp_orig.vtag,
                     conn.reply.ip.src,
                     sctp_reply.sport,
                     conn.reply.ip.dst,
                     sctp_reply.dport,
+                    sctp_reply.vtag,
                 )?;
             }
             _ => (),

--- a/retis-events/src/packet.rs
+++ b/retis-events/src/packet.rs
@@ -888,7 +888,7 @@ impl RawPacket {
                     let os = u16::from_be_bytes(payload[8..10].try_into().unwrap());
                     let mis = u16::from_be_bytes(payload[10..12].try_into().unwrap());
                     let init_tsn = u32::from_be_bytes(payload[12..16].try_into().unwrap());
-                    write!(f, " [INIT init_tag {init_tag} rwnd {rwnd} OS {os} MIS {mis} init_TSN {init_tsn}]")?;
+                    write!(f, " [INIT init_tag {init_tag:#x} rwnd {rwnd} OS {os} MIS {mis} init_TSN {init_tsn}]")?;
                 }
                 SctpChunkTypes::INIT_ACK => {
                     if payload.len() < 16 {
@@ -900,7 +900,7 @@ impl RawPacket {
                     let os = u16::from_be_bytes(payload[8..10].try_into().unwrap());
                     let mis = u16::from_be_bytes(payload[10..12].try_into().unwrap());
                     let init_tsn = u32::from_be_bytes(payload[12..16].try_into().unwrap());
-                    write!(f, " [INIT_ACK init_tag {init_tag} rwnd {rwnd} OS {os} MIS {mis} init_TSN {init_tsn}]")?;
+                    write!(f, " [INIT_ACK init_tag {init_tag:#x} rwnd {rwnd} OS {os} MIS {mis} init_TSN {init_tsn}]")?;
                 }
                 SctpChunkTypes::DATA => {
                     if payload.len() < 12 {
@@ -1116,7 +1116,7 @@ mod tests {
 
         assert_eq!(
             &format!("{}", raw.display(&DisplayFormat::new(), &FormatterConf::new())),
-            "10.0.42.1.34124 > 10.0.42.2.5060 tos 0x0 ECT(0) ttl 64 id 0 off 0 [DF] len 68 proto SCTP (132) vtag 0x0 [INIT init_tag 3314234158 rwnd 106496 OS 10 MIS 65535 init_TSN 4174528668]"
+            "10.0.42.1.34124 > 10.0.42.2.5060 tos 0x0 ECT(0) ttl 64 id 0 off 0 [DF] len 68 proto SCTP (132) vtag 0x0 [INIT init_tag 0xc58b332e rwnd 106496 OS 10 MIS 65535 init_TSN 4174528668]"
         );
     }
 }

--- a/retis/src/bindings/ct_hook_uapi.rs
+++ b/retis/src/bindings/ct_hook_uapi.rs
@@ -72,6 +72,25 @@ impl Default for nf_conn_tuple {
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct ct_proto_sctp {
+    pub vtag: [u32_; 2usize],
+}
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union ct_proto_data {
+    pub sctp: ct_proto_sctp,
+}
+impl Default for ct_proto_data {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ct_event {
     pub orig: nf_conn_tuple,
@@ -82,6 +101,7 @@ pub struct ct_event {
     pub labels: [u8_; 16usize],
     pub zone_id: u16_,
     pub proto_state: u8_,
+    pub proto: ct_proto_data,
 }
 impl Default for ct_event {
     fn default() -> Self {

--- a/retis/src/collect/collector/ct/bpf.rs
+++ b/retis/src/collect/collector/ct/bpf.rs
@@ -202,17 +202,21 @@ impl CtEventFactory {
                 },
             )
         } else if flags & RETIS_CT_PROTO_SCTP != 0 {
+            let vtag_orig = u32::from_be(unsafe { raw.proto.sctp }.vtag[0]);
+            let vtag_reply = u32::from_be(unsafe { raw.proto.sctp }.vtag[1]);
             (
                 CtProto::Sctp {
                     sctp: CtSctp {
                         sport: u16::from_be(raw.orig.src.data),
                         dport: u16::from_be(raw.orig.dst.data),
+                        vtag: vtag_orig,
                     },
                 },
                 CtProto::Sctp {
                     sctp: CtSctp {
                         sport: u16::from_be(raw.reply.src.data),
                         dport: u16::from_be(raw.reply.dst.data),
+                        vtag: vtag_reply,
                     },
                 },
             )

--- a/retis/src/collect/collector/ct/bpf/ct_hook.bpf.c
+++ b/retis/src/collect/collector/ct/bpf/ct_hook.bpf.c
@@ -55,6 +55,16 @@ struct nf_conn_tuple {
 	struct nf_conn_addr_proto dst;
 } __binding;
 
+/* SCTP-specific info. */
+struct ct_proto_sctp {
+	u32 vtag[IP_CT_DIR_MAX];
+} __binding;
+
+/* Per-protocol extra info. */
+union ct_proto_data {
+	struct ct_proto_sctp sctp;
+} __binding;
+
 /* Conntrack event information */
 struct ct_event {
 	struct nf_conn_tuple orig;
@@ -65,6 +75,7 @@ struct ct_event {
 	u8 labels[16];
 	u16 zone_id;
 	u8 proto_state;
+	union ct_proto_data proto;
 } __binding;
 
 static __always_inline bool ct_protocol_is_supported(u16 l3num, u8 protonum)
@@ -221,6 +232,10 @@ static __always_inline int process_nf_conn(struct ct_event *e,
 		e->reply.src.data = BPF_CORE_READ(ct, REPLY.src.u.sctp.port);
 		e->reply.dst.data = BPF_CORE_READ(ct, REPLY.dst.u.sctp.port);
 		e->proto_state = (u8)BPF_CORE_READ(ct, proto.sctp.state);
+		e->proto.sctp.vtag[IP_CT_DIR_ORIGINAL] =
+			BPF_CORE_READ(ct, proto.sctp.vtag[IP_CT_DIR_ORIGINAL]);
+		e->proto.sctp.vtag[IP_CT_DIR_REPLY] =
+			BPF_CORE_READ(ct, proto.sctp.vtag[IP_CT_DIR_REPLY]);
 		break;
 	}
 


### PR DESCRIPTION
Add in the ct_event a per-protocol data. SCTP uses it to carry orig/reply vtags.