### PR TITLE
collector: netns: allow operating on non-skb probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ lint-rust: fmt-rust clippy
 
 lint-ebpf:
 	$(call out_console,CHECKPATCH,checking eBPF coding style ...)
-	ignore="SPDX_LICENSE_TAG,FILE_PATH_CHANGES,EMAIL_SUBJECT,VOLATILE,MACRO_WITH_FLOW_CONTROL,MACRO_ARG_UNUSED"; \
+	ignore="SPDX_LICENSE_TAG,FILE_PATH_CHANGES,EMAIL_SUBJECT,VOLATILE,MACRO_WITH_FLOW_CONTROL,MACRO_ARG_UNUSED,COMMIT_LOG_LONG_LINE,COMMIT_MESSAGE,NOT_UNIFIED_DIFF"; \
 	base_hash=$$(git merge-base $${BASE_COMMIT:-main} HEAD); \
 	COMMIT_RANGE=$$(git rev-list --no-merges --reverse $${base_hash}..HEAD); \
 	for commit in $$COMMIT_RANGE; do \

--- a/docs/collectors/overview.md
+++ b/docs/collectors/overview.md
@@ -124,15 +124,17 @@ The `nft` collector produces the [nft](../events/nft.md) event section.
 
 ## Network device
 
-The `dev` collector provides information about network devices, either if a
-`struct net_device` is available as part of a probe arguments or through a
-`struct sk_buff` and its reference.
+The `dev` collector provides information about network devices, using the
+reference inside `struct sk_buff` or directly operating on `struct net_device`
+if no `skb` is available in a probed function and in an `ftrace` section.
 
 The `dev` collector produces the [dev](../events/dev.md) event section.
 
 ## Namespace
 
-The `ns` collector retrieves information about namespaces, currently only
-network namespaces.
+The `ns` collector retrieves information about network namespaces, using the
+reference inside `struct sk_buff` (through `struct net_device` or `struct sock`)
+or directly operating on `struct net` if no `skb` is available in a probed
+function and in an `ftrace` section.
 
 The `ns` collector produces the [netns](../events/netns.md) event section.

--- a/retis/src/collect/collector/dev/bpf/dev_hook.bpf.c
+++ b/retis/src/collect/collector/dev/bpf/dev_hook.bpf.c
@@ -12,7 +12,7 @@ struct dev_event {
 	u32 iif;
 } __binding;
 
-DEFINE_HOOK_RAW(
+DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
 	struct sk_buff *skb;
 	struct net_device *dev;
 	struct dev_event *e;
@@ -22,15 +22,7 @@ DEFINE_HOOK_RAW(
 	 * data linked to packets.
 	 */
 	skb = retis_get_sk_buff(ctx);
-	if (skb) {
-		if (!skb_is_tracked(skb))
-			return 0;
-
-		dev = BPF_CORE_READ(skb, dev);
-	} else {
-		dev = retis_get_net_device(ctx);
-	}
-
+	dev = skb ? BPF_CORE_READ(skb, dev) : retis_get_net_device(ctx);
 	if (!dev)
 		return 0;
 

--- a/retis/src/collect/collector/ns/bpf/netns_hook.bpf.c
+++ b/retis/src/collect/collector/ns/bpf/netns_hook.bpf.c
@@ -39,26 +39,19 @@ static __always_inline struct net *get_net_from_skb(struct sk_buff *skb)
 	return NULL;
 }
 
-DEFINE_HOOK_RAW(
+DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
 	/* Netns cookies are not available on older kernels. */
 	bool get_cookie = bpf_core_field_exists(struct net, net_cookie);
 	struct netns_event *e;
 	struct sk_buff *skb;
 	struct net *net;
-	u64 cookie;
+	u64 cookie = 0;
 	u32 inum;
 
 	skb = retis_get_sk_buff(ctx);
-	if (!skb || !skb_is_tracked(skb))
+	net = skb ? get_net_from_skb(skb) : get_net_from_parms(ctx);
+	if (!net)
 		return 0;
-
-	net = get_net_from_skb(skb);
-	if (!net) {
-		/* Fallback to parameters. */
-		net = get_net_from_parms(ctx);
-		if (!net)
-			return 0;
-	}
 
 	if (get_cookie)
 		cookie = BPF_CORE_READ(net, net_cookie);

--- a/retis/src/collect/collector/skb_drop/bpf/skb_drop_hook.bpf.c
+++ b/retis/src/collect/collector/skb_drop/bpf/skb_drop_hook.bpf.c
@@ -8,7 +8,7 @@ struct skb_drop_event {
 	s32 drop_reason;
 } __binding;
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
 	struct skb_drop_event *e;
 
 	/* Check if the kernel knows about skb drop reasons, and if so check we

--- a/retis/src/core/probe/kernel/bpf/include/common.h
+++ b/retis/src/core/probe/kernel/bpf/include/common.h
@@ -344,8 +344,20 @@ static __always_inline int chain(struct retis_context *ctx)
 		log_warning("ctx extension failed: %d", ret);
 
 	skb = retis_get_sk_buff(ctx);
-	if (skb)
+	if (skb) {
 		ctx->flags = filter(skb);
+
+		if (!RETIS_TRACKABLE(ctx)) {
+			/* Terminate any potentially existing entry not
+			 * associated with a tracked skb. Blind termination
+			 * approach is supposed to be more performing in the
+			 * worst case and will lead to a simple lookup failure
+			 * in most cases. This acts as packet path garbage
+			 * collection (e.g. skb_tracking stale entry hanging).
+			 */
+			track_stack_end(ctx->stack_base);
+		}
+	}
 
 	if (stack_in_window(ctx->stack_base))
 		ctx->flags |= RETIS_F_WINDOW_PASS;
@@ -357,18 +369,8 @@ static __always_inline int chain(struct retis_context *ctx)
 	 * logic runs even if later ops fail: we don't want to miss information
 	 * because of non-fatal errors!
 	 */
-	if (RETIS_TRACKABLE(ctx)) {
+	if (RETIS_TRACKABLE(ctx))
 		track_skb_start(ctx, cfg->ftrace);
-	} else if (skb) {
-		/* Terminate any potentially existing entry not
-		 * associated with a tracked skb. Blind termination
-		 * approach is supposed to be more performing in the
-		 * worst case and will lead to a simple lookup failure
-		 * in most cases. This acts as packet path garbage
-		 * collection (e.g. skb_tracking stale entry hanging).
-		 */
-		track_stack_end(ctx->stack_base);
-	}
 
 	/* Shortcut when there are no hooks (e.g. tracking-only probe); no need
 	 * to allocate and fill an event to drop it later on.


### PR DESCRIPTION
The netns hook was requiring an skb to be available in the function parameters, but it can also operate on `struct net *` directly. Do something similar to what the dev collector is doing, allowing to operate on both situations.