### PR TITLE
collect: allow limiting the number of rotated output files

### DIFF
--- a/retis-events/src/file/rotate.rs
+++ b/retis-events/src/file/rotate.rs
@@ -40,6 +40,8 @@ pub struct RotateWriter {
     inner: BufWriter<File>,
     // Controls how rotation is done.
     policy: Option<RotationPolicy>,
+    // Optional limit to the number of events file.
+    rotate_count: Option<u32>,
     // Target file name for the output. Will be suffixed following the rotation
     // policy rules.
     target: PathBuf,
@@ -58,6 +60,7 @@ impl RotateWriter {
     pub fn new<P: AsRef<Path>>(
         file: P,
         policy: Option<RotationPolicy>,
+        rotate_count: Option<u32>,
         cmdline: &str,
         monotonic_offset: TimeSpec,
     ) -> Result<Self> {
@@ -71,6 +74,7 @@ impl RotateWriter {
         Ok(Self {
             inner,
             policy,
+            rotate_count,
             target: file.as_ref().to_path_buf(),
             index,
             written,
@@ -136,6 +140,45 @@ impl RotateWriter {
         // Create the new file.
         (self.inner, self.written) = Self::new_file(&self.target, &startup)?;
 
+        // Enforce the output files limit, if any.
+        let limit = match self.rotate_count {
+            Some(limit) => limit,
+            None => return Ok(()),
+        };
+
+        // Check if we should enforce the limit yet.
+        if limit > self.index {
+            return Ok(());
+        }
+
+        let mut target = self.target.clone().into_os_string();
+        target.push(format!(".{}", self.index - limit));
+        fs::remove_file(target)
+    }
+
+    // In case we need to tweak the file names once the collection is done.
+    fn files_fixup(&mut self) -> Result<()> {
+        let range = match self.rotate_count {
+            Some(count) if self.index < count => return Ok(()),
+            Some(count) => count,
+            None => return Ok(()),
+        };
+
+        let mut from = self.index - range;
+        let mut to = 0;
+
+        while to < range {
+            let mut file_from = self.target.clone().into_os_string();
+            let mut file_to = file_from.clone();
+            file_from.push(format!(".{from}"));
+            file_to.push(format!(".{to}"));
+
+            fs::rename(&file_from, &file_to)?;
+
+            from += 1;
+            to += 1;
+        }
+
         Ok(())
     }
 }
@@ -170,9 +213,21 @@ impl Drop for RotateWriter {
             return;
         }
 
+        // In case we have a limit on the number of files generated, rename them
+        // so they start at offset 0.
+        if self.policy.is_some() {
+            if let Err(e) = self.files_fixup() {
+                error!("Could not fixup file names: {e}");
+            }
+        }
+
         info!(
-            "Wrote {} event file(s)",
-            if self.policy.is_none() { 1 } else { self.index }
+            "Wrote {} event file(s){}",
+            if self.policy.is_none() { 1 } else { self.index },
+            match self.rotate_count {
+                Some(count) if self.index > count => format!(", kept {count}"),
+                _ => String::new(),
+            },
         );
     }
 }

--- a/retis-events/src/file/rotate.rs
+++ b/retis-events/src/file/rotate.rs
@@ -1,6 +1,5 @@
 /// # Writer handling file rotation
 use std::{
-    ffi::OsStr,
     fs::{self, File, OpenOptions},
     io::{self, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write},
     ops::Drop,
@@ -8,7 +7,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use log::{error, info, warn};
+use log::{error, info};
 use nix::sys::utsname::uname;
 
 use crate::{compat::json, file::guess_version, helpers::time::*, *};
@@ -100,19 +99,11 @@ impl RotateWriter {
         self.flush()?;
 
         // Move the file, if needed.
-        if let Some(policy) = &self.policy {
-            match policy {
-                RotationPolicy::Size { .. } => {
-                    let mut target = self.target.clone().into_os_string();
-                    target.push(format!(".{}", self.index));
-
-                    fs::rename(&self.target, &target)?;
-
-                    // The `Size` policy suffix the output file with their index; we
-                    // can reuse the internal index here.
-                    self.index += 1;
-                }
-            }
+        if self.policy.is_some() {
+            let mut target = self.target.clone().into_os_string();
+            target.push(format!(".{}", self.index));
+            fs::rename(&self.target, &target)?;
+            self.index += 1;
         }
 
         Ok(())
@@ -283,18 +274,20 @@ impl RotateReader {
 
         if let Some(startup) = event.startup {
             if let Some(split) = startup.split_file {
-                match split.policy {
-                    RotationPolicy::Size { .. } => {
-                        if path.extension()
-                            == Some(<String as AsRef<OsStr>>::as_ref(&format!("{}", split.id)))
-                        {
-                            path.set_extension("");
-                            return Ok((path, split.id, Some(split.policy)));
-                        } else {
-                            warn!("File extension does not match the rotation policy");
-                        }
+                match path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|s| s.parse::<u32>())
+                {
+                    Some(Ok(extension)) => {
+                        path.set_extension("");
+                        return Ok((path, extension, Some(split.policy)));
                     }
-                }
+                    _ => error!(
+                        "{} has an invalid extension (should be a number)",
+                        path.display()
+                    ),
+                };
             }
         }
 

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -98,8 +98,10 @@ Examples of meta filters:
         long,
         requires = "out",
         value_name = "LIMIT",
-        help = "Rotate the output file (see `--out`) once a given limit is reached. The rotation limit can be:
-- A size: <LIMIT> is in bytes and must be suffixed with a size unit (MB, GB). The file names will be <OUT>.X, with X being a number starting at 0 and increasing over time. e.g. '--out-rotate 64MB'.
+        help = "Rotate the output file (see `--out`) once a given limit is reached. The file names will be <OUT>.X, with X being a number starting at 0 and increasing over time.
+
+The rotation limit can be:
+- A size: <LIMIT> is in bytes and must be suffixed with a size unit (MB, GB). e.g. '--out-rotate 64MB'.
 
 Events from the same series might end up on different files. If a previous collection with rotation enabled was not removed only the files required to store the new collection will be overridden. This includes the '--out' value."
     )]

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -95,6 +95,7 @@ Examples of meta filters:
     )]
     pub(super) out: Option<PathBuf>,
     #[arg(
+        short = 'r',
         long,
         requires = "out",
         value_name = "LIMIT",
@@ -107,6 +108,7 @@ Events from the same series might end up on different files. If a previous colle
     )]
     pub(super) out_rotate: Option<String>,
     #[arg(
+        short = 'R',
         long,
         requires = "out_rotate",
         value_name = "COUNT",

--- a/retis/src/collect/cli.rs
+++ b/retis/src/collect/cli.rs
@@ -106,6 +106,14 @@ The rotation limit can be:
 Events from the same series might end up on different files. If a previous collection with rotation enabled was not removed only the files required to store the new collection will be overridden. This includes the '--out' value."
     )]
     pub(super) out_rotate: Option<String>,
