### PR TITLE
improve the hook filtering logic

### DIFF
--- a/retis/src/collect/collector/ct/bpf/ct_hook.bpf.c
+++ b/retis/src/collect/collector/ct/bpf/ct_hook.bpf.c
@@ -244,7 +244,7 @@ static __always_inline int process_nf_conn(struct ct_event *e,
 	return 0;
 }
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	struct nf_conn *nf_conn;
 	struct ct_meta_event *m;
 	struct sk_buff *skb;

--- a/retis/src/collect/collector/dev/bpf/dev_hook.bpf.c
+++ b/retis/src/collect/collector/dev/bpf/dev_hook.bpf.c
@@ -12,15 +12,12 @@ struct dev_event {
 	u32 iif;
 } __binding;
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
+DEFINE_HOOK(
 	struct sk_buff *skb;
 	struct net_device *dev;
 	struct dev_event *e;
 	int ifindex;
 
-	/* Get the device from the skb if possible, as in the end we care about
-	 * data linked to packets.
-	 */
 	skb = retis_get_sk_buff(ctx);
 	dev = skb ? BPF_CORE_READ(skb, dev) : retis_get_net_device(ctx);
 	if (!dev)

--- a/retis/src/collect/collector/nft/bpf/nft_hook.bpf.c
+++ b/retis/src/collect/collector/nft/bpf/nft_hook.bpf.c
@@ -223,7 +223,7 @@ const struct nft_verdict *nft_get_verdict(struct retis_context *ctx,
 }
 
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	const struct nft_verdict *verdict;
 	const struct nft_chain *chain;
 	struct nft_traceinfo *info;

--- a/retis/src/collect/collector/ns/bpf/netns_hook.bpf.c
+++ b/retis/src/collect/collector/ns/bpf/netns_hook.bpf.c
@@ -39,7 +39,7 @@ static __always_inline struct net *get_net_from_skb(struct sk_buff *skb)
 	return NULL;
 }
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
+DEFINE_HOOK(
 	/* Netns cookies are not available on older kernels. */
 	bool get_cookie = bpf_core_field_exists(struct net, net_cookie);
 	struct netns_event *e;

--- a/retis/src/collect/collector/ovs/bpf/kernel_exec_actions_hook.bpf.c
+++ b/retis/src/collect/collector/ovs/bpf/kernel_exec_actions_hook.bpf.c
@@ -2,7 +2,7 @@
 #include <ovs_common.h>
 
 /* Hook for kprobe:ovs_execute_actions. */
-DEFINE_HOOK(F_GROUPS(RETIS_F_PACKET_PASS),
+DEFINE_HOOK(
 	u32 queue_id;
 	struct execute_actions_ctx ectx = {};
 	struct execute_actions_ctx *pectx;

--- a/retis/src/collect/collector/ovs/bpf/kernel_process_packet_hook.bpf.c
+++ b/retis/src/collect/collector/ovs/bpf/kernel_process_packet_hook.bpf.c
@@ -2,7 +2,7 @@
 #include <ovs_common.h>
 
 /* Hook for kprobe:ovs_dp_process_packet. */
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	struct execute_actions_ctx ectx = {};
 	u64 sb = ctx->stack_base;
 

--- a/retis/src/collect/collector/ovs/bpf/kernel_upcall_ret_hook.bpf.c
+++ b/retis/src/collect/collector/ovs/bpf/kernel_upcall_ret_hook.bpf.c
@@ -8,7 +8,7 @@ struct upcall_ret_event {
 } __binding;
 
 /* Hook for kretprobe:ovs_dp_upcall */
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	struct upcall_ret_event *ret;
 	struct upcall_context *uctx;
 	u64 sb = ctx->stack_base;

--- a/retis/src/collect/collector/ovs/bpf/kernel_upcall_tp_hook.bpf.c
+++ b/retis/src/collect/collector/ovs/bpf/kernel_upcall_tp_hook.bpf.c
@@ -11,7 +11,7 @@ struct upcall_event {
 } __binding;
 
 /* Hook for raw_tracepoint:openvswitch:ovs_dp_upcall. */
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	struct dp_upcall_info *upcall;
 	struct upcall_context uctx = {};
 	struct upcall_event *upcall_event;

--- a/retis/src/collect/collector/skb/bpf/skb_hook.bpf.c
+++ b/retis/src/collect/collector/skb/bpf/skb_hook.bpf.c
@@ -283,7 +283,7 @@ skip_gso:
 	return 0;
 }
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS),
+DEFINE_HOOK(
 	struct sk_buff *skb;
 
 	skb = retis_get_sk_buff(ctx);

--- a/retis/src/collect/collector/skb_drop/bpf/skb_drop_hook.bpf.c
+++ b/retis/src/collect/collector/skb_drop/bpf/skb_drop_hook.bpf.c
@@ -8,7 +8,7 @@ struct skb_drop_event {
 	s32 drop_reason;
 } __binding;
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
+DEFINE_HOOK(
 	struct skb_drop_event *e;
 
 	/* Check if the kernel knows about skb drop reasons, and if so check we

--- a/retis/src/collect/collector/skb_tracking/bpf/tracking_hook.bpf.c
+++ b/retis/src/collect/collector/skb_tracking/bpf/tracking_hook.bpf.c
@@ -10,7 +10,7 @@ struct skb_tracking_event {
 	u64 skb;
 } __binding;
 
-DEFINE_HOOK(F_GROUPS(RETIS_ALL_FILTERS, RETIS_F_WINDOW_PASS),
+DEFINE_HOOK(
 	struct skb_tracking_event *e;
 	struct tracking_info *ti;
 	struct sk_buff *skb;

--- a/retis/src/core/probe/kernel/bpf/include/common.h
+++ b/retis/src/core/probe/kernel/bpf/include/common.h
@@ -47,45 +47,17 @@ struct {
 } stack_map SEC(".maps");
 
 
-/* All bits in the mask. */
-#define F_ALL(fmask)	((ctx->flags & (fmask)) == (fmask))
-/* Always true. Used by raw hooks. */
-#define F_ALWAYS	1
-
-/* OR of AND-groups: each argument is a bitmask that must be fully set (AND),
- * and the groups are OR'd together. Up to 4 groups are supported.
- *
- *   F_GROUPS(A)       ->  F_ALL(A)
- *   F_GROUPS(A, B)    ->  F_ALL(A) || F_ALL(B)
- */
-#define _F_GROUPS1(a)		(F_ALL(a))
-#define _F_GROUPS2(a, b)	(F_ALL(a) || F_ALL(b))
-#define _F_GROUPS3(a, b, c)	(F_ALL(a) || F_ALL(b) || F_ALL(c))
-#define _F_GROUPS4(a, b, c, d)	(F_ALL(a) || F_ALL(b) || F_ALL(c) || F_ALL(d))
-
-#define _F_GROUPS_SEL(_1, _2, _3, _4, N, ...)	N
-#define F_GROUPS(...)						\
-	_F_GROUPS_SEL(__VA_ARGS__,				\
-		      _F_GROUPS4, _F_GROUPS3,			\
-		      _F_GROUPS2, _F_GROUPS1)(__VA_ARGS__)
-
 #define RETIS_TRACKABLE(ctx)	((ctx->flags & RETIS_ALL_FILTERS) == RETIS_ALL_FILTERS)
 
 /* Helper to define a hook (mostly in collectors) while not having to duplicate
  * the common part everywhere. This also ensure hooks are doing the right thing
  * and should help with maintenance.
  *
- * fexpr is a boolean expression over ctx->flags, built using the F_ALL()
- * helper or the F_GROUPS() macro for disjunctions of flag groups:
- *
- *   F_GROUPS(flags)      -- all bits in the mask
- *   F_GROUPS(A, B)       -- all of mask A, or all of mask B
- *
  * To define a hook in a collector hook, say hook.bpf.c,
  * ```
  * #include <common.h>
  *
- * DEFINE_NAMED_HOOK(hook_name, F_GROUPS(RETIS_ALL_FILTERS),
+ * DEFINE_NAMED_HOOK(hook_name,
  *	do_something(ctx);
  *	return 0;
  * )
@@ -93,23 +65,29 @@ struct {
  * char __license[] SEC("license") = "GPL";
  * ```
  */
-#define DEFINE_NAMED_HOOK(hook_name, fexpr, statements)				\
+#define __DEFINE_NAMED_HOOK(hook_name, is_raw, statements)			\
 	SEC("ext/hook")								\
 	int hook_name(struct retis_context *ctx, struct retis_raw_event *event) \
 	{									\
 		/* Let the verifier be happy */					\
 		if (!ctx || !event)						\
 			return 0;						\
-		if (!(fexpr))							\
-			return 0;						\
+		if (!is_raw) {							\
+			struct sk_buff *skb = retis_get_sk_buff(ctx);		\
+			barrier_var(ctx);					\
+			/* RETIS_F_WINDOW_PASS guarantees the skb is tracked */	\
+			if ((skb && !RETIS_TRACKABLE(ctx)) &&			\
+			    !(ctx->flags & RETIS_F_WINDOW_PASS))		\
+				return 0;					\
+		}								\
 		statements							\
 	}
 
 /* Simple wrapper for DEFINE_NAMED_HOOK() that use file base name as
  * default name.
  */
-#define DEFINE_HOOK(fexpr, statements)					\
-	DEFINE_NAMED_HOOK(__PROG_NAME, fexpr, statements)
+#define DEFINE_HOOK(statements)						\
+	__DEFINE_NAMED_HOOK(__PROG_NAME, false, statements)
 
 /* Helper that defines a hook that doesn't depend on any filtering
  * result and runs regardless.  Filtering outcome is still available
@@ -129,7 +107,7 @@ struct {
  * ```
  */
 #define DEFINE_HOOK_RAW(statements)					\
-	DEFINE_NAMED_HOOK(__PROG_NAME, F_ALWAYS, statements)
+	__DEFINE_NAMED_HOOK(__PROG_NAME, true, statements)
 
 /* Number of hooks installed, used to micro-optimize the call chain */
 const volatile u32 nhooks = 0;


### PR DESCRIPTION
This was discussed in https://github.com/retis-org/retis/pull/644#discussion_r3673105571 and we decided to delay the discussion in the next dev window and in a dedicated PR; this is it.

___

Under normal circumstances hooks should generate events if and only if the events can be linked to a packet (at runtime or post-processing time), unless if in an ftrace section. For special cases, raw hooks are available. We should not have to know all the filtering logic when defining hooks.

This makes the above handled in the core logic: if an skb is available, it must be tracked. If no skb is available, we only let the hook run if in an ftrace window as this is the piece linking those events to a tracked skb. Hooks are still responsible for checking the arguments they are operating on are available and valid (eg. an skb).

Thanks to this, remove special tracking checks in the skb-drop, dev and ns collectors. Also fix the kprobe:ovs_execute_actions hook that was not operating on meta filtered skbs.

This should not change the existing filtering and hooks behavior but makes writing hooks more clear, easier to maintain and to extend.