### PR TITLE
Various updates (doc, fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
+ "anyhow",
  "indoc",
  "inventory",
  "libc",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,18 +1,27 @@
-# Release checklist
+# Releasing
 
-1. Release a new version on GitHub.
-   1. Make sure the README is up-to-date (collectors, build instructions, etc).
+1. Release a new version on GitHub:
+   1. Make sure the docs and README are up-to-date (collectors, build
+      instructions, etc).
    1. Add new authors to the authors file if needed, by running
       `./tools/authors.sh` and committing the changes.
    1. Tag the right commit in the `vx.y.z` form and push it.
-1. Write and publish a release notes in the GitHub interface. This must be done
-   once the rpm and the image successfully built to allow pushing last minute
-   build fixes.
+1. Write and publish release notes in the GitHub interface:
    1. Make sure "Set as the latest release" is checked only for y-stream
       releases and z-stream releases of the latest major version.
+   1. The milestone and `git log --merges <last x.y version>..` can be used to
+      find important changes.
+
+## Binary distributions
+
+1. Build and publish on COPR:
+   1. Update the [COPR spec file](https://github.com/retis-org/copr).
+   1. Trigger a build on [COPR](https://copr.fedorainfracloud.org/coprs/g/retis/retis/).
+1. Build and upload the Python bindings:
+   1. `podman run --rm --env MATURIN_PYPI_TOKEN=$(cat ~/.my_pypi_token)
+       -v $(pwd):/io:z ghcr.io/pyo3/maturin publish -m retis-events/Cargo.toml
+       -F python-lib`.
 
 ## After the release
 
 1. Update the version in `Cargo.toml` and the name in `retis/Cargo.toml`.
-1. Build and upload the python bindings.
-   1. `podman run --rm --env MATURIN_PYPI_TOKEN=$(cat ~/.my_pypi_token) -v $(pwd):/io:z ghcr.io/pyo3/maturin publish -m retis-events/Cargo.toml -F python-lib`

--- a/docs/install.md
+++ b/docs/install.md
@@ -87,27 +87,21 @@ Retis depends on the following (in addition to Git and Cargo):
 If the `python` feature is used (which is by default), the Python3 shared
 libraries and headers must be available.
 
-On Fedora, one can run:
+To download Retis' sources:
 
 ```none
-$ dnf -y install git cargo clang elfutils-libelf-devel python3-devel \
-        jq libpcap-devel llvm make pkgconf-pkg-config
+$ git clone https://github.com/retis-org/retis    # Consider using --depth 1.
+$ cd retis
 ```
 
-On Ubuntu:
+To build Retis:
 
 ```none
-$ apt update
-$ apt -y install git cargo clang jq libelf-dev libpcap-dev python3-dev \
-        llvm make pkg-config
-```
+$ make -j$(nproc) release       # Release build.
+$ ./target/release/retis -V
 
-Then, to download and build Retis:
-
-```none
-$ git clone --depth 1 https://github.com/retis-org/retis; cd retis
-$ make release
-$ ./target/release/retis --help
+$ make -j$(nproc)               # Debug build.
+$ ./target/debug/retis -V
 ```
 
 Finally, profiles should be installed in either `/usr/share/retis/profiles` or
@@ -116,6 +110,23 @@ Finally, profiles should be installed in either `/usr/share/retis/profiles` or
 ```none
 $ mkdir -p /usr/share/retis/profiles
 $ cp retis/profiles/* /usr/share/retis/profiles
+```
+
+#### Fedora
+
+```none
+$ dnf -y install git cargo clang elfutils-libelf-devel python3-devel \
+        jq libpcap-devel llvm make pkgconf-pkg-config
+$ make -j$(nproc) release
+```
+
+#### Debian based
+
+```none
+$ apt update
+$ apt -y install git cargo clang jq libelf-dev libpcap-dev python3-dev \
+        llvm make pkg-config
+$ make -j$(nproc) release
 ```
 
 #### Cross-compilation

--- a/docs/install.md
+++ b/docs/install.md
@@ -126,7 +126,13 @@ $ make -j$(nproc) release
 $ apt update
 $ apt -y install git cargo clang jq libelf-dev libpcap-dev python3-dev \
         llvm make pkg-config
-$ make -j$(nproc) release
+```
+
+On Debian based systems `asm/errno.h` does not live in a path known to the
+compiler, in turn an additional header location must be configured. For example:
+
+```none
+$ CPATH=/usr/include/x86_64-linux-gnu make -j$(nproc) release
 ```
 
 #### Cross-compilation

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,15 +3,6 @@
 Retis can be installed from a container image, using pre-built packages on
 supported Linux distributions or from sources.
 
-## Fedora
-
-Starting with Fedora 43, Retis is available as an official package.
-
-```none
-$ dnf -y install retis
-$ retis --help
-```
-
 ## Container image
 
 We provide a script to run Retis in a container for `x86_64` and `aarch64` targets,
@@ -50,24 +41,22 @@ $ RETIS_IMAGE=my-registry.example.com/retis ./retis_in_container.sh --help
 `OVS_RUNDIR` environment variable can also be specified if the default one
 (/var/run/openvswitch) does not point to OVS's runtime directory.
 
-## COPR
+## Pre-built packages on Linux distributions
 
-RPM packages for Fedora (currently supported releases including Rawhide), RHEL (>=
-8) and EPEL (>= 8) are available.
+### Fedora (>= 43)
+
+```none
+$ dnf -y install retis
+```
+
+### Fedora (<= 42), RHEL (>= 8.6), CentOS Stream (>= 8.6), EPEL (>= 8.6)
 
 ```none
 $ dnf -y copr enable @retis/retis
 $ dnf -y install retis
-$ retis --help
 ```
 
-Or on older distributions,
-
-```none
-$ yum -y copr enable @retis/retis
-$ yum -y install retis
-$ retis --help
-```
+Use `yum` instead of `dnf` on older distributions (e.g. CentOS Stream 8).
 
 ## From sources
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -142,17 +142,6 @@ $ file ./target/aarch64-unknown-linux-gnu/release/retis
 [...] ARM aarch64, [...]
 ```
 
-## Running as non-root
-
-Retis can run as non-root if it has the right capabilities. Note that doing this
-alone often means `tracefs` won't be available as it's usually owned by `root`
-only and Retis won't be able to fully filter probes.
-
-```none
-$ sudo setcap cap_sys_admin,cap_bpf,cap_syslog=ep $(which retis)
-$ retis collect
-```
-
 ## Shell auto-completion
 
 Retis can generate completion files for shells (Bash, Zsh, Fish...).

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,10 +1,9 @@
 # Installation
 
-Retis can be installed from a container image,
-[COPR](https://copr.fedorainfracloud.org/coprs/g/retis/retis/) for
-rpm-compatible distributions, or from sources.
+Retis can be installed from a container image, using pre-built packages on
+supported Linux distributions or from sources.
 
-### Fedora
+## Fedora
 
 Starting with Fedora 43, Retis is available as an official package.
 
@@ -13,14 +12,13 @@ $ dnf -y install retis
 $ retis --help
 ```
 
-### Container image
+## Container image
 
-We provide a script to run Retis in a container for x86_64 and aarch64 targets,
+We provide a script to run Retis in a container for `x86_64` and `aarch64` targets,
 [retis_in_container.sh](https://raw.githubusercontent.com/retis-org/retis/main/tools/retis_in_container.sh).
 The current directory is mounted with read-write permissions to the container
 working directory. This allows Retis to read and write files (eg. events, pcap).
-Both the Podman and Docker runtimes are supported (which is auto-detected by the
-above script).
+Both the Podman and Docker runtimes are supported (which is auto-detected).
 
 ```none
 $ curl -O https://raw.githubusercontent.com/retis-org/retis/main/tools/retis_in_container.sh
@@ -52,7 +50,7 @@ $ RETIS_IMAGE=my-registry.example.com/retis ./retis_in_container.sh --help
 `OVS_RUNDIR` environment variable can also be specified if the default one
 (/var/run/openvswitch) does not point to OVS's runtime directory.
 
-### COPR
+## COPR
 
 RPM packages for Fedora (currently supported releases including Rawhide), RHEL (>=
 8) and EPEL (>= 8) are available.
@@ -71,7 +69,7 @@ $ yum -y install retis
 $ retis --help
 ```
 
-### From sources
+## From sources
 
 Retis depends on the following (in addition to Git and Cargo):
 
@@ -112,7 +110,7 @@ $ mkdir -p /usr/share/retis/profiles
 $ cp retis/profiles/* /usr/share/retis/profiles
 ```
 
-#### Fedora
+### Fedora
 
 ```none
 $ dnf -y install git cargo clang elfutils-libelf-devel python3-devel \
@@ -120,7 +118,7 @@ $ dnf -y install git cargo clang elfutils-libelf-devel python3-devel \
 $ make -j$(nproc) release
 ```
 
-#### Debian based
+### Debian based
 
 ```none
 $ apt update
@@ -135,7 +133,7 @@ compiler, in turn an additional header location must be configured. For example:
 $ CPATH=/usr/include/x86_64-linux-gnu make -j$(nproc) release
 ```
 
-#### Cross-compilation
+### Cross-compilation
 
 Retis can be cross-compiled and is currently supported on x86, x86-64 and
 aarch64. The target is defined using the `CARGO_BUILD_TARGET` environment
@@ -155,7 +153,7 @@ $ file ./target/aarch64-unknown-linux-gnu/release/retis
 [...] ARM aarch64, [...]
 ```
 
-### Running as non-root
+## Running as non-root
 
 Retis can run as non-root if it has the right capabilities. Note that doing this
 alone often means `tracefs` won't be available as it's usually owned by `root`
@@ -166,7 +164,7 @@ $ sudo setcap cap_sys_admin,cap_bpf,cap_syslog=ep $(which retis)
 $ retis collect
 ```
 
-### Shell auto-completion
+## Shell auto-completion
 
 Retis can generate completion files for shells (Bash, Zsh, Fish...).
 For example to enable auto-completion of Retis command in Bash, you can

--- a/retis-events/Cargo.toml
+++ b/retis-events/Cargo.toml
@@ -24,7 +24,7 @@ nix = { version = "0.30", features = ["feature", "time"] }
 once_cell = "1.15"
 retis-derive = {version = "1.4", path = "../retis-derive"}
 retis-pnet = {version = "1.5", path = "../retis-pnet"}
-pyo3 = {version = "0.25", features = ["multiple-pymethods"], optional = true}
+pyo3 = {version = "0.25", features = ["anyhow", "multiple-pymethods"], optional = true}
 semver = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"

--- a/retis-events/src/file/rotate.rs
+++ b/retis-events/src/file/rotate.rs
@@ -179,7 +179,10 @@ impl Drop for RotateWriter {
             return;
         }
 
-        info!("Wrote {} event file(s)", self.index);
+        info!(
+            "Wrote {} event file(s)",
+            if self.policy.is_none() { 1 } else { self.index }
+        );
     }
 }
 

--- a/retis-events/src/python/python.rs
+++ b/retis-events/src/python/python.rs
@@ -215,8 +215,7 @@ pub(crate) struct PyEventReader {
 
 impl PyEventReader {
     fn from_event_file(file: EventFile) -> PyResult<Self> {
-        let factory = FileEventsFactory::from_event_file(file)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let factory = FileEventsFactory::from_event_file(file)?;
 
         if matches!(factory.file_type(), FileType::Series) {
             return Err(PyRuntimeError::new_err(
@@ -256,11 +255,7 @@ impl PyEventReader {
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
     ) -> PyResult<Option<Py<PyAny>>> {
-        match slf
-            .factory
-            .next_event()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
-        {
+        match slf.factory.next_event()? {
             Some(event) => {
                 let pyevent: Bound<'_, PyEvent> = Bound::new(py, PyEvent::new(py, event)?)?;
                 Ok(Some(pyevent.into_any().into()))
@@ -292,8 +287,7 @@ pub(crate) struct PySeriesReader {
 impl PySeriesReader {
     #[new]
     pub(crate) fn new(path: PathBuf) -> PyResult<Self> {
-        let factory = FileEventsFactory::from_path(path)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let factory = FileEventsFactory::from_path(path)?;
 
         if matches!(factory.file_type(), FileType::Event) {
             return Err(PyRuntimeError::new_err(
@@ -313,11 +307,7 @@ impl PySeriesReader {
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
     ) -> PyResult<Option<Py<PyAny>>> {
-        match slf
-            .factory
-            .next_series()
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?
-        {
+        match slf.factory.next_series()? {
             Some(series) => {
                 let pyseries: Bound<'_, PyEventSeries> =
                     Bound::new(py, PyEventSeries::new(py, series)?)?;
@@ -354,14 +344,11 @@ pub(crate) struct PyEventFile {
 
 impl PyEventFile {
     pub(crate) fn from_event_file(file: EventFile) -> PyResult<Self> {
-        let temp = FileEventsFactory::from_event_file(file.clone())
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        let ftype = temp.file_type();
+        let ftype = FileEventsFactory::from_event_file(file.clone())?
+            .file_type()
+            .clone();
 
-        Ok(Self {
-            file,
-            ftype: ftype.clone(),
-        })
+        Ok(Self { file, ftype })
     }
 }
 


### PR DESCRIPTION
Prep work before the next release. This includes a few fixes and improvements, most notably about the installation docs.

Generated doc available at https://retis.readthedocs.io/en/at-release-prep/