### PR TITLE
runtime ci: trigger on PR synchronize events as well

### DIFF
--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -2,7 +2,7 @@ name: Functional Tests
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
If the job is only triggered on for 'labeled' events, it won't run again when the pull request is updated. Also trigger the jobs if the PR is updated. The job then only runs if the run-functional-tests labeled is present.