### PR TITLE
ci/next: some fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,10 +158,12 @@ else
 endif
 
 functional-tests:
+	ret=0; \
 	for script in tests/next/*.sh; do \
 		[ "$$LIST_TESTS" = "1" ] && echo "$$script:"; \
-		$$script; \
-	done
+		$$script || ret=$$?; \
+	done; \
+	exit $$ret
 
 functional-tests-list: export LIST_TESTS=1
 functional-tests-list: functional-tests

--- a/tests/next/drop.sh
+++ b/tests/next/drop.sh
@@ -5,6 +5,9 @@ source $(dirname $0)/include/helpers.sh
 drop_sanity() {
 	two_ns
 
+	# trigger ARP resolution to avoid failures on older kernels
+	ip netns exec ns0 ping -w 1 -c 1 10.0.42.2
+
 	$retis collect -o -c skb-drop,skb,dev -f tcp \
 		--cmd 'ip netns exec ns0 socat -T1 - TCP:10.0.42.2:443'
 

--- a/tests/next/pcap.sh
+++ b/tests/next/pcap.sh
@@ -6,7 +6,7 @@ pcap_tcp_cc() {
 	two_ns
 
 	ip netns exec ns1 socat TCP-LISTEN:80 /dev/null &
-	$retis collect -o \
+	$retis collect -c skb -o \
 		-f "tcp port 80 or arp" \
 		-p net:netif_rx -p net:net_dev_start_xmit \
 		--cmd "ip netns exec ns0 socat - TCP:10.0.42.2:80"


### PR DESCRIPTION
- The for loop masks the failure of non ending tests. They will still be reported as failing, but the makefile will not trigger the CI failure as the exit value is successful if the last test is successful
- fix flaky pcap test due to a spurious event 