### PR TITLE
ci: next: unify sleep delays

### DIFF
--- a/tests/next/rotation.sh
+++ b/tests/next/rotation.sh
@@ -7,8 +7,9 @@ rotation_by_size() {
 
 	ip netns exec ns1 socat TCP-LISTEN:80 /dev/null &
 	$retis collect -o --out-rotate 1MB \
+		--stop-after 8000 \
 		-f "host 10.0.42.1" \
-		--cmd "head -c10M /dev/zero | ip netns exec ns0 socat - TCP:10.0.42.2:80; sleep 1"
+		--cmd "ip netns exec ns0 socat /dev/zero TCP:10.0.42.2:80"
 
 	# Rotation file names should be used.
 	[ ! -f retis.data ]

--- a/tests/next/rotation.sh
+++ b/tests/next/rotation.sh
@@ -8,7 +8,7 @@ rotation_by_size() {
 	ip netns exec ns1 socat TCP-LISTEN:80 /dev/null &
 	$retis collect -o --out-rotate 1MB \
 		-f "host 10.0.42.1" \
-		--cmd "head -c10M /dev/zero | ip netns exec ns0 socat - TCP:10.0.42.2:80; sleep 0.1"
+		--cmd "head -c10M /dev/zero | ip netns exec ns0 socat - TCP:10.0.42.2:80; sleep 1"
 
 	# Rotation file names should be used.
 	[ ! -f retis.data ]

--- a/tests/next/tracking.sh
+++ b/tests/next/tracking.sh
@@ -19,7 +19,7 @@ EOF
 	$retis collect -o -c skb,skb-tracking,dev,ns \
 		-f "icmp and host 10.0.255.1" \
 		-p net:netif_rx \
-		--cmd "ip netns exec ns0 ping -c1 10.0.255.1; sleep 0.1"
+		--cmd "ip netns exec ns0 ping -c1 10.0.255.1; sleep 1"
 
 	cat >test.py <<EOF
 from helpers import assert_events_present


### PR DESCRIPTION
Use a 1 second everywhere (as already done in the skb tests) waiting for all events to be captured when using the --cmd flag during collection.

This fixes the flaky rotation test too.