+    #[arg(
+        long,
+        requires = "out_rotate",
+        value_name = "COUNT",
+        value_parser = clap::value_parser!(u32).range(1..),
+        help = "When rotating the output file (see `--out-rotate`) limit the number of output files created to <COUNT>."
+    )]
+    pub(super) out_rotate_count: Option<u32>,
     #[arg(long, help = "Write the events to stdout even if --out is used.")]
     pub(super) print: bool,
     #[arg(

--- a/retis/src/collect/collect.rs
+++ b/retis/src/collect/collect.rs
@@ -546,6 +546,7 @@ impl Collectors {
                             Some(s) => Some(rotation_policy_from_str(s)?),
                             None => None,
                         },
+                        collect.out_rotate_count,
                         &main_config.cmdline,
                         self.monotonic_offset,
                     )

--- a/retis/src/process/cli/stats.rs
+++ b/retis/src/process/cli/stats.rs
@@ -93,8 +93,8 @@ impl StatsProcessor {
     }
 
     fn print(&self) -> Result<()> {
-        for file in self.files.iter() {
-            file.print()?;
+        for (index, file) in self.files.iter().enumerate() {
+            file.print(index)?;
         }
         Ok(())
     }
@@ -177,13 +177,12 @@ impl FileStats {
         println!("Retis cmdline: {}", self.startup.cmdline);
     }
 
-    fn print(&self) -> Result<()> {
-        let idx = self.startup.split_file.as_ref().map(|s| s.id).unwrap_or(0);
-        if idx == 0 {
+    fn print(&self, index: usize) -> Result<()> {
+        if index == 0 {
             self.print_common();
         }
-        if self.startup.split_file.is_some() {
-            println!("\nSplit index: {}", idx);
+        if let Some(sf) = &self.startup.split_file {
+            println!("\nSplit index: {}", sf.id);
         }
 
         if self.n_series > 0 {

--- a/tests/next/rotation.sh
+++ b/tests/next/rotation.sh
@@ -26,20 +26,20 @@ rotation_by_size() {
 
 	# Check reading rotated events.
 
-	out=$($retis print)
-	echo $out | grep "file id 0"
-	echo $out | grep "file id 1"
-	echo $out | grep "file id 2"
+	$retis print > print
+	grep "file id 0" print
+	grep "file id 1" print
+	grep "file id 2" print
 
-	out=$($retis print retis.data.1)
-	echo $out | grep -v "file id 0"
-	echo $out | grep "file id 1"
-	echo $out | grep -v "file id 2"
+	$retis print retis.data.1 > print
+	grep -v "file id 0" print
+	grep "file id 1" print
+	grep -v "file id 2" print
 
-	out=$($retis print retis.data.1..)
-	echo $out | grep -v "file id 0"
-	echo $out | grep "file id 1"
-	echo $out | grep "file id 2"
+	$retis print retis.data.1.. > print
+	grep -v "file id 0" print
+	grep "file id 1" print
+	grep "file id 2" print
 
 	# Check stats contain all 3 rotation blocks
 	$retis stats > stats
@@ -70,20 +70,20 @@ for e in reader.events():
 	print(e)
 EOF
 
-		out=$($retis python test.py)
-		echo $out | grep "file id 0"
-		echo $out | grep "file id 1"
-		echo $out | grep "file id 2"
+		$retis python test.py > python
+		grep "file id 0" python
+		grep "file id 1" python
+		grep "file id 2" python
 
-		out=$($retis python --input retis.data.1 test.py)
-		echo $out | grep -v "file id 0"
-		echo $out | grep "file id 1"
-		echo $out | grep -v "file id 2"
+		$retis python --input retis.data.1 test.py > python
+		grep -v "file id 0" python
+		grep "file id 1" python
+		grep -v "file id 2" python
 
-		out=$($retis python --input retis.data.1.. test.py)
-		echo $out | grep -v "file id 0"
-		echo $out | grep "file id 1"
-		echo $out | grep "file id 2"
+		$retis python --input retis.data.1.. test.py > python
+		grep -v "file id 0" python
+		grep "file id 1" python
+		grep "file id 2" python
 	fi
 }
 

--- a/tests/next/rotation.sh
+++ b/tests/next/rotation.sh
@@ -87,4 +87,51 @@ EOF
 	fi
 }
 
-run_tests rotation_by_size
+rotation_files_count() {
+	two_ns
+
+	#############
+	# Limit = 1 #
+	#############
+
+	ip netns exec ns1 socat TCP-LISTEN:80 /dev/null &
+	socat_pid=$!
+	$retis collect -o --out-rotate 1MB --out-rotate-count 1 \
+		--stop-after 8000 \
+		-f "host 10.0.42.1" \
+		--cmd "ip netns exec ns0 socat /dev/zero TCP:10.0.42.2:80"
+
+	# Rotation file names should be used.
+	[ ! -f retis.data ]
+
+	# Check the limit was respected.
+	count=$(ls retis.data.* | wc -l)
+	[ $count == "1" ]
+
+	# We can also check we have the expected output.
+	[ -f retis.data.0 ]
+
+	#############
+	# Limit = 2 #
+	#############
+
+	ip netns exec ns1 kill $socat_pid || true
+	ip netns exec ns1 socat TCP-LISTEN:80 /dev/null &
+	$retis collect -o --out-rotate 1MB --out-rotate-count 2 \
+		--stop-after 8000 \
+		-f "host 10.0.42.1" \
+		--cmd "ip netns exec ns0 socat /dev/zero TCP:10.0.42.2:80"
+
+	# Rotation file names should be used.
+	[ ! -f retis.data ]
+
+	# Check the limit was respected.
+	count=$(ls retis.data.* | wc -l)
+	[ $count == "2" ]
+
+	# We can also check we have the expected output.
+	[ -f retis.data.0 ]
+	[ -f retis.data.1 ]
+}
+
+run_tests rotation_by_size rotation_files_count


### PR DESCRIPTION
Adds support for limiting the number of output files when using output rotation. This enables running Retis over long periods of time without filling the disk, e.g. waiting for a once in a while issue to be seen.

This was requested in #630. More explanation in the commit logs.

This is the expected behavior:

```
$ retis collect --out --out-rotate 20MB --out-rotate-count 3
[...]
$ ls retis.data*
retis.data.42
retis.data.43
retis.data.44
$ retis print retis.data.42..       # File name must be explicitly used at post-processing time.
[...]
```

While at it provide a short version of the rotation args, for ease of use. The exact letter to use can be discussed. Since the rotation feature is not yet released this is also the last opportunity to change the long version of those arguments before the release (`--out-rotate`/`-r` and `--out-rotate-count`/`-R`).