### PR TITLE
builder: set verifier log level when tracing

### DIFF
--- a/retis/src/core/probe/builder.rs
+++ b/retis/src/core/probe/builder.rs
@@ -9,7 +9,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 
-use crate::core::probe::*;
+use crate::{core::probe::*, helpers::logger::set_libbpf_rs_prog_log_level};
 
 /// Trait representing the interface used to create and handle probes. We use a
 /// trait here as we're supporting various attach types.
@@ -75,6 +75,7 @@ pub(super) fn replace_hook(fd: RawFd, hook: &Hook, target: String) -> Result<lib
     open_prog.set_prog_type(libbpf_rs::ProgramType::Ext);
     open_prog.set_attach_target(fd, Some(target))?;
 
+    set_libbpf_rs_prog_log_level(&mut open_obj);
     let obj = open_obj.load()?;
     let link = obj
         .progs_mut()

--- a/retis/src/core/workaround.rs
+++ b/retis/src/core/workaround.rs
@@ -15,6 +15,8 @@ use std::{
 
 use anyhow::Result;
 
+use crate::helpers::logger::set_libbpf_rs_prog_log_level;
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ProgHandlerOpts {
     /// Custom user-provided value accessible in the callbacks, if needed.
@@ -158,8 +160,10 @@ impl<'a, T> SkelStorage<T> {
     where
         O: libbpf_rs::skel::OpenSkel<'a, Output = T>,
     {
-        let skel = ManuallyDrop::into_inner(from.skel);
+        let mut skel = ManuallyDrop::into_inner(from.skel);
         let storage = ManuallyDrop::into_inner(from.storage);
+
+        set_libbpf_rs_prog_log_level(skel.open_object_mut());
 
         Ok(SkelStorage {
             storage: ManuallyDrop::new(storage),

--- a/retis/src/helpers/logger.rs
+++ b/retis/src/helpers/logger.rs
@@ -134,6 +134,24 @@ impl log::Log for Logger {
     }
 }
 
+/// Set verifier log level on all programs in an open object.
+///
+/// The log level is a bitmask defined in include/linux/bpf_verifier.h:
+///   BPF_LOG_LEVEL1 (1): log each instruction's index and mnemonic, but
+///                        discard logs from successfully explored branches.
+///   BPF_LOG_LEVEL2 (2): additionally log the full register state at every
+///                        instruction, precision tracking details, and
+///                        preserve logs from all explored paths.
+///   BPF_LOG_STATS  (4): emit verification time and per-subprog stack depth.
+///   BPF_LOG_FIXED  (8): use a fixed-size buffer instead of a circular one.
+///
+/// Note that libbpf itself retries a failed load with level 1.
+pub(crate) fn set_libbpf_rs_prog_log_level(open_obj: &mut libbpf_rs::OpenObject) {
+    if log::max_level() == LevelFilter::Trace {
+        open_obj.progs_mut().for_each(|mut p| p.set_log_level(2));
+    }
+}
+
 pub(crate) fn set_libbpf_rs_print_callback(level: LevelFilter) {
     let libbpf_rs_print = |level, msg: String| {
         let msg = msg.trim_end_matches('\n');


### PR DESCRIPTION
Set the log level for programs in open object to 2 when retis log level is set on tracing. This would result in increased logs providing way more information than the default behavior.