### PR TITLE
Update pcap-file to 3.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "byteorder",
  "fallible-iterator",
  "memmap2",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ dependencies = [
  "semver 1.0.27",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -990,7 +990,7 @@ checksum = "a97512398a192253d9e9e164834be6469723b6b9502392c071a87978d4bb0b48"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1043,13 +1043,14 @@ dependencies = [
 
 [[package]]
 name = "pcap-file"
-version = "3.0.0-rc1"
-source = "git+https://github.com/courvoif/pcap-file.git?rev=e60e2f9b614812360fdf6909b90a8b05283adb05#e60e2f9b614812360fdf6909b90a8b05283adb05"
+version = "3.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9552aee583a05913b6c6345e3c5f69a746787fd60c8fd39ca82ef882de0613b4"
 dependencies = [
  "byteorder_slice",
  "derive-into-owned",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1059,7 +1060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "ucd-trie",
 ]
 
@@ -1400,7 +1401,7 @@ dependencies = [
  "signal-hook",
  "termcolor",
  "test-case",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "time 0.3.43",
 ]
 
@@ -1430,7 +1431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1929,11 +1930,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1949,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/retis/Cargo.toml
+++ b/retis/Cargo.toml
@@ -47,7 +47,7 @@ once_cell = "1.15"
 ovs-unixctl = { version = "0.1.0" }
 pager = "0.16"
 pcap = "2.2"
-pcap-file = { git = "https://github.com/courvoif/pcap-file.git", rev = "e60e2f9b614812360fdf6909b90a8b05283adb05" }
+pcap-file = "=3.0.0-rc.2"
 pest = "2.7"
 pest_derive = "2.7"
 plain = "0.2"


### PR DESCRIPTION
We use a strong match on the version because upstream published a version named 3.0.0-rc1 which to cargo is newer than $topic.

Fixes #605